### PR TITLE
Fix ride history during recording: lock SD scan, show in-progress row, hide stub rides

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -59,3 +59,7 @@
 #define RIDE_DIR            "/rides"
 #define RECORD_INTERVAL_MS  1000
 #define FIT_FLUSH_EVERY_S   15
+// Rides smaller than this are stubs (an accidental start/stop with under a
+// minute of data) and are hidden from the history list — a FIT file is ~284
+// fixed bytes plus ~25 per 1 Hz record (see fit_writer.cpp).
+#define RIDE_MIN_USEFUL_BYTES 1500

--- a/src/ride_recorder.cpp
+++ b/src/ride_recorder.cpp
@@ -244,6 +244,12 @@ void stopRide(bool save) {
 
 bool isRecording() { return fit.isOpen(); }
 
+const char* currentRideFile() {
+    if (!fit.isOpen()) return "";
+    const char* base = strrchr(ridePath, '/');
+    return base ? base + 1 : ridePath;
+}
+
 RideSummary summary() {
     RideSummary r;
     r.distanceM = distanceM;

--- a/src/ride_recorder.h
+++ b/src/ride_recorder.h
@@ -16,6 +16,10 @@ void startRide();
 void stopRide(bool save);
 bool isRecording();
 
+// Basename (no directory) of the FIT file currently being recorded, or ""
+// when idle. Lets the history screen skip the still-open, unfinalized file.
+const char* currentRideFile();
+
 // Stats of the ride in progress (or the one just stopped) for the
 // summary screen.
 RideSummary summary();

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "ride_state.h"
 #include "ride_recorder.h"
+#include "sd_bus.h"
 #include "gps_service.h"
 #include "board_power.h"
 #include <esp_sleep.h>
@@ -588,13 +589,41 @@ void renderListScreen(uint8_t* fb) {
         case SCREEN_HISTORY: {
             title = "RIDE HISTORY";
             footer = "rides upload from /rides on the SD card";
+
+            // A ride in progress gets a pinned row at the top; its still-open,
+            // unfinalized FIT file is then skipped in the scan below.
+            const char* activeFile = ride_recorder::currentRideFile();
+            if (activeFile[0]) {
+                RideState s = g_state.snapshot();
+                snprintf(rows[count].title, sizeof(rows[0].title),
+                         "Recording in progress");
+                uint32_t secs = s.elapsedS;
+                snprintf(rows[count].subtitle, sizeof(rows[0].subtitle),
+                         "%.1f %s · %lu:%02lu:%02lu",
+                         units::distM(s.distanceM, s.useMiles),
+                         units::distLabel(s.useMiles),
+                         (unsigned long)(secs / 3600),
+                         (unsigned long)(secs / 60 % 60),
+                         (unsigned long)(secs % 60));
+                rows[count].inverted = true;
+                count++;
+            }
+
+            // The recorder writes FIT records on this same SPI bus 1 Hz while
+            // riding; scanning the directory without the lock corrupts that
+            // traffic and returns a garbled/empty list (why history looked
+            // inaccessible during a ride). Hold the lock for the whole scan.
+            sdLock();
             File dir = SD.open(RIDE_DIR);
             if (dir) {
                 for (File f = dir.openNextFile(); f && count < kMenuRowCount;
                      f = dir.openNextFile()) {
-                    if (!f.isDirectory()) {
-                        const char* base = strrchr(f.name(), '/');
-                        base = base ? base + 1 : f.name();
+                    const char* base = strrchr(f.name(), '/');
+                    base = base ? base + 1 : f.name();
+                    // Skip subdirs, the in-progress file (shown above), and
+                    // stub rides too small to be worth opening.
+                    if (!f.isDirectory() && strcmp(base, activeFile) != 0 &&
+                        f.size() >= RIDE_MIN_USEFUL_BYTES) {
                         snprintf(rows[count].title, sizeof(rows[0].title),
                                  "%s", base);
                         snprintf(rows[count].subtitle, sizeof(rows[0].subtitle),
@@ -605,6 +634,7 @@ void renderListScreen(uint8_t* fb) {
                 }
                 dir.close();
             }
+            sdUnlock();
             break;
         }
         default:


### PR DESCRIPTION
## Summary

Addresses all three problems reported in #1 with the Ride History screen.

### 1. History was inaccessible while recording (root cause)

The History screen scanned `/rides` with a bare `SD.open(RIDE_DIR)` and **no `sdLock()`**. The SD card sits on a SPI bus shared with the ride recorder, which writes a FIT record every second while riding. Per `sd_bus.h`, "every unit of SD work … must be wrapped in `sdLock()`/`sdUnlock()`" — concurrent transactions corrupt the card. So while a ride was recording, the unlocked directory scan collided with the recorder's writes and returned a garbled/empty list, which is why history looked inaccessible.

This was the *only* unlocked `/rides` scan in the codebase — `ride_recorder::rideCount()` and `ble_server::sendRideList()` both already hold the lock. The scan is now wrapped in `sdLock()`/`sdUnlock()` for its full duration.

### 2. History now says a recording is in progress

When a ride is recording, a pinned inverted row is shown at the top of the list — **"Recording in progress"** with the live distance and elapsed time (e.g. `3.2 KM · 0:12:34`). This reuses the existing inverted-row convention already used for connected sensors and the active route. The still-open, unfinalized FIT file for the current ride is excluded from the normal list below (it would otherwise show as a tiny partial ride).

Added `ride_recorder::currentRideFile()` to expose the in-progress filename for that exclusion.

### 3. Tiny "stub" rides are hidden

Accidental start/stops produce FIT files with almost no data that are openable but useless. Rides smaller than `RIDE_MIN_USEFUL_BYTES` (1500 bytes, ~under a minute of 1 Hz data — a FIT file is ~284 fixed bytes plus ~25 per record) are now filtered out of the list.

## Files changed

- `src/config.h` — new `RIDE_MIN_USEFUL_BYTES` threshold.
- `src/ride_recorder.{h,cpp}` — new `currentRideFile()` accessor.
- `src/ui_dashboard.cpp` — History screen: lock the scan, add the in-progress row, skip the active file and stub rides (`#include "sd_bus.h"`).

## Notes & decisions

- **Threshold choice:** 1500 bytes ≈ under one minute of riding. Chosen as a reasonable "not worth opening" cutoff; noted here in case a different value is preferred.
- The menu's "N rides on card" subtitle (`ride_recorder::rideCount()`) still counts every file on the card, unfiltered. Left as-is intentionally — it's a card-level count and out of scope for this screen — but it will read slightly higher than the visible history list.
- **Build/test:** This is a PlatformIO/ESP32 firmware target that requires the vendored LilyGO board-support repo and the ESP32 toolchain, neither of which is available in this environment (`vendor/` is gitignored and not cloned; `pio` not installed). The macOS preview harness only compiles `ui_render.cpp` (unchanged here), not `ui_dashboard.cpp`. Changes were verified by hand against the actual field/function signatures (`RideState.distanceM/elapsedS/useMiles`, `units::distM/distLabel`, `sdLock/sdUnlock`) and follow existing patterns in the file; please run `pio run` on a configured checkout before flashing.

Closes #1

🤖 Opened by issue-fixer.