### PR TITLE
Build the iOS companion app on macos-26 so the iOS 26 SDK is available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,10 @@ jobs:
 
   ios:
     name: Companion app (iOS)
-    runs-on: macos-15
+    # RouteView uses MKDirectionsTransportType.cycling, which Apple only
+    # exposes in the iOS 26 SDK (backdated to iOS 14 availability). macos-15
+    # defaults to Xcode 16.4 / iOS 18.5, where that symbol does not exist.
+    runs-on: macos-26
     defaults:
       run:
         working-directory: companion-ios
@@ -77,6 +80,7 @@ jobs:
       # neither scheme autocreation nor run-destination resolution.
       - name: Build
         run: |
+          xcodebuild -version
           xcodebuild build \
             -project BikeGPSCompanion.xcodeproj \
             -target BikeGPSCompanion \


### PR DESCRIPTION
Fixes #9.

## What was wrong

The iOS job failed to compile, while the firmware job was already passing:

```
/companion-ios/Sources/RouteView.swift:230:47: error: type 'MKDirectionsTransportType' has no member 'cycling'
Command SwiftCompile failed with a nonzero exit code
** BUILD FAILED **
Process completed with exit code 65.
```

`RouteView.buildRoute()` asks MapKit for cycling directions (falling back to walking geometry where Apple has no cycling coverage). `MKDirectionsTransportType.cycling` is only exposed in the iOS 26 SDK — Apple backdated its availability annotation to iOS 14, but the case is absent from earlier SDKs:

```c
// iOS 26 SDK, MKDirectionsTypes.h
MKDirectionsTransportTypeCycling API_AVAILABLE(ios(14.0), macos(11.0), watchos(7.0), tvos(14.0), visionos(1.0)) = 1 << 3,
```

The `macos-15` runner defaults to Xcode 16.4 / iOS 18.5 SDK, where that symbol doesn't exist. So this is a CI toolchain gap, not an app bug — the source is correct and builds on a current Xcode.

## The fix

Build the iOS job on `macos-26` (GA image, default Xcode 26.5, iOS 26 SDK) instead of `macos-15`. Also log `xcodebuild -version` in the build step so a future SDK mismatch is obvious from the job output rather than requiring a bisect.

I chose this over changing the app source. The alternative — dropping `.cycling` and routing everything as walking — would silently downgrade a real product behavior (bike-appropriate routing) to work around an old CI toolchain. Pinning `macos-15` + `xcode-select` to a specific `Xcode_26.x.app` path was also possible, but those exact paths churn as images are updated, whereas the `macos-26` default will stay on Xcode 26.

`macos-15` and `macos-26` are both GA per [runner-images](https://github.com/actions/runner-images); no deprecated label is involved. The firmware job is untouched.

## Testing

**Reproduced the original failure** — the pre-fix run on `main` (29531910118), where firmware passed and iOS failed:

```
$ gh run view 29531910118
X main Build · 29531910118
JOBS
X Companion app (iOS) in 35s (ID 87733975258)
  X Build
✓ Firmware (ESP32-S3) in 2m14s (ID 87733975331)

$ gh run view 29531910118 --log-failed | grep -iE "error:|BUILD FAILED"
** BUILD FAILED **
.../Sources/RouteView.swift:230:47: error: type 'MKDirectionsTransportType' has no member 'cycling'
Command SwiftCompile failed with a nonzero exit code
```
That log also confirms the toolchain in use: `/Applications/Xcode_16.4.app/.../xcodebuild ... SDKROOT = iphonesimulator18.5`.

**Confirmed the source is fine on a current SDK** — typechecked every Swift file locally against the iOS 26 simulator SDK (Xcode 26.0, build 17A321), including the `.cycling` call site:

```
$ SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
$ swiftc -typecheck -sdk "$SDK" -target arm64-apple-ios17.0-simulator \
    -import-objc-header Sources/BikeGPS-Bridging-Header.h \
    -I Sources/H3 -I Sources/H3/include $(find Sources -name '*.swift')
=== typecheck finished ===      # no diagnostics
```
I confirmed the symbol's presence directly in the SDK header (`MKDirectionsTypes.h`, quoted above).

**Verified the fix in CI** — dispatched the workflow on this branch (run 29533414274), which is the real proof since it exercises the changed runner label:

```
$ gh run view 29533414274
✓ issue-fixer/9-fix-the-ios-build-in-the-github-action Build · 29533414274
JOBS
✓ Companion app (iOS) in 58s (ID 87738870602)
✓ Firmware (ESP32-S3) in 1m34s (ID 87738870632)

$ gh run view --job=87738870602 --log | grep -iE "Xcode 26|BUILD SUCCEEDED|error:"
Xcode 26.5
** BUILD SUCCEEDED **
```
The new `xcodebuild -version` line reporting `Xcode 26.5` confirms the runner picked up the intended toolchain, and both jobs are green — same commit that failed before, passing now.

**Edge cases and gaps:**
- The `deploymentTarget: iOS 17.0` in `project.yml` is below `.cycling`'s annotated iOS 14 availability, so no `@available` guard is needed — confirmed by the clean typecheck at `-target arm64-apple-ios17.0-simulator`.
- I did not run a full `xcodebuild` locally: my machine's simulator runtime (23A339) doesn't match its iOS 26 SDK (23A337), so `actool` fails on `Assets.xcassets` before compiling. That's a local environment quirk unrelated to this repo — asset compilation already succeeded on CI under Xcode 16.4, and now succeeds on CI under Xcode 26.5. The green CI run covers what the local build would have.
- Not addressed, out of scope: the runs emit a `Node.js 20 is deprecated` annotation for `actions/checkout@v4`, `actions/cache@v4`, `actions/setup-python@v5`, and `actions/upload-artifact@v4`. It's a warning, not a failure, and affects both jobs — worth a separate bump to the v5 action lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #9

🤖 Opened by issue-fixer.