### PR TITLE
Stop the map store from hammering the SD bus while outside map coverage

### DIFF
--- a/src/map_store.cpp
+++ b/src/map_store.cpp
@@ -32,6 +32,16 @@ size_t primaryLen = 0;
 double loadedS = 0, loadedW = 0, loadedN = 0, loadedE = 0;
 bool haveBounds = false;
 
+// Index of the whole maps on the card (name + bbox), so "which whole map covers
+// this position?" is a RAM lookup rather than a scan of the card. Mirrors the
+// H3 tile index below. Whole maps only appear/disappear when one is downloaded
+// or a host computer edits the card, so this is rebuilt at those points instead
+// of being re-derived from SD on every position update.
+constexpr int MAX_MAPS = 32;
+struct MapMeta { char name[56]; double s, w, n, e; };
+MapMeta g_maps[MAX_MAPS];
+int g_mapCount = 0;
+
 // --- H3 tile layer -------------------------------------------------------
 // Each downloaded H3 cell is its own small .ebm under /maps/tiles, named by
 // its H3 id. We keep a lightweight in-memory index of (name, bbox) and load
@@ -103,34 +113,49 @@ bool loadFile(const char* path) {
     return true;
 }
 
-// Find a downloaded whole map whose bounds contain (lat, lon); load if found.
-bool loadCovering(double lat, double lon) {
+// (Re)build the in-memory whole-map index from the /maps headers.
+void scanMaps() {
+    g_mapCount = 0;
     sdLock();
+    if (!SD.exists(MAP_DIR)) SD.mkdir(MAP_DIR);
     File dir = SD.open(MAP_DIR);
-    if (!dir) { sdUnlock(); return false; }
-    char best[64] = "";
-    for (File e = dir.openNextFile(); e; e = dir.openNextFile()) {
-        if (!e.isDirectory()) {
-            const char* nm = e.name();
-            const char* base = strrchr(nm, '/');
-            base = base ? base + 1 : nm;
-            if (strstr(base, ".ebm")) {
-                uint8_t h[36];
-                if (e.read(h, 36) == 36) {
+    if (dir) {
+        for (File e = dir.openNextFile(); e && g_mapCount < MAX_MAPS;
+             e = dir.openNextFile()) {
+            if (!e.isDirectory()) {
+                const char* nm = e.name();
+                const char* base = strrchr(nm, '/');
+                base = base ? base + 1 : nm;
+                if (strstr(base, ".ebm")) {
+                    uint8_t h[36];
                     double s, w, n, ee;
-                    if (headerBounds(h, s, w, n, ee) &&
-                        lat >= s && lat <= n && lon >= w && lon <= ee) {
-                        snprintf(best, sizeof(best), "%s/%s", MAP_DIR, base);
+                    if (e.read(h, 36) == 36 && headerBounds(h, s, w, n, ee)) {
+                        MapMeta& m = g_maps[g_mapCount++];
+                        strncpy(m.name, base, sizeof(m.name) - 1);
+                        m.name[sizeof(m.name) - 1] = 0;
+                        m.s = s; m.w = w; m.n = n; m.e = ee;
                     }
                 }
             }
+            e.close();
         }
-        e.close();
-        if (best[0]) break;
+        dir.close();
     }
-    dir.close();
     sdUnlock();
-    return best[0] ? loadFile(best) : false;
+    diag::log("map: %d whole maps indexed", g_mapCount);
+}
+
+// Find an indexed whole map whose bounds contain (lat, lon); load if found.
+// A RAM lookup — no SD work unless there's actually a map to load.
+bool loadCovering(double lat, double lon) {
+    for (int i = 0; i < g_mapCount; ++i) {
+        const MapMeta& m = g_maps[i];
+        if (lat < m.s || lat > m.n || lon < m.w || lon > m.e) continue;
+        char path[80];
+        snprintf(path, sizeof(path), "%s/%s", MAP_DIR, m.name);
+        return loadFile(path);
+    }
+    return false;
 }
 
 // (Re)build the in-memory tile index from /maps/tiles headers. Invalidates
@@ -258,13 +283,24 @@ void begin(double lat, double lon) {
     if (!SD.exists(MAP_DIR)) SD.mkdir(MAP_DIR);
     sdUnlock();
     scanTiles();
+    scanMaps();
     if (!loadCovering(lat, lon)) clearPrimary();   // no fallback map
 }
 
+void rescanCard() {
+    scanTiles();
+    scanMaps();
+}
+
+// Called once per rendered frame (~1 Hz), including the whole time the rider is
+// outside the downloaded area — so it must not touch the SD card unless there
+// is actually a map to load. The recorder appends to the FIT on the same SPI
+// bus under the same mutex once a second, and a ride must never be held up by
+// map bookkeeping. Hence the RAM-resident bounds index.
 void ensureForPosition(double lat, double lon) {
     if (boundsCover(lat, lon)) return;      // current whole map already covers us
     if (loadCovering(lat, lon)) return;     // switched to a better downloaded map
-    if (!boundsCover(lat, lon)) clearPrimary();   // nothing whole-map covers us now
+    clearPrimary();                         // nothing whole-map covers us now
 }
 
 void renderInto(double lat, double lon, float metersPerPixel, int centerX,
@@ -330,6 +366,7 @@ bool saveAndActivate(const char* name, const uint8_t* data, size_t len) {
     sdUnlock();
     if (!ok) { diag::log("map save: write failed %s", path); return false; }
     diag::log("map saved: %s (%u KB)", path, (unsigned)(len / 1024));
+    scanMaps();   // index the new map so ensureForPosition can find it later
     return loadFile(path);
 }
 

--- a/src/map_store.h
+++ b/src/map_store.h
@@ -21,9 +21,16 @@ namespace map_store {
 // embedded default). Call after the SD card is mounted.
 void begin(double lat, double lon);
 
-// If the currently loaded whole map doesn't cover (lat, lon), look for a
-// downloaded one that does. No-op when tiles are what's covering us.
+// If the currently loaded whole map doesn't cover (lat, lon), load the
+// downloaded one that does. Answered from the in-RAM bounds index, so outside
+// the downloaded area (where there is nothing to load) this costs no SD access
+// at all — it runs every second, on the bus the recorder writes the FIT to.
 void ensureForPosition(double lat, double lon);
+
+// Re-read the tile and whole-map indexes from the card. Call after something
+// other than saveTile/saveAndActivate could have changed /maps — i.e. when a
+// host computer releases the SD after mounting it over USB.
+void rescanCard();
 
 // Render the map around (lat, lon) into `out`: projects every H3 tile that
 // overlaps the viewport (loading them from SD on demand), falling back to the

--- a/src/ride_recorder.cpp
+++ b/src/ride_recorder.cpp
@@ -16,6 +16,13 @@ FitWriter fit;
 bool sdOk = false;
 char ridePath[48];
 
+// The rider started a ride and hasn't stopped it. Deliberately NOT derived from
+// fit.isOpen(): the FIT handle lives on an SPI bus shared with the map store,
+// the diag log and USB mass storage, and a ride must outlive any trouble down
+// there. Only startRide()/stopRide() move this.
+bool rideActive = false;
+bool loggedFileLost = false;   // so a lost handle logs once, not once a second
+
 double lastLat = 0, lastLon = 0;
 bool havePrevFix = false;
 double distanceM = 0;
@@ -183,7 +190,7 @@ bool begin() {
 }
 
 void startRide() {
-    if (!sdOk || fit.isOpen() || usb_storage::hostActive()) return;
+    if (!sdOk || rideActive || usb_storage::hostActive()) return;
 
     RideState s = g_state.snapshot();
     if (!s.timeValid) {
@@ -202,6 +209,8 @@ void startRide() {
 
     startUtc = s.utc;
     resetStats();
+    rideActive = true;
+    loggedFileLost = false;
     g_state.with([](RideState& st) {
         st.recording = true;
         st.distanceM = 0;
@@ -214,7 +223,8 @@ void startRide() {
 }
 
 void stopRide(bool save) {
-    if (!fit.isOpen()) return;
+    if (!rideActive) return;
+    rideActive = false;
     RideState s = g_state.snapshot();
     endUtc = s.timeValid ? s.utc : startUtc + timerS;
     sdLock();
@@ -242,7 +252,7 @@ void stopRide(bool save) {
     });
 }
 
-bool isRecording() { return fit.isOpen(); }
+bool isRecording() { return rideActive; }
 
 RideSummary summary() {
     RideSummary r;
@@ -293,7 +303,18 @@ void task(void*) {
     for (;;) {
         vTaskDelay(pdMS_TO_TICKS(RECORD_INTERVAL_MS));
         // Never write while a host computer owns the SD over USB.
-        if (!fit.isOpen() || usb_storage::hostActive()) continue;
+        if (!rideActive || usb_storage::hostActive()) continue;
+
+        // The FIT handle went away underneath us (SD trouble — the card is
+        // shared with the map store, diag logging and USB storage). Keep the
+        // ride running: the timer, distance and summary stay live, auto-sleep
+        // stays blocked, and the rider stops the ride when they mean to. Say so
+        // in the log, once, so a short FIT is diagnosable after the fact.
+        if (!fit.isOpen() && !loggedFileLost) {
+            loggedFileLost = true;
+            diag::log("rec: FIT handle lost mid-ride (%s) — ride still timing, "
+                      "records not being written", ridePath);
+        }
 
         RideState s = g_state.snapshot();
         timerS++;

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -740,7 +740,10 @@ void task(void*) {
         // When the computer releases the SD (eject/unplug), check whether it
         // dropped a firmware.bin on the card and flash it automatically.
         bool host = usb_storage::hostActive();
-        if (lastHostActive && !host) applySdUpdate();
+        if (lastHostActive && !host) {
+            applySdUpdate();
+            map_store::rescanCard();   // it may have added/removed maps too
+        }
         lastHostActive = host;
 
         // Terrain elevation from the map DEM at the current position (~1 Hz).


### PR DESCRIPTION
Fixes #4.

## What I found

I could not reproduce this on hardware (I have no device), so I went looking for
anything that behaves differently *specifically* while the rider is outside the
downloaded map area. There is exactly one such thing, and it sits on the same
SPI bus and the same mutex the ride recorder needs every second.

`map_store::ensureForPosition()` is called once per rendered frame (~1 Hz) from
the UI task. Its old shape was:

```cpp
if (boundsCover(lat, lon)) return;   // loaded whole map covers us -> cheap
if (loadCovering(lat, lon)) return;  // else SEARCH THE CARD
```

`loadCovering()` opened `/maps`, then opened and read a 36-byte header from
**every** `.ebm` on the card, all with `sdLock()` held. Inside coverage this
never runs — `boundsCover()` short-circuits. Outside coverage `boundsCover()`
can never become true, so the full scan ran **once a second for the rest of the
ride**, permanently contending with `ride_recorder::task()`'s 1 Hz
`fit.writeRecord()` / `fit.checkpoint()` on the shared SD.

That is the behavior the issue describes as the trigger, so it is what I fixed.

## The fix

Whole maps now get a RAM-resident bounds index (`g_maps[]`: name + bbox),
mirroring the `g_tiles[]` H3 index that already exists a few lines below in the
same file. `loadCovering()` becomes a RAM lookup that touches SD only when there
is genuinely a map to load. Outside coverage it costs **zero** SD access. The
index is rebuilt at `begin()`, after `saveAndActivate()`, and via a new
`rescanCard()` called when a host computer releases the SD over USB (a computer
can add/remove maps behind our back — previously the per-second rescan would
eventually notice; now something has to ask).

I also decoupled "a ride is in progress" from the FIT file handle in
`ride_recorder.cpp`. `isRecording()` was `fit.isOpen()`, i.e. the rider's ride
existed only as a side effect of an SD `File` on that same contended bus. If
that handle ever went away, `isRecording()` silently went false — which also
un-blocks the 10-minute auto-sleep in `ui_dashboard.cpp:810` that is guarded by
`!ride_recorder::isRecording()`. A ride now lives in an explicit `rideActive`
flag moved only by `startRide()`/`stopRide()`, and a lost handle logs once and
keeps the ride timing rather than ending it silently.

To be straight about the causal chain: I have **not** proven the SD contention
is what stopped this specific ride — I can't, without the device. I've fixed the
one mechanism unique to being outside coverage, removed the silent-stop failure
mode, and added a diag line so that if it does recur the log says why.

## Testing

### Firmware build (`pio run`)

The vendored board repo was missing, so I cloned it per the comment at the top
of `platformio.ini`, then built:

```
RAM:   [===       ]  34.4% (used 112624 bytes from 327680 bytes)
Flash: [==        ]  18.0% (used 1179337 bytes from 6553600 bytes)
Building .pio/build/t5s3-pro/firmware.bin
esptool.py v4.5.1
Creating esp32s3 image...
Merged 3 ELF sections
Successfully created esp32s3 image.
========================= [SUCCESS] Took 4.11 seconds =========================
```

RAM goes 33.5% -> 34.4%; the ~2.8 KB is the `g_maps[32]` index. Flash +64 bytes.

The host preview harness (`tools/preview/render_preview.sh`) still builds and
runs; the regenerated PNGs under `tools/preview/out/` came out byte-identical
(`git status` shows only the four source files), so no render change.

### Reproducing the bug, and proving it's gone

There's no test infrastructure in the repo and `map_store.cpp` needs `SD.h` /
`esp_heap_caps.h`, so I built a throwaway host harness **in /tmp (not
committed)**: shim headers plus an in-memory fake SD that counts directory scans
and header reads, linked against the *real, unmodified* `map_store.cpp`. Four
downloaded whole maps on the fake card; ride 300 s outside all of them.

I compiled the identical harness against `git show HEAD:src/map_store.cpp`
(before) and against the patched file (after):

```
######## BEFORE (HEAD, unfixed) ########
--- 60 s inside sf.ebm coverage ---
/maps directory scans: 0   file header reads: 0
--- 300 s riding OUTSIDE every downloaded map (issue #4) ---
/maps directory scans: 300   file header reads: 1200
covered here? no
--- riding back into oakland.ebm coverage ---
/maps directory scans: 1   covered now? yes
--- leave sf.ebm east edge, turn around, come back ---
outside edge covered? no   back inside covered? yes   scans: 2

######## AFTER (this PR) ########
--- 60 s inside sf.ebm coverage ---
/maps directory scans: 0   file header reads: 0
--- 300 s riding OUTSIDE every downloaded map (issue #4) ---
/maps directory scans: 0   file header reads: 0
covered here? no
--- riding back into oakland.ebm coverage ---
/maps directory scans: 0   covered now? yes
--- leave sf.ebm east edge, turn around, come back ---
outside edge covered? no   back inside covered? yes   scans: 0
```

The broken behavior is the `300 scans / 1200 header reads` line: one full scan
of the card per second, every second spent outside coverage, each one holding
the mutex the recorder needs. Inside coverage it's 0 — which is why this only
bites you once you leave the map. After the fix it's 0 in both cases, and
crucially the last two blocks show coverage detection and map switching still
behave identically (`covered now? yes`, `back inside covered? yes`).

### Edge cases exercised

- **Re-entering coverage where you left it.** My first attempt at this fix
  memoized "searched here, found nothing" within ~200 m. The harness showed it
  regressed exactly this case — the memo point sits on the boundary you exited,
  so riding back in would leave the map blank for a few hundred metres. That's
  why the final fix is the bounds index instead; the last block above covers it.
- **Switching between whole maps** (`riding back into oakland.ebm`) still loads
  the right map, now with no scan.
- **New map arriving mid-session**: `saveAndActivate()` re-indexes; USB-dropped
  maps are picked up by the new `rescanCard()` on host release.
- **>32 whole maps** would now be ignored past the 32nd, where the old scan
  found any of them. `MAX_MAPS = 32` against a `g_tiles[512]` index in the same
  file seemed a fair trade; shout if you disagree.

### Not verified

- **Nothing was run on the device.** No hardware here, so I could not ride out
  of a map area, and I have not confirmed that SD contention is what actually
  stopped the reported ride. The fix is reasoned from the code plus the harness
  above.
- The `ride_recorder.cpp` change is **compile-verified only**. The
  `rideActive` / lost-handle path has not been exercised at runtime — I could
  not make a real FIT handle die on demand off-device.
- Before merging, a human should: record a ride, ride out of the downloaded
  area and back, stop the ride, and confirm the `.fit` covers the whole ride
  including the uncovered stretch. Worth checking `/logs/YYYYMMDD.log` for the
  new `map: N whole maps indexed` line and the absence of
  `rec: FIT handle lost mid-ride`.

## Note for the maintainer

If this recurs after the fix, the diag log is now the place to look — a
`rec: FIT handle lost mid-ride` line would confirm the SD-handle theory and
point at the recorder, and its absence would rule it out and send us elsewhere
(e.g. a crash/reset, which `resetReasonStr()` already logs at boot).


Closes #4

🤖 Opened by issue-fixer.