### PR TITLE
Recover rides interrupted by a reset; fix always-zero FIT CRC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,10 @@ companion-ios/DerivedData/
 # Compiled preview-harness binary (rebuild via tools/preview/render_preview.sh)
 tools/preview/preview
 
+# FIT test-harness binary and the .fit files it emits (rebuild via
+# tools/fit_test/run_fit_test.sh)
+tools/fit_test/fit_test
+tools/fit_test/out/
+
 # Xcode archive / build output
 companion-ios/build/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ code for macOS (hardware layer stubbed) and renders the UI to PNGs in
 map view fed with a synthetic street scene. Iterate on layout there before
 flashing.
 
+## FIT encoder tests without hardware
+
+`tools/fit_test/run_fit_test.sh` compiles the real `src/fit_writer.cpp`
+against a small FS shim and writes sample rides to `tools/fit_test/out/` —
+including a ride cut short by a reset, to cover the boot-time recovery path.
+With [fitdecode](https://pypi.org/project/fitdecode/) installed
+(`pip install fitdecode`) it then parses each file with CRC checking, which
+is what catches encoder bugs an upload would otherwise reject.
+
 ## Layout
 
 ```

--- a/src/fit_writer.cpp
+++ b/src/fit_writer.cpp
@@ -108,12 +108,34 @@ uint16_t crc16(uint16_t crc, uint8_t byte) {
 }
 
 uint32_t fitTime(time_t utc) { return (uint32_t)(utc - FIT_EPOCH_OFFSET); }
+time_t   utcFromFit(uint32_t fit) { return (time_t)fit + FIT_EPOCH_OFFSET; }
 
 void put16(uint8_t* p, uint16_t v) { p[0] = v & 0xFF; p[1] = v >> 8; }
 void put32(uint8_t* p, uint32_t v) {
     p[0] = v & 0xFF; p[1] = (v >> 8) & 0xFF;
     p[2] = (v >> 16) & 0xFF; p[3] = (v >> 24) & 0xFF;
 }
+uint32_t get32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+// begin() always emits the same prologue, so its length is fixed: the 12-byte
+// header, then the file_id definition + message, the timer-start event
+// definition + message, and the record definition. Records follow at a fixed
+// stride. repair() relies on both to find where the record stream starts and
+// how far it got. Keep in sync with begin() / writeRecord().
+constexpr uint32_t PROLOGUE_BYTES = 12 +          // header
+                                    (6 + 5 * 3) + // file_id definition
+                                    14 +          // file_id message
+                                    (6 + 4 * 3) + // event definition
+                                    8 +           // timer-start event
+                                    (6 + 9 * 3);  // record definition
+constexpr uint32_t RECORD_BYTES = 25;
+
+// Byte offsets within a record message, mirroring writeRecord().
+constexpr uint32_t REC_OFF_TIMESTAMP = 1;
+constexpr uint32_t REC_OFF_DISTANCE  = 15;
 
 }  // namespace
 
@@ -137,7 +159,9 @@ void FitWriter::writeDefinition(uint8_t localType, uint16_t globalNum,
 }
 
 bool FitWriter::begin(fs::FS& fs, const char* path, time_t startUtc) {
-    file_ = fs.open(path, FILE_WRITE);
+    // "w+", not FILE_WRITE ("w"): finish() computes the trailing CRC by
+    // re-reading the file, and a write-only handle reads back zero bytes.
+    file_ = fs.open(path, "w+");
     if (!file_) return false;
     startUtc_ = startUtc;
     dataSize_ = 0;
@@ -195,6 +219,80 @@ void FitWriter::writeRecord(const Record& r) {
     buf[23] = r.heartRate;
     buf[24] = r.cadence;
     writeBytes(buf, sizeof(buf));
+}
+
+FitWriter::RepairResult FitWriter::repair(fs::FS& fs, const char* path) {
+    RepairResult res;
+
+    File f = fs.open(path, "r+");  // read/write, no truncate
+    if (!f) return res;            // INVALID
+    uint32_t fileSize = f.size();
+    if (fileSize < PROLOGUE_BYTES) { f.close(); return res; }
+
+    uint8_t prologue[PROLOGUE_BYTES];
+    if (f.read(prologue, PROLOGUE_BYTES) != (int)PROLOGUE_BYTES) {
+        f.close();
+        return res;
+    }
+    if (prologue[0] != 12 || memcmp(&prologue[8], ".FIT", 4) != 0) {
+        f.close();
+        return res;  // not one of ours
+    }
+
+    // A finished ride is exactly header + data_size + the 2-byte CRC. Anything
+    // else is a ride that was still being written when the device went down;
+    // its data_size only reflects the last checkpoint, so don't trust it.
+    uint32_t headerDataSize = get32(&prologue[4]);
+    if (fileSize == 12 + headerDataSize + 2) {
+        f.close();
+        res.status = RepairResult::ALREADY_FINISHED;
+        return res;
+    }
+
+    res.startUtc = utcFromFit(get32(&prologue[43]));  // file_id.time_created
+
+    // Walk the record stream. A reset can leave a torn final record, so only
+    // whole ones count; the tail written below overwrites any partial bytes.
+    uint32_t records = (fileSize - PROLOGUE_BYTES) / RECORD_BYTES;
+    time_t   endUtc = res.startUtc;
+    double   distanceM = 0;
+    uint32_t good = 0;
+    uint8_t  rec[RECORD_BYTES];
+    for (uint32_t i = 0; i < records; ++i) {
+        f.seek(PROLOGUE_BYTES + i * RECORD_BYTES);
+        if (f.read(rec, RECORD_BYTES) != (int)RECORD_BYTES) break;
+        if (rec[0] != L_RECORD) break;  // stream desynced — salvage what we have
+        endUtc = utcFromFit(get32(&rec[REC_OFF_TIMESTAMP]));
+        distanceM = get32(&rec[REC_OFF_DISTANCE]) / 100.0;
+        good = i + 1;
+    }
+
+    if (good == 0) {
+        f.close();
+        res.status = RepairResult::EMPTY;
+        return res;
+    }
+
+    res.records = (int)good;
+    res.distanceM = distanceM;
+    // The true timer count died with the reset; elapsed time is the honest
+    // stand-in, and matches what the record stream actually spans.
+    res.elapsedS = (uint32_t)(endUtc - res.startUtc);
+
+    // Hand the open handle to a writer positioned just past the last whole
+    // record, so finish() appends the usual tail and fixes up size + CRC.
+    FitWriter w;
+    w.file_ = f;
+    w.startUtc_ = res.startUtc;
+    w.dataSize_ = PROLOGUE_BYTES - 12 + good * RECORD_BYTES;
+    if (!w.file_.seek(PROLOGUE_BYTES + good * RECORD_BYTES)) {
+        f.close();
+        return res;  // INVALID
+    }
+    if (!w.finish(endUtc, distanceM, res.elapsedS)) return res;
+
+    res.status = RepairResult::REPAIRED;
+    return res;
 }
 
 bool FitWriter::finish(time_t endUtc, double totalDistanceM, uint32_t timerS) {

--- a/src/fit_writer.h
+++ b/src/fit_writer.h
@@ -32,15 +32,37 @@ public:
 
     void writeRecord(const Record& r);
 
-    // Call periodically so a crash mid-ride loses seconds, not the ride.
-    // Also patches the header's data_size to the bytes written so far, so a
-    // ride cut short by power loss is still recoverable without finish().
+    // Call periodically to push buffered records onto the card, so a crash
+    // mid-ride loses seconds rather than minutes. This does NOT leave a
+    // readable file behind: an activity is only valid once finish() has
+    // appended the lap/session/activity messages and the trailing CRC. A ride
+    // cut short by a reset is put back together by repair() on the next boot.
     void checkpoint();
 
     // Timer-stop event, lap, session, activity, then header/CRC fixup.
     bool finish(time_t endUtc, double totalDistanceM, uint32_t timerS);
 
     bool isOpen() const { return (bool)file_; }
+
+    struct RepairResult {
+        enum Status {
+            ALREADY_FINISHED,  // has a trailing CRC — left untouched
+            REPAIRED,          // records salvaged and finish() applied
+            EMPTY,             // valid prologue but no records to salvage
+            INVALID,           // not a file this writer produced
+        };
+        Status   status = INVALID;
+        int      records = 0;
+        double   distanceM = 0;
+        uint32_t elapsedS = 0;
+        time_t   startUtc = 0;
+    };
+
+    // Finalizes, in place, a ride left unfinished by a reset or power loss.
+    // Replays the record stream to recover the end time and distance, then
+    // writes the same tail finish() would have. Safe to call on any file: an
+    // already-finished ride is reported as ALREADY_FINISHED and not rewritten.
+    static RepairResult repair(fs::FS& fs, const char* path);
 
 private:
     void writeBytes(const uint8_t* data, size_t len);

--- a/src/ride_recorder.cpp
+++ b/src/ride_recorder.cpp
@@ -62,6 +62,54 @@ void makeRidePath(char* out, size_t len, time_t utc) {
              tmv.tm_hour, tmv.tm_min, tmv.tm_sec);
 }
 
+// A reset mid-ride (watchdog, brownout, flat battery) leaves the ride on the
+// card without the lap/session/activity tail and CRC that make it an activity,
+// so Strava and friends reject it — the ride looks lost even though every
+// record is sitting there. Put those files back together at boot, before the
+// UI or a USB host can touch the card.
+//
+// Repairing rewrites a file's tail but never adds or removes a directory
+// entry, so it is safe to do while walking the directory; deletions are held
+// back until the walk is done.
+void recoverInterruptedRides() {
+    char toDelete[8][32];
+    int deleteCount = 0;
+    int repaired = 0;
+
+    sdLock();
+    File dir = SD.open(RIDE_DIR);
+    if (dir) {
+        for (File f = dir.openNextFile(); f; f = dir.openNextFile()) {
+            if (f.isDirectory()) { f.close(); continue; }
+            char path[48];
+            // name() is the bare filename on this core, not the full path.
+            snprintf(path, sizeof(path), RIDE_DIR "/%s", f.name());
+            f.close();
+
+            FitWriter::RepairResult r = FitWriter::repair(SD, path);
+            if (r.status == FitWriter::RepairResult::REPAIRED) {
+                repaired++;
+                diag::log("ride recovered: %s — %.2f km, %lu s (%d pts)", path,
+                          r.distanceM / 1000.0, (unsigned long)r.elapsedS,
+                          r.records);
+            } else if (r.status == FitWriter::RepairResult::EMPTY) {
+                // Died before the first GPS fix: a header and nothing else.
+                if (deleteCount < 8) {
+                    snprintf(toDelete[deleteCount++], sizeof(toDelete[0]), "%s",
+                             path);
+                }
+            }
+        }
+        dir.close();
+    }
+    for (int i = 0; i < deleteCount; ++i) SD.remove(toDelete[i]);
+    sdUnlock();
+
+    if (repaired) {
+        Serial.printf("[rec] recovered %d interrupted ride(s)\n", repaired);
+    }
+}
+
 void resetStats() {
     distanceM = 0;
     timerS = 0;
@@ -179,6 +227,7 @@ bool begin() {
     }
     Serial.printf("[rec] SD ready, %llu MB free\n",
                   (SD.totalBytes() - SD.usedBytes()) / (1024ULL * 1024ULL));
+    recoverInterruptedRides();
     return true;
 }
 

--- a/tools/fit_test/fit_test.cpp
+++ b/tools/fit_test/fit_test.cpp
@@ -1,0 +1,173 @@
+// Host harness for FitWriter — compiles the real src/fit_writer.cpp against a
+// thin FS shim so the crash/recovery paths can be exercised without hardware.
+//
+// Emits .fit files into tools/fit_test/out/ for a real parser to validate:
+//   normal.fit    — ride closed cleanly via finish()
+//   crashed.fit   — ride cut off mid-stream, then repaired in place
+//   torn.fit      — cut off mid-record, then repaired in place
+//   empty.fit     — cut off before the first GPS fix (prologue only)
+//
+// Build/run: tools/fit_test/run_fit_test.sh
+
+#include "fit_writer.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* OUT_DIR = "tools/fit_test/out";
+fs::FS host(OUT_DIR);
+
+// 2026-07-16 17:39:05 UTC — the peninsula ride from issue #5.
+constexpr time_t RIDE_START = 1784223545;
+
+int failures = 0;
+
+void check(bool ok, const char* what) {
+    if (!ok) { printf("  FAIL: %s\n", what); failures++; }
+}
+
+std::string fullPath(const char* p) { return std::string(OUT_DIR) + p; }
+
+// Roughly 20 km/h heading south down the peninsula from San Francisco.
+FitWriter::Record makeRecord(int i, double& distanceM) {
+    distanceM += 5.5;  // ~5.5 m per 1 Hz sample
+    FitWriter::Record r;
+    r.utc = RIDE_START + i;
+    r.latitudeDeg = 37.7527 - i * 0.00005;
+    r.longitudeDeg = -122.4365 + i * 0.00001;
+    r.altitudeM = 30.0f + (i % 40);
+    r.speedMs = 5.5f;
+    r.distanceM = distanceM;
+    r.powerW = 180 + (i % 30);
+    r.heartRate = 140 + (i % 10);
+    r.cadence = 85;
+    return r;
+}
+
+std::vector<uint8_t> readAll(const char* path) {
+    FILE* f = fopen(fullPath(path).c_str(), "rb");
+    if (!f) return {};
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    std::vector<uint8_t> buf((size_t)n);
+    if (n > 0 && fread(buf.data(), 1, (size_t)n, f) != (size_t)n) buf.clear();
+    fclose(f);
+    return buf;
+}
+
+uint32_t fileSize(const char* path) { return (uint32_t)readAll(path).size(); }
+
+// Writes a complete ride, then produces `dst` as the first `keepBytes` of it
+// with the header's data_size rolled back to `staleDataSize` — byte-for-byte
+// what a watchdog reset leaves on the card: records on disk, but a data_size
+// frozen at the last 15 s checkpoint and no lap/session/activity/CRC tail.
+void simulateCrash(const char* dst, int records, int extraBytes,
+                   uint32_t staleDataSize) {
+    {
+        FitWriter w;
+        if (!w.begin(host, "/scratch.fit", RIDE_START)) {
+            printf("FAIL: cannot open scratch\n");
+            exit(1);
+        }
+        double dist = 0;
+        for (int i = 0; i < records; ++i) w.writeRecord(makeRecord(i, dist));
+        // One more whole record when a torn tail is wanted; the truncation
+        // below keeps only the first `extraBytes` of it.
+        if (extraBytes > 0) w.writeRecord(makeRecord(records, dist));
+        // finish() only serves to close the handle here — everything it appends
+        // lands past `keep` and is truncated away.
+        w.finish(RIDE_START + records, dist, (uint32_t)records);
+    }
+    std::vector<uint8_t> buf = readAll("/scratch.fit");
+    size_t keep = 106 + (size_t)records * 25 + (size_t)extraBytes;
+    if (buf.size() < keep) { printf("FAIL: scratch too small\n"); exit(1); }
+    buf.resize(keep);
+    buf[4] = staleDataSize & 0xFF;
+    buf[5] = (staleDataSize >> 8) & 0xFF;
+    buf[6] = (staleDataSize >> 16) & 0xFF;
+    buf[7] = (staleDataSize >> 24) & 0xFF;
+    FILE* f = fopen(fullPath(dst).c_str(), "wb");
+    fwrite(buf.data(), 1, buf.size(), f);
+    fclose(f);
+    remove(fullPath("/scratch.fit").c_str());
+}
+
+}  // namespace
+
+int main() {
+    printf("prologue = %u bytes, record = 25 bytes\n\n", (unsigned)106);
+
+    // 1. A clean ride, closed properly.
+    {
+        FitWriter w;
+        if (!w.begin(host, "/normal.fit", RIDE_START)) { printf("FAIL: open\n"); return 1; }
+        double dist = 0;
+        for (int i = 0; i < 345; ++i) w.writeRecord(makeRecord(i, dist));
+        check(w.finish(RIDE_START + 345, dist, 345), "finish() succeeds");
+        printf("normal.fit   %6u bytes  clean finish\n", fileSize("/normal.fit"));
+    }
+
+    // 2. The issue #5 ride: 345 whole samples on disk, data_size frozen at the
+    //    last checkpoint (345 = 23 checkpoints of 15 records: 340 records in).
+    simulateCrash("/crashed.fit", 345, 0, 106 - 12 + 340 * 25);
+    printf("crashed.fit  %6u bytes  watchdog reset, never finished\n",
+           fileSize("/crashed.fit"));
+    check(fileSize("/crashed.fit") == 8731, "crashed size matches the 8731 in the log");
+    {
+        FitWriter::RepairResult r = FitWriter::repair(host, "/crashed.fit");
+        printf("             -> %s: %d records, %.2f km, %lu s\n",
+               r.status == FitWriter::RepairResult::REPAIRED ? "REPAIRED" : "FAILED",
+               r.records, r.distanceM / 1000.0, (unsigned long)r.elapsedS);
+        check(r.status == FitWriter::RepairResult::REPAIRED, "crashed ride repaired");
+        check(r.records == 345, "all 345 records recovered");
+        check(r.elapsedS == 344, "elapsed spans the record stream");
+    }
+
+    // 3. Reset mid-record: the torn tail must be dropped, not decoded.
+    simulateCrash("/torn.fit", 100, 11, 0);
+    {
+        FitWriter::RepairResult r = FitWriter::repair(host, "/torn.fit");
+        printf("torn.fit     %6u bytes  -> %s: %d records\n", fileSize("/torn.fit"),
+               r.status == FitWriter::RepairResult::REPAIRED ? "REPAIRED" : "FAILED",
+               r.records);
+        check(r.status == FitWriter::RepairResult::REPAIRED, "torn ride repaired");
+        check(r.records == 100, "torn trailing record dropped");
+    }
+
+    // 4. A ride that died before the first GPS fix — no samples to salvage.
+    simulateCrash("/empty.fit", 0, 0, 0);
+    {
+        FitWriter::RepairResult r = FitWriter::repair(host, "/empty.fit");
+        printf("empty.fit    %6u bytes  -> %s\n", fileSize("/empty.fit"),
+               r.status == FitWriter::RepairResult::EMPTY ? "EMPTY" : "unexpected");
+        check(fileSize("/empty.fit") == 106, "empty size matches the 106 in the log");
+        check(r.status == FitWriter::RepairResult::EMPTY, "empty ride reported EMPTY");
+    }
+
+    // 5. Recovery runs every boot, so a finished ride must be left alone.
+    {
+        std::vector<uint8_t> before = readAll("/normal.fit");
+        FitWriter::RepairResult r = FitWriter::repair(host, "/normal.fit");
+        printf("normal.fit   -> %s\n",
+               r.status == FitWriter::RepairResult::ALREADY_FINISHED
+                   ? "ALREADY_FINISHED (skipped)" : "unexpected");
+        check(r.status == FitWriter::RepairResult::ALREADY_FINISHED,
+              "finished ride skipped");
+        check(readAll("/normal.fit") == before, "finished ride left byte-identical");
+    }
+
+    // 6. Repair is idempotent — a repaired ride is now a finished ride.
+    {
+        FitWriter::RepairResult r = FitWriter::repair(host, "/crashed.fit");
+        check(r.status == FitWriter::RepairResult::ALREADY_FINISHED,
+              "repair is idempotent");
+    }
+
+    printf("\n%s\n", failures ? "HOST ASSERTIONS FAILED" : "all host assertions passed");
+    return failures ? 1 : 0;
+}

--- a/tools/fit_test/run_fit_test.sh
+++ b/tools/fit_test/run_fit_test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Builds and runs the host FitWriter test, then validates the emitted .fit
+# files with a real FIT parser if one is installed (pip install fitdecode).
+# Output: tools/fit_test/out/*.fit
+set -e
+cd "$(dirname "$0")/../.."
+
+mkdir -p tools/fit_test/out
+clang++ -std=c++17 -O2 -Wall \
+    -I tools/fit_test/shim -I src \
+    tools/fit_test/fit_test.cpp src/fit_writer.cpp \
+    -o tools/fit_test/fit_test
+
+./tools/fit_test/fit_test
+
+# empty.fit is deliberately unrecoverable (the device deletes it rather than
+# keeping a ride with no points), so it is not expected to parse.
+if python3 -c "import fitdecode" 2>/dev/null; then
+    echo
+    python3 tools/fit_test/validate_fit.py \
+        tools/fit_test/out/normal.fit \
+        tools/fit_test/out/crashed.fit \
+        tools/fit_test/out/torn.fit
+else
+    echo
+    echo "(skipping parser validation — pip install fitdecode to enable)"
+fi

--- a/tools/fit_test/shim/Arduino.h
+++ b/tools/fit_test/shim/Arduino.h
@@ -1,0 +1,8 @@
+// Host shim: the sliver of Arduino.h that fit_writer.cpp needs.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <ctime>

--- a/tools/fit_test/shim/FS.h
+++ b/tools/fit_test/shim/FS.h
@@ -1,0 +1,67 @@
+// Host shim for the Arduino FS API, faithful to the ESP32 implementation:
+// VFSImpl::open() is a plain fopen(), so the mode string decides whether the
+// handle can be read back. Keeping that behaviour here is the whole point —
+// opening "w" and then read()ing returns 0 bytes on device, and does so here.
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#define FILE_READ   "r"
+#define FILE_WRITE  "w"
+#define FILE_APPEND "a"
+
+class File {
+public:
+    File() = default;
+    explicit File(FILE* f, std::string path = {}) : f_(f), path_(std::move(path)) {}
+
+    explicit operator bool() const { return f_ != nullptr; }
+
+    size_t write(const uint8_t* data, size_t len) {
+        return f_ ? fwrite(data, 1, len, f_) : 0;
+    }
+    int read(uint8_t* buf, size_t len) {
+        if (!f_) return -1;
+        return (int)fread(buf, 1, len, f_);
+    }
+    bool seek(uint32_t pos) { return f_ && fseek(f_, (long)pos, SEEK_SET) == 0; }
+    uint32_t position() const { return f_ ? (uint32_t)ftell(f_) : 0; }
+    uint32_t size() const {
+        if (!f_) return 0;
+        long cur = ftell(f_);
+        fseek(f_, 0, SEEK_END);
+        long end = ftell(f_);
+        fseek(f_, cur, SEEK_SET);
+        return (uint32_t)end;
+    }
+    void flush() { if (f_) fflush(f_); }
+    void close() { if (f_) { fclose(f_); f_ = nullptr; } }
+    const char* name() const { return path_.c_str(); }
+
+private:
+    FILE* f_ = nullptr;
+    std::string path_;
+};
+
+namespace fs {
+class FS {
+public:
+    explicit FS(std::string root = ".") : root_(std::move(root)) {}
+    File open(const char* path, const char* mode = FILE_READ) {
+        std::string full = root_ + path;
+        FILE* f = fopen(full.c_str(), mode);
+        return File(f, full);
+    }
+    bool exists(const char* path) {
+        FILE* f = fopen((root_ + path).c_str(), "r");
+        if (f) { fclose(f); return true; }
+        return false;
+    }
+    bool remove(const char* path) { return ::remove((root_ + path).c_str()) == 0; }
+
+private:
+    std::string root_;
+};
+}  // namespace fs

--- a/tools/fit_test/validate_fit.py
+++ b/tools/fit_test/validate_fit.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Validate .fit files the way Strava/intervals.icu do: full parse + CRC check.
+
+Reports the messages that decide whether an upload is accepted — a file without
+a session/activity is not an activity, however many records it carries.
+"""
+import sys
+
+import fitdecode
+
+
+def check(path):
+    counts = {}
+    try:
+        with fitdecode.FitReader(path, check_crc=fitdecode.CrcCheck.RAISE) as fit:
+            for frame in fit:
+                if frame.frame_type == fitdecode.FIT_FRAME_DATA:
+                    counts[frame.name] = counts.get(frame.name, 0) + 1
+    except Exception as e:
+        print(f"  {path}: REJECTED — {type(e).__name__}: {e}")
+        return False
+
+    need = ("file_id", "record", "session", "activity")
+    missing = [m for m in need if not counts.get(m)]
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    if missing:
+        print(f"  {path}: REJECTED — no {'/'.join(missing)} ({summary})")
+        return False
+    print(f"  {path}: OK — {summary}")
+    return True
+
+
+if __name__ == "__main__":
+    print("FIT parser validation (CRC enforced):")
+    ok = all([check(p) for p in sys.argv[1:]])
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
Fixes #5.

## Diagnosis

The peninsula ride **was recorded** — it's still on your SD card as `/rides/20260716-173905.fit`. It just isn't a file any parser will accept.

Reading `bikegps-diag.log`, the ride started at 17:39:05 and the device reset 6 minutes in:

```
[17:37:37] gps FIX: chars=4597815 ck=93324/0 sats=9/18 snr=30 hdop=1.5
[17:45:15] boot firmware v0.50 (reset: task watchdog [6])
[17:45:15] CRASH dump: task 'epd_prep' PC=0x4037954e
```

There's no `ride start -> /rides/20260716-173905.fit` line because `diag.cpp` stages 48 KB of log in RAM before flushing to SD, so the crash took the lines between 17:37:37 and 17:45:15 with it. But the file surfaces later in the log, and its size gives the whole game away:

```
[18:18:17] download 20260716-173905.fit: total=8731, MTU=247, chunk=180
```

`begin()` always emits a fixed 106-byte prologue, and each record is exactly 25 bytes. **8731 = 106 + 345 × 25** — 345 GPS samples, sitting on the card intact. The same arithmetic explains the other orphan in the log: `20260716-160342.fit` at **106 bytes exactly** is a ride killed by the 16:04:52 watchdog before its first fix — prologue, zero records.

The problem is that a FIT file only becomes an *activity* once `finish()` appends the lap/session/activity messages and the trailing CRC. Nothing did that, so Strava sees a malformed file and the ride reads as "never saved". Nothing on the next boot looked for it either, so it just sat there.

`checkpoint()`'s comment claimed otherwise — *"a ride cut short by power loss is still recoverable without finish()"* — but it only patches `data_size`. That was never true.

**A second, latent bug found while testing:** `begin()` opened files with `FILE_WRITE`, which is `"w"` on this core — write-only. `finish()` computes the CRC by re-reading the file, and reading a write-only handle returns zero bytes, so the CRC loop never ran and **every ride file this device has ever written has a CRC of `0x0000`**. Strava is lenient enough about CRCs that this stayed hidden; strict parsers reject those files outright.

## The fix

- **`FitWriter::repair()`** — finalizes an interrupted ride in place, replaying the record stream to recover the end time and distance, then writing the tail `finish()` would have. Doesn't trust the header's `data_size` (it's frozen at the last 15 s checkpoint); drops a torn final record; reports `ALREADY_FINISHED` for a healthy file and leaves it byte-identical.
- **`ride_recorder::begin()`** — runs recovery over `/rides` at boot, before the UI or a USB host can touch the card. Rides with no points (the 106-byte case) are deleted rather than left as clutter. Repair rewrites a file's tail but never adds or removes a directory entry, so it's safe during the walk; deletions are held until after.
- **`begin()` opens `"w+"`** instead of `FILE_WRITE`, so the CRC read-back works.
- **`tools/fit_test/`** — compiles the real `src/fit_writer.cpp` against an FS shim (faithful to ESP32's `VFSImpl`, where the mode string decides readability) and validates output with a real FIT parser. Follows the `tools/preview` host-harness pattern already in the repo.

**When you boot this firmware with that SD card in, your peninsula ride will be repaired automatically** and appear as a normal 345-point activity.

## Testing

### Reproducing the bug (original code, before the fix)

Built `HEAD`'s `fit_writer.cpp` against the FS shim, wrote a 345-record ride, and truncated it to 8731 bytes with `data_size` frozen at the last checkpoint — byte-for-byte what the watchdog left. Then parsed both with `fitdecode` (CRC enforced):

```
normal_before.fit  8909 bytes (finish() called)
crashed_before.fit 8731 bytes (watchdog reset)
--- validating files produced by the ORIGINAL code ---
FIT parser validation (CRC enforced):
  /tmp/before/out/crashed_before.fit: REJECTED — FitCRCError: mismatching CRC in FIT footer (footer offset: 8606; read crc: 36097; expected crc: 55295)
  /tmp/before/out/normal_before.fit: REJECTED — FitCRCError: mismatching CRC in FIT footer (footer offset: 8907; read crc: 0; expected crc: 6216)
```

The crashed ride is rejected — the reported bug. And `read crc: 0` on the *cleanly finished* ride is the `"w"`-mode bug caught in the act.

### After the fix

`./tools/fit_test/run_fit_test.sh` (exit 0):

```
prologue = 106 bytes, record = 25 bytes

normal.fit     8909 bytes  clean finish
crashed.fit    8731 bytes  watchdog reset, never finished
             -> REPAIRED: 345 records, 1.90 km, 344 s
torn.fit       2784 bytes  -> REPAIRED: 100 records
empty.fit       106 bytes  -> EMPTY
normal.fit   -> ALREADY_FINISHED (skipped)

all host assertions passed

FIT parser validation (CRC enforced):
  tools/fit_test/out/normal.fit: OK — activity=1, event=2, file_id=1, lap=1, record=345, session=1
  tools/fit_test/out/crashed.fit: OK — activity=1, event=2, file_id=1, lap=1, record=345, session=1
  tools/fit_test/out/torn.fit: OK — activity=1, event=2, file_id=1, lap=1, record=100, session=1
```

The harness asserts the simulated crash file is **8731 bytes** and the no-fix file **106 bytes** — matching the real sizes in your log, which is what pins the reconstruction to the actual failure.

Decoding the recovered ride shows the timeline lines up with the log exactly:

```
--- tools/fit_test/out/crashed.fit (recovered peninsula ride) ---
  session.start_time = 2026-07-16 17:39:05+00:00
  session.total_elapsed_time = 344.0
  session.total_distance = 1897.5
  session.sport = cycling
  session.num_laps = 1
  records = 345
  first: t=2026-07-16 17:39:05+00:00 lat=450407255.00000 lon=-1460724343.00000 dist=5.5 power=180 hr=140
  last: t=2026-07-16 17:44:49+00:00 lat=450202051.00000 lon=-1460683302.00000 dist=1897.5 power=194 hr=144
```

`start_time` matches the `20260716-173905.fit` filename, and the last sample lands 26 s before the 17:45:15 watchdog reset.

### Firmware build

`pio run` after cloning `vendor/T5S3-4.7-e-paper-PRO`:

```
RAM:   [===       ]  33.5% (used 109800 bytes from 327680 bytes)
Flash: [==        ]  18.0% (used 1180641 bytes from 6553600 bytes)
========================= [SUCCESS] Took 11.22 seconds =========================
```

No new warnings from `fit_writer.cpp` or `ride_recorder.cpp`.

### Edge cases exercised

- Torn trailing record (reset mid-write) — dropped, rest recovered. The finish tail is ~176 bytes and a partial record is at most 24, so it always overwrites the remnant; no truncate needed.
- Ride with no points — reported `EMPTY`, deleted by the recorder.
- Already-finished ride — skipped, verified byte-identical (recovery runs every boot).
- Repair is idempotent — a repaired ride reports `ALREADY_FINISHED` on the next pass.

### Not verified

- **No hardware run.** I have no T5S3 board, so `ride_recorder::recoverInterruptedRides()` itself was not executed — only `FitWriter::repair()`, which holds the logic it drives. Worth confirming on-device that boot logs `ride recovered: /rides/20260716-173905.fit — ... (345 pts)` and that the file then uploads to Strava. Its SD iteration relies on `File::name()` returning a bare filename, which I checked against the installed core (2.0.14, `VFSFileImpl::name()` → `pathToFileName(path())`) rather than at runtime.
- **Back up that .fit before booting the new firmware.** Recovery rewrites in place, and I'd rather you have a copy than trust my byte math with your only one.
- I did not upload a repaired file to Strava — validation is `fitdecode` with CRC checking, which is stricter than Strava about CRCs but isn't the same acceptance test.

## Deliberately out of scope

- **The `epd_prep` watchdog crash itself.** Two resets in this log (16:04:52 and 17:45:15) both fire in epdiy's display task, with a corrupt backtrace and inside the vendored library — a separate investigation, and worth its own issue. This PR makes a crash cost you seconds instead of the whole ride, but doesn't stop it.
- **Auto-resume after a reset.** You rode 17:45→18:07 with no recording at all and only noticed at 18:07:45. Recovery salvages the pre-crash ride, but the firmware still won't restart recording by itself — a bigger change (persisting ride state across boots) that I'd rather not fold in here.
- The recovery pass deletes at most 8 empty rides per boot; any beyond that are picked up on the next boot. Repairs are unbounded.


Closes #5

🤖 Opened by issue-fixer.