### PR TITLE
Add GitHub Actions build validation for the firmware and iOS projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  firmware:
+    name: Firmware (ESP32-S3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # The espressif32 toolchain is a few hundred MB and unpacks slowly;
+      # keyed on platformio.ini so a platform bump refetches it.
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: pio-${{ runner.os }}-
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      # Board definition + display/touch/battery drivers live here, and
+      # platformio.ini points boards_dir/lib_extra_dirs at it.
+      - name: Clone LilyGO board support
+        run: |
+          git clone --depth 1 \
+            https://github.com/Xinyuan-LilyGO/T5S3-4.7-e-paper-PRO \
+            vendor/T5S3-4.7-e-paper-PRO
+
+      - name: Build
+        run: pio run
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: |
+            .pio/build/t5s3-pro/firmware.bin
+            .pio/build/t5s3-pro/firmware.elf
+          if-no-files-found: error
+
+  ios:
+    name: Companion app (iOS)
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: companion-ios
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        run: xcodegen generate
+
+      # Signing off: the project pins a DEVELOPMENT_TEAM that a runner has no
+      # certificate for, and this only needs to prove the app compiles.
+      # Built by -target against the simulator SDK rather than
+      # -scheme/-destination: no scheme is committed (project.yml declares
+      # none, so schemes are synthesized per-invocation) and this form needs
+      # neither scheme autocreation nor run-destination resolution.
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project BikeGPSCompanion.xcodeproj \
+            -target BikeGPSCompanion \
+            -sdk iphonesimulator \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open E-Paper Bike Computer
 
+[![Build](https://github.com/RaemondBW/epaper-bike-gps/actions/workflows/build.yml/badge.svg)](https://github.com/RaemondBW/epaper-bike-gps/actions/workflows/build.yml)
+
 DIY bike GPS head unit for the [LilyGO T5S3 4.7" e-paper PRO](https://github.com/Xinyuan-LilyGO/T5S3-4.7-e-paper-PRO).
 
 The board has everything onboard: ESP32-S3 (16MB flash / 8MB PSRAM, BLE 5),


### PR DESCRIPTION
Fixes #3.

The repo had no `.github/` directory at all, so nothing was validating either project on push. This adds `.github/workflows/build.yml` with two jobs, running on pushes to `main`, on pull requests, and via manual dispatch:

- **Firmware (ESP32-S3)** — `ubuntu-latest`. Installs PlatformIO, clones the vendored LilyGO board support that `platformio.ini` points `boards_dir` / `lib_extra_dirs` at, runs `pio run`, and uploads `firmware.bin` / `firmware.elf` as artifacts. `~/.platformio` and the pip cache are cached, keyed on `platformio.ini` so a platform bump refetches the toolchain.
- **Companion app (iOS)** — `macos-15`. Installs XcodeGen, runs `xcodegen generate`, and builds with `xcodebuild`.

Also adds a build badge to the README.

### Notes on two judgement calls

**Signing is disabled** (`CODE_SIGNING_ALLOWED=NO`). `project.yml` pins `DEVELOPMENT_TEAM: G5JFC849XY` with `CODE_SIGN_STYLE: Automatic`; a runner has no certificate for that team. The job only needs to prove the app compiles, so it builds unsigned against the simulator SDK. Producing a signed/installable build would need signing secrets and is out of scope here.

**The iOS job uses `-target` + `-sdk iphonesimulator` rather than the more idiomatic `-scheme` + `-destination`.** No scheme is committed — `project.yml` declares none, so there's no `.xcscheme` anywhere and `xcodebuild` synthesizes one per invocation. The `-target` form depends on neither scheme autocreation nor run-destination resolution, and it's the only form I could get to compile locally (see below). If you'd rather have the idiomatic form, the durable fix is to declare a scheme in `project.yml` so a real shared scheme gets generated.

The vendor clone is left as the plain `git clone --depth 1` from the README (337MB, not sparse/cached) so CI exercises the documented build path rather than a faster variant that could drift from it.

## Testing

**Firmware — fully verified.** Cloned the vendor repo and ran the workflow's build command from a clean `.pio`:

```
$ rm -rf .pio && pio run
RAM:   [===       ]  33.5% (used 109800 bytes from 327680 bytes)
Flash: [==        ]  18.0% (used 1179045 bytes from 6553600 bytes)
Building .pio/build/t5s3-pro/firmware.bin
esptool.py v4.5.1
Creating esp32s3 image...
Successfully created esp32s3 image.
========================= [SUCCESS] Took 10.91 seconds =========================
firmware exit=0
```

Both artifact paths the workflow uploads exist afterward (`firmware.bin` 1179456 bytes, `firmware.elf` 17975244 bytes), so the `if-no-files-found: error` upload step won't trip.

**Workflow lint — verified.** `actionlint .github/workflows/build.yml` → exit 0 (parses the YAML, checks expressions, shellchecks the `run` blocks).

**XcodeGen — verified.** `xcodegen generate` (2.46.0) succeeded and produced **no** git diff against the committed `.xcodeproj`, confirming the checked-in project is in sync with `project.yml` and that the generate step won't cause surprises.

### Not verified: the iOS build does not complete on my machine

`xcodebuild` fails here at the asset-catalog step, before any Swift compiles:

```
Sources/Assets.xcassets: error: No simulator runtime version from ["23A339"]
  available to use with iphonesimulator SDK version 23A337
** BUILD FAILED **
The following build commands failed:
	CompileAssetCatalogVariant thinned .../BikeGPSCompanion.app .../Assets.xcassets
(1 failure)
```

This is a broken local Xcode 26.0 install — the installed simulator runtime (`23A339`) doesn't match the SDK (`23A337`), and the iOS device platform isn't installed at all (`iOS 26.0 is not installed`). It is not a defect in this repo's code, and GitHub's macOS runners ship matched SDK/runtime pairs. Installing a matching runtime is a multi-GB download I skipped deliberately.

Two things worth being precise about, since they bound what the evidence proves:

1. **`actool` runs early** (it feeds `GenerateAssetSymbols`), so the failing build produced **zero** `SwiftCompile` steps. I initially misread the log as "everything compiled" — it hadn't. The one failing command is the asset catalog; nothing downstream of it ran.
2. To get real evidence the Swift is healthy anyway, I type-checked all 15 sources against the iOS 17 SDK, which bypasses `actool` entirely:

```
$ xcrun swiftc -typecheck -sdk $(xcrun --sdk iphoneos --show-sdk-path) \
    -target arm64-apple-ios17.0 \
    -import-objc-header Sources/BikeGPS-Bridging-Header.h \
    -I Sources/H3/include -I Sources/H3 Sources/*.swift
typecheck exit=0
```

Exit 0, zero diagnostics — the Swift sources and the H3 bridging header resolve cleanly.

I also confirmed the workflow's exact `xcodebuild` invocation resolves the project and target and accepts the signing override, failing *only* at `actool` (`(1 failure)`). So what remains unproven on CI is specifically: asset-catalog compilation, Swift compilation as driven by `xcodebuild` (as opposed to `swiftc -typecheck`), and linking.

**What a human should check before merging:** that the `Companion app (iOS)` job goes green on its first run. If it fails, the likely culprit is the synthesized-scheme/destination area called out above, not the source. The firmware job I'd expect to pass as-is.


Closes #3

🤖 Opened by issue-fixer.