### PR TITLE
Add GitHub Pages site with in-browser Web Serial firmware flasher

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy site
+
+# Publishes the static project site in docs/ to GitHub Pages.
+# One-time setup: repo Settings → Pages → Build and deployment →
+# Source: "GitHub Actions". After that this runs on every push to main
+# that touches docs/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Assemble the publish dir from docs/ plus the device screenshots, which
+      # live in tools/preview/out/ (regenerated on every UI change) and are
+      # copied in here rather than duplicated into docs/ — so the gallery is
+      # always current and the repo carries a single copy of each image.
+      - name: Assemble site
+        run: |
+          mkdir -p _site/img
+          cp -R docs/. _site/
+          for f in dashboard map summary menu sensors nav_banner; do
+            cp "tools/preview/out/$f.png" "_site/img/$f.png"
+          done
+          touch _site/.nojekyll
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 DIY bike GPS head unit for the [LilyGO T5S3 4.7" e-paper PRO](https://github.com/Xinyuan-LilyGO/T5S3-4.7-e-paper-PRO),
 plus a SwiftUI iOS companion app for maps, routes and settings.
 
+**[→ Project site](https://raemondbw.github.io/epaper-bike-gps/)** — feature tour
+and an in-browser Web Serial firmware flasher (Chrome/Edge, no toolchain needed).
+Source in [`docs/`](docs/).
+
 The board has everything onboard: ESP32-S3 (16 MB flash / 8 MB PSRAM, BLE 5),
 960×540 e-paper (driven in 540×960 portrait) with GT911 touch, GPS (u-blox
 MIA-M10Q or L76K/CASIC — autodetected), SD card slot, PCF8563 RTC, BQ25896
@@ -203,6 +207,10 @@ The board runs in USB-OTG mode, so esptool's auto-reset can't enter the
 bootloader: to flash, hold **BOOT**, tap **RESET**, release **BOOT** (the port
 enumerates as `…usbmodem2101`), upload, then tap **RESET** to run. Alternatively
 copy `firmware.bin` to the SD card root and reboot, or push OTA from the app.
+
+No toolchain? Flash a prebuilt `firmware.bin` (from CI artifacts or a release)
+straight from the [project site](https://raemondbw.github.io/epaper-bike-gps/#flash)
+over Web Serial in Chrome/Edge — same manual download-mode step as above.
 
 ### iOS companion
 

--- a/docs/flash.js
+++ b/docs/flash.js
@@ -1,0 +1,196 @@
+// Web Serial firmware flasher for the Open E-Paper Bike Computer.
+//
+// Uses esptool-js (the maintained successor to Adafruit_WebSerial_ESPTool).
+// Pinned to a known version whose writeFlash() expects each fileArray entry's
+// `data` as a *binary string* (it calls bstrToUi8 internally) — so files are
+// read with readAsBinaryString, not as a Uint8Array. Everything runs locally;
+// no binary ever leaves the browser.
+import { ESPLoader, Transport } from "https://cdn.jsdelivr.net/npm/esptool-js@0.5.7/bundle.js";
+
+const $ = (id) => document.getElementById(id);
+const logEl = $("log");
+const statusEl = $("status");
+const connectBtn = $("connect");
+const disconnectBtn = $("disconnect");
+const flashBtn = $("flash-btn");
+const rowsEl = $("rows");
+const barWrap = document.querySelector(".progress");
+const bar = $("bar");
+
+let transport = null;
+let esploader = null;
+let device = null;
+
+const term = {
+  clean() { logEl.textContent = ""; },
+  writeLine(data) { log(data); },
+  write(data) { logEl.textContent += data; logEl.scrollTop = logEl.scrollHeight; },
+};
+
+function log(msg) {
+  logEl.textContent += msg + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function setStatus(text, kind) {
+  statusEl.textContent = text;
+  statusEl.className = "status" + (kind ? " " + kind : "");
+}
+
+// --- browser support gate ---------------------------------------------------
+if (!("serial" in navigator)) {
+  $("unsupported").hidden = false;
+  connectBtn.disabled = true;
+  setStatus("Web Serial not available in this browser.", "err");
+}
+
+// --- file rows --------------------------------------------------------------
+function refreshRemoveButtons() {
+  const rows = rowsEl.querySelectorAll(".file-row");
+  rows.forEach((r) => {
+    r.querySelector("button.rm").hidden = rows.length <= 1;
+  });
+}
+
+$("addrow").addEventListener("click", () => {
+  const row = document.createElement("div");
+  row.className = "file-row";
+  row.innerHTML =
+    '<input type="text" value="0x0" aria-label="Flash offset" class="offset">' +
+    '<input type="file" accept=".bin" class="bin" aria-label="firmware binary">' +
+    '<button class="rm" title="Remove row">×</button>';
+  rowsEl.appendChild(row);
+  refreshRemoveButtons();
+});
+
+rowsEl.addEventListener("click", (e) => {
+  if (e.target.classList.contains("rm")) {
+    e.target.closest(".file-row").remove();
+    refreshRemoveButtons();
+  }
+});
+
+// Read a File as a binary (latin-1) string, which is what esptool-js wants.
+function readBinaryString(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsBinaryString(file);
+  });
+}
+
+// Parse a flash offset, always interpreted as hexadecimal ("0x10000" or "10000").
+function parseOffset(str) {
+  const cleaned = String(str).trim().replace(/^0x/i, "");
+  if (!/^[0-9a-f]+$/i.test(cleaned)) return NaN;
+  return parseInt(cleaned, 16);
+}
+
+// --- connect / disconnect ---------------------------------------------------
+connectBtn.addEventListener("click", async () => {
+  try {
+    device = await navigator.serial.requestPort();
+    transport = new Transport(device, true);
+    esploader = new ESPLoader({
+      transport,
+      baudrate: 115200,
+      terminal: term,
+    });
+    setStatus("Connecting… (board must be in download mode)");
+    const chip = await esploader.main();
+    setStatus(`Connected: ${chip}`, "ok");
+    connectBtn.hidden = true;
+    disconnectBtn.hidden = false;
+    flashBtn.disabled = false;
+  } catch (err) {
+    console.error(err);
+    log("Error: " + (err?.message || err));
+    setStatus("Connection failed — is the board in download mode?", "err");
+    await cleanup();
+  }
+});
+
+disconnectBtn.addEventListener("click", cleanup);
+
+async function cleanup() {
+  try { if (transport) await transport.disconnect(); } catch (_) {}
+  transport = null;
+  esploader = null;
+  device = null;
+  connectBtn.hidden = false;
+  disconnectBtn.hidden = true;
+  flashBtn.disabled = true;
+  barWrap.hidden = true;
+  bar.style.width = "0";
+  if (statusEl.className.indexOf("err") === -1) setStatus("Not connected.");
+}
+
+// --- flash ------------------------------------------------------------------
+flashBtn.addEventListener("click", async () => {
+  if (!esploader) return;
+
+  // Gather and validate rows.
+  const rows = [...rowsEl.querySelectorAll(".file-row")];
+  const fileArray = [];
+  for (const row of rows) {
+    const fileInput = row.querySelector("input.bin");
+    const file = fileInput.files[0];
+    if (!file) continue; // skip empty rows
+    const address = parseOffset(row.querySelector("input.offset").value);
+    if (Number.isNaN(address)) {
+      setStatus("Bad offset — use hex like 0x10000.", "err");
+      return;
+    }
+    const data = await readBinaryString(file);
+    fileArray.push({ data, address, name: file.name });
+  }
+
+  if (fileArray.length === 0) {
+    setStatus("Choose at least one .bin file to flash.", "err");
+    return;
+  }
+
+  flashBtn.disabled = true;
+  connectBtn.disabled = true;
+  barWrap.hidden = false;
+  bar.style.width = "0";
+  const numFiles = fileArray.length;
+
+  try {
+    for (const f of fileArray) {
+      log(`Flashing ${f.name} → 0x${f.address.toString(16)} (${f.data.length} bytes)`);
+    }
+    setStatus("Flashing… do not unplug.", "");
+
+    await esploader.writeFlash({
+      fileArray,
+      flashSize: "keep",
+      flashMode: "keep",
+      flashFreq: "keep",
+      eraseAll: $("erase").checked,
+      compress: true,
+      // esptool-js reports written/size in compressed bytes per file, so track
+      // the per-file fraction across the file count rather than summing bytes.
+      reportProgress: (fileIndex, written, size) => {
+        const frac = size > 0 ? written / size : 0;
+        const pct = Math.min(100, Math.round(((fileIndex + frac) / numFiles) * 100));
+        bar.style.width = pct + "%";
+      },
+    });
+
+    bar.style.width = "100%";
+    setStatus("Done! Tap RESET on the board to run the new firmware.", "ok");
+    log("\n✔ Flash complete. Tap RESET to boot.");
+    try { await esploader.after(); } catch (_) { /* OTG can't auto-reset; that's fine */ }
+  } catch (err) {
+    console.error(err);
+    log("Error: " + (err?.message || err));
+    setStatus("Flash failed — see the log above.", "err");
+  } finally {
+    flashBtn.disabled = false;
+    connectBtn.disabled = false;
+  }
+});
+
+refreshRemoveButtons();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Open E-Paper Bike Computer</title>
+<meta name="description" content="DIY bike GPS head unit for the LilyGO T5S3 4.7&quot; e-paper PRO — offline maps, GPX routes, FIT recording, BLE sensors. Flash the firmware straight from your browser over USB.">
+<meta property="og:title" content="Open E-Paper Bike Computer">
+<meta property="og:description" content="A hackable e-paper bike GPS. Offline maps, routes, FIT recording — flash it from the browser.">
+<meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%9A%B2%3C/text%3E%3C/svg%3E">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap">
+    <span class="brand">🚲 E-Paper Bike Computer</span>
+    <nav>
+      <a href="#features">Features</a>
+      <a href="#screens">Screens</a>
+      <a href="#split">Phone&nbsp;/&nbsp;device</a>
+      <a href="#flash">Flash firmware</a>
+      <a href="https://github.com/RaemondBW/epaper-bike-gps">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <section class="hero" style="border-bottom:none;">
+    <h1>An open e-paper bike computer you can hack.</h1>
+    <p class="lede">A sunlight-readable GPS head unit for the LilyGO&nbsp;T5S3 4.7&quot; e-paper PRO — offline maps, GPX routes, FIT ride recording and BLE sensors, all onboard. Flash the latest firmware straight from this page over USB.</p>
+    <div class="cta-row">
+      <a class="btn accent" href="#flash">⚡ Flash firmware</a>
+      <a class="btn secondary" href="#features">See what it does</a>
+      <a class="btn secondary" href="https://github.com/RaemondBW/epaper-bike-gps">View source</a>
+    </div>
+    <p class="badge-row" style="color:var(--ink-soft);font-size:.9rem;">
+      LilyGO T5S3 4.7&quot; e-paper PRO · ESP32-S3 · open source ·
+      <a href="https://github.com/RaemondBW/epaper-bike-gps/actions/workflows/build.yml">CI builds</a>
+    </p>
+  </section>
+
+  <section id="features">
+    <h2>Features</h2>
+    <p class="sub">Everything a ride needs, on a screen you can actually read in direct sun — and none of it depends on a phone once it&rsquo;s set up.</p>
+    <div class="features">
+      <div class="feature">
+        <h3><span class="ic">🛰️</span>GPS &amp; speed</h3>
+        <p>Position, speed, heading, altitude, satellites and UTC time. L76K/CASIC and u-blox M10Q auto-detected, warm-started from the last-known fix.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">🗺️</span>Offline maps</h3>
+        <p>1-bit H3 hexagonal vector tiles on the SD card. Zoom 1–8&nbsp;m/px, follows GPS, optional track-up rotation. No data connection on the bike.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">🧭</span>GPX routes</h3>
+        <p>Plan on the phone or drop a <code>.gpx</code> in <code>/routes</code>. The route draws on the map — ridden solid, ahead dashed — with km-remaining and turn banners.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">⏺️</span>Ride recording</h3>
+        <p>1&nbsp;Hz FIT files ready for Strava or intervals.icu. Moving time, avg/normalized power, HR and climbing. Rides cut short by a crash are repaired on next boot.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">❤️</span>BLE sensors</h3>
+        <p>Heart rate, cycling power (with cadence from crank data) and speed/cadence. Pair once from the Sensors screen; pairings persist in flash.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">⛰️</span>Map-cached elevation</h3>
+        <p>Altitude and climb read from a DEM grid baked into each map tile — not the GPS chip&rsquo;s noisy barometric altitude.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">⚙️</span>On-device settings</h3>
+        <p>Units, 12/24&nbsp;h clock, FTP power zones, timezone, frontlight and USB-drive mode — persisted in NVS and mirrored to the companion app.</p>
+      </div>
+      <div class="feature">
+        <h3><span class="ic">⬆️</span>Easy updates</h3>
+        <p>Flash from this page over USB, drop <code>firmware.bin</code> on the SD card, or push OTA from the app. A/B partitions protect the running image either way.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="screens">
+    <h2>On the panel</h2>
+    <p class="sub">Rendered pixel-for-pixel by the real drawing code (<code>src/ui_render.cpp</code>) — these are the actual device screens.</p>
+    <div class="gallery">
+      <figure class="shot device">
+        <img loading="lazy" src="img/dashboard.png" alt="Dashboard screen">
+        <figcaption>Dashboard</figcaption>
+      </figure>
+      <figure class="shot device">
+        <img loading="lazy" src="img/map.png" alt="Map following GPS">
+        <figcaption>Map (follows GPS)</figcaption>
+      </figure>
+      <figure class="shot device">
+        <img loading="lazy" src="img/summary.png" alt="Ride summary screen">
+        <figcaption>Ride summary</figcaption>
+      </figure>
+      <figure class="shot device">
+        <img loading="lazy" src="img/menu.png" alt="Menu screen">
+        <figcaption>Menu</figcaption>
+      </figure>
+      <figure class="shot device">
+        <img loading="lazy" src="img/sensors.png" alt="Sensors screen">
+        <figcaption>Sensors</figcaption>
+      </figure>
+      <figure class="shot device">
+        <img loading="lazy" src="img/nav_banner.png" alt="Navigation turn banner">
+        <figcaption>Turn banner</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section id="split">
+    <h2>Phone / device split</h2>
+    <p class="sub">The head unit is fully standalone. The iOS companion app is the authoring surface — anything awkward on a touch e-paper screen happens on the phone and is pushed over BLE.</p>
+    <table class="split">
+      <thead>
+        <tr><th></th><th>Device (ESP32-S3 firmware)</th><th>iOS companion app</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Owns</td><td>GPS, sensors, ride recording, rendering, navigation</td><td>Map-tile authoring, route planning, ride history, settings UI, OTA</td></tr>
+        <tr><td>Storage</td><td>SD card (<code>/rides</code>, <code>/routes</code>, <code>/maps</code>, <code>/logs</code>)</td><td>Transient — streamed to/from the device</td></tr>
+        <tr><td>Maps</td><td>Renders H3 tiles from the SD card</td><td>Fetches OSM + elevation, builds tiles, streams them</td></tr>
+        <tr><td>Firmware</td><td>Applies updates from USB, SD or BLE</td><td>Bundles <code>firmware.bin</code>, pushes OTA over BLE</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="flash">
+    <h2>⚡ Flash firmware from your browser</h2>
+    <p class="sub">Powered by <a href="https://github.com/espressif/esptool-js">esptool-js</a> and the Web Serial API — the same approach as the <a href="https://github.com/adafruit/Adafruit_WebSerial_ESPTool">Adafruit WebSerial ESPTool</a>. Everything runs locally in your browser; nothing is uploaded anywhere.</p>
+
+    <div id="unsupported" class="notice warn" hidden>
+      <strong>Your browser can&rsquo;t do this.</strong> Web Serial needs a Chromium-based desktop browser —
+      use <strong>Chrome</strong>, <strong>Edge</strong> or <strong>Opera</strong> on desktop (not Safari, Firefox or mobile).
+    </div>
+
+    <div class="flash-grid">
+      <div class="card">
+        <strong>1 &nbsp;Get a firmware binary</strong>
+        <p style="color:var(--ink-soft);font-size:.95rem;margin:.5rem 0 0;">
+          Grab <code>firmware.bin</code> from a
+          <a href="https://github.com/RaemondBW/epaper-bike-gps/actions/workflows/build.yml">CI build</a>
+          (the <em>firmware</em> artifact) or a
+          <a href="https://github.com/RaemondBW/epaper-bike-gps/releases">release</a>,
+          or build it yourself with <code>pio run</code>.
+        </p>
+        <strong style="display:block;margin-top:1rem;">2 &nbsp;Put the board in download mode</strong>
+        <p style="color:var(--ink-soft);font-size:.95rem;margin:.5rem 0 0;">
+          The board runs in USB-OTG mode, so it can&rsquo;t auto-reset into the bootloader.
+          Do it by hand: hold <span class="kbd">BOOT</span>, tap <span class="kbd">RESET</span>,
+          then release <span class="kbd">BOOT</span>. Then click <em>Connect</em> below and pick the
+          <code>usbmodem</code> / <code>USB Serial</code> port.
+        </p>
+        <strong style="display:block;margin-top:1rem;">3 &nbsp;Flash, then tap RESET to run</strong>
+        <p style="color:var(--ink-soft);font-size:.95rem;margin:.5rem 0 0;">
+          By default this writes just the app at <code>0x10000</code> — enough to update an already-set-up
+          board. For a blank board or recovery, add the bootloader / partition rows under
+          <em>Advanced</em>.
+        </p>
+      </div>
+
+      <div class="card">
+        <div class="flash-controls" style="margin-top:0;">
+          <button id="connect" class="btn accent">Connect</button>
+          <button id="disconnect" class="btn secondary" hidden>Disconnect</button>
+          <span id="status" class="status">Not connected.</span>
+        </div>
+
+        <div class="file-rows" id="rows">
+          <div class="file-row">
+            <input type="text" value="0x10000" aria-label="Flash offset" class="offset">
+            <input type="file" accept=".bin" class="bin" aria-label="firmware.bin">
+            <button class="rm" title="Remove row" hidden>×</button>
+          </div>
+        </div>
+
+        <details class="adv">
+          <summary>Advanced — full / blank-board flash</summary>
+          <p style="font-size:.9rem;color:var(--ink-soft);">
+            A full ESP32-S3 flash needs four parts. Add rows and supply each binary
+            (from your PlatformIO <code>.pio/build/t5s3-pro/</code> folder):
+          </p>
+          <table class="split" style="font-size:.86rem;">
+            <tr><td><code>0x0</code></td><td>bootloader.bin</td></tr>
+            <tr><td><code>0x8000</code></td><td>partitions.bin</td></tr>
+            <tr><td><code>0xe000</code></td><td>boot_app0.bin</td></tr>
+            <tr><td><code>0x10000</code></td><td>firmware.bin</td></tr>
+          </table>
+          <button id="addrow" class="btn secondary" style="padding:7px 14px;font-size:.9rem;">+ Add row</button>
+        </details>
+
+        <div class="flash-controls">
+          <button id="flash-btn" class="btn" disabled>Flash</button>
+          <label style="font-size:.9rem;color:var(--ink-soft);">
+            <input type="checkbox" id="erase"> Erase whole flash first
+          </label>
+        </div>
+
+        <div class="progress" hidden><i id="bar"></i></div>
+        <div class="console" id="log" aria-live="polite"></div>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<footer>
+  <div class="wrap">
+    <span>Open E-Paper Bike Computer — <a href="https://github.com/RaemondBW/epaper-bike-gps/blob/main/LICENSE">open source</a>.</span>
+    <span>
+      <a href="https://github.com/RaemondBW/epaper-bike-gps">Source</a> ·
+      <a href="https://github.com/RaemondBW/epaper-bike-gps/blob/main/README.md">Docs</a> ·
+      <a href="https://github.com/RaemondBW/epaper-bike-gps/issues">Issues</a>
+    </span>
+  </div>
+</footer>
+
+<script type="module" src="flash.js"></script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,169 @@
+/* Open E-Paper Bike Computer — project site
+   E-ink inspired: high-contrast, paper-white, one warm accent. */
+
+:root {
+  --ink: #141414;
+  --ink-soft: #4a4a4a;
+  --paper: #f7f6f2;
+  --panel: #ffffff;
+  --line: #d8d4c8;
+  --accent: #c65a1e;      /* warm bike-frame orange */
+  --accent-dark: #9c440f;
+  --good: #2e7d32;
+  --bad: #c62828;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+/* [hidden] must beat author display rules (e.g. .btn sets display:inline-block,
+   which would otherwise override the UA hidden style). */
+[hidden] { display: none !important; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent-dark); }
+a:hover { color: var(--accent); }
+
+.wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
+
+/* --- top nav --- */
+header.nav {
+  position: sticky; top: 0; z-index: 20;
+  background: rgba(247, 246, 242, 0.92);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--line);
+}
+header.nav .wrap {
+  display: flex; align-items: center; gap: 20px;
+  min-height: 56px; flex-wrap: wrap;
+}
+header.nav .brand { font-weight: 700; letter-spacing: -0.01em; }
+header.nav nav { display: flex; gap: 18px; margin-left: auto; flex-wrap: wrap; }
+header.nav nav a { text-decoration: none; color: var(--ink-soft); font-size: 0.95rem; }
+header.nav nav a:hover { color: var(--ink); }
+
+/* --- hero --- */
+.hero { padding: 64px 0 40px; border-bottom: 1px solid var(--line); }
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.08; letter-spacing: -0.02em; margin: 0 0 14px;
+}
+.hero p.lede { font-size: 1.2rem; color: var(--ink-soft); max-width: 44ch; margin: 0 0 26px; }
+.cta-row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+.btn {
+  display: inline-block; font: inherit; font-weight: 600; cursor: pointer;
+  padding: 11px 20px; border-radius: 8px; border: 1px solid var(--ink);
+  background: var(--ink); color: #fff; text-decoration: none;
+  transition: transform .05s ease, background .15s ease;
+}
+.btn:hover { background: #000; color: #fff; }
+.btn:active { transform: translateY(1px); }
+.btn.secondary { background: transparent; color: var(--ink); }
+.btn.secondary:hover { background: #eceae2; color: var(--ink); }
+.btn.accent { background: var(--accent); border-color: var(--accent); }
+.btn.accent:hover { background: var(--accent-dark); border-color: var(--accent-dark); }
+.btn:disabled { opacity: .5; cursor: not-allowed; }
+
+.badge-row { margin-top: 20px; }
+.badge-row img { height: 20px; vertical-align: middle; }
+
+/* --- sections --- */
+section { padding: 52px 0; border-bottom: 1px solid var(--line); }
+section h2 { font-size: 1.6rem; letter-spacing: -0.01em; margin: 0 0 6px; }
+section .sub { color: var(--ink-soft); margin: 0 0 28px; max-width: 60ch; }
+
+/* --- feature grid --- */
+.features { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; }
+.feature {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 18px 18px 20px;
+}
+.feature h3 { margin: 0 0 6px; font-size: 1.05rem; }
+.feature h3 .ic { margin-right: 8px; }
+.feature p { margin: 0; color: var(--ink-soft); font-size: 0.96rem; }
+
+/* --- screens gallery --- */
+.gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; }
+.shot { text-align: center; }
+.shot img {
+  width: 100%; height: auto; border: 1px solid var(--line); border-radius: 8px;
+  background: #fff; display: block;
+}
+.shot figcaption { margin-top: 8px; font-size: 0.85rem; color: var(--ink-soft); }
+.shot.device img { max-height: 360px; object-fit: contain; }
+
+/* --- flasher --- */
+.flash-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; }
+@media (max-width: 720px) { .flash-grid { grid-template-columns: 1fr; } }
+
+.card {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 20px;
+}
+.card ol { margin: 0; padding-left: 20px; }
+.card ol li { margin-bottom: 10px; }
+.kbd {
+  font: 600 0.82em var(--mono); background: #eceae2; border: 1px solid var(--line);
+  border-radius: 5px; padding: 1px 6px; white-space: nowrap;
+}
+
+.file-rows { display: flex; flex-direction: column; gap: 8px; margin: 14px 0; }
+.file-row { display: flex; gap: 8px; align-items: center; }
+.file-row input[type="text"] {
+  width: 96px; font: inherit; font-family: var(--mono); padding: 7px 8px;
+  border: 1px solid var(--line); border-radius: 6px; background: #fff;
+}
+.file-row input[type="file"] { flex: 1; min-width: 0; font-size: 0.9rem; }
+.file-row button.rm {
+  border: 1px solid var(--line); background: #fff; border-radius: 6px; cursor: pointer;
+  width: 30px; height: 30px; line-height: 1; color: var(--ink-soft);
+}
+.file-row button.rm:hover { color: var(--bad); border-color: var(--bad); }
+
+.flash-controls { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-top: 6px; }
+.status { font-size: 0.9rem; color: var(--ink-soft); }
+.status.ok { color: var(--good); }
+.status.err { color: var(--bad); }
+
+.console {
+  margin-top: 16px; background: #16150f; color: #e9e4d4; border-radius: 8px;
+  font: 0.82rem/1.5 var(--mono); padding: 14px; height: 220px; overflow: auto;
+  white-space: pre-wrap; word-break: break-word;
+}
+.progress {
+  height: 8px; background: #eceae2; border-radius: 5px; overflow: hidden; margin-top: 12px;
+  border: 1px solid var(--line);
+}
+.progress > i { display: block; height: 100%; width: 0; background: var(--accent); transition: width .1s linear; }
+
+.notice {
+  border-left: 3px solid var(--accent); background: #fbf3ec; padding: 12px 16px;
+  border-radius: 0 8px 8px 0; margin: 0 0 22px; font-size: 0.95rem;
+}
+.notice.warn { border-color: var(--bad); background: #fdefef; }
+
+details.adv { margin-top: 12px; }
+details.adv summary { cursor: pointer; color: var(--ink-soft); font-size: 0.92rem; }
+
+/* --- split table --- */
+.split { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
+.split th, .split td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+.split th { background: #eceae2; }
+.split td:first-child { font-weight: 600; white-space: nowrap; }
+
+/* --- footer --- */
+footer { padding: 40px 0 60px; color: var(--ink-soft); font-size: 0.9rem; }
+footer a { color: var(--ink-soft); }
+footer .wrap { display: flex; gap: 18px; flex-wrap: wrap; justify-content: space-between; }
+
+code { font-family: var(--mono); background: #eceae2; padding: 1px 5px; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
Closes #11.

Adds a static project site under `docs/` that showcases the device's features and flashes firmware straight from the browser over the Web Serial API — the same approach as the [Adafruit WebSerial ESPTool](https://github.com/adafruit/Adafruit_WebSerial_ESPTool) referenced in the issue, built on its maintained successor [esptool-js](https://github.com/espressif/esptool-js).

## What's included

- **`docs/index.html`** — single-page site: hero, an 8-card feature grid, a device-screen gallery, the phone/device split table, and the flasher. Content is drawn from the README so it stays accurate. E-ink-inspired styling in **`docs/style.css`**.
- **`docs/flash.js`** — Web Serial flasher (ES module, pinned to `esptool-js@0.5.7` from jsDelivr):
  - Feature-gates on `navigator.serial` and shows a clear "use Chrome/Edge on desktop" notice where unsupported.
  - Connect → `Transport` + `ESPLoader.main()`; per-row *offset + .bin* file pickers (Adafruit-style), add/remove rows, a live progress bar and a log console.
  - Defaults to writing just the app at `0x10000` (updates an already-set-up board); an **Advanced** section documents the full blank-board set (`0x0` bootloader, `0x8000` partitions, `0xe000` boot_app0, `0x10000` app).
  - Files are read with `readAsBinaryString` because this esptool-js version's `writeFlash` consumes each `data` field as a binary string (verified against the bundle source — it calls `bstrToUi8`). Flash params are passed as `"keep"`, which esptool-js only applies to the bootloader at `0x0`, so app-only flashing is safe.
  - Documents the board's manual download-mode step (hold **BOOT**, tap **RESET**, release **BOOT**) since USB-OTG mode blocks esptool's auto-reset — the same caveat already in the README's flashing section.
- **`.github/workflows/pages.yml`** — deploys the site to GitHub Pages on pushes to `main` that touch `docs/`. It assembles the publish dir from `docs/` plus the device screenshots copied from `tools/preview/out/` at deploy time, so the gallery is always current and no image binaries are duplicated into `docs/` (keeping this diff free of committed images).
- **`README.md`** — links to the project site from the intro and the flashing section.

## Decisions / notes for the maintainer

- **One-time setup:** enable Pages via **Settings → Pages → Source: "GitHub Actions"** for the deploy workflow to publish. (The repo is currently private; Pages publishing from a private repo needs a paid plan, and while private the in-page links to `github.com`/CI won't resolve for anonymous visitors — they will once the repo/Pages is public.)
- **Firmware source:** the flasher takes a `firmware.bin` the user supplies (CI artifact, a release, or a local `pio run` build) rather than hosting binaries in the repo. Full bootloader/partition binaries aren't produced by the current CI (`build.yml` only uploads `firmware.bin`), so a hosted one-click manifest wasn't possible without also publishing those parts. The per-row picker mirrors the Adafruit tool and covers both app-update and blank-board recovery. If you later publish full release assets, this could gain a one-click "flash latest" button.

## Testing

Verified the site and flasher end-to-end in a real browser via the Chrome DevTools Protocol (headless Google Chrome driving the page), plus JS syntax checks. I do **not** have the LilyGO T5S3 hardware, so the actual USB flash of a device was not exercised — see "Not verified" below.

**Static checks + module import**

```
$ node --check flash.js   # (as .mjs)
flash.js: SYNTAX OK (ES module parse)

# esptool-js 0.5.7 bundle reachable and exports what we import
$ curl -s -o /dev/null -w "HTTP %{http_code}, %{size_download} bytes\n" \
    https://cdn.jsdelivr.net/npm/esptool-js@0.5.7/bundle.js
HTTP 200, 179662 bytes
export{... Pe as ESPLoader, ... de as Transport, ...}

# methods the flasher calls all exist in 0.5.7:
ESPLoader.after: 1   Transport.disconnect: 1   writeFlash: 1   main: 1
```

Confirmed against the bundle source that `writeFlash` treats `fileArray[].data` as a binary string (`e=this.ui8ToBstr(ue(this.bstrToUi8(e),4))`), and that `_updateImageFlashParams` only rewrites flash params for the bootloader at offset `0x0` — so `"keep"` + app-only flashing is correct.

**Live page checks** (headless Chrome loading a locally-served copy assembled the same way the workflow does):

```
=== DOM / behavior checks ===
  flash-btn present: true
  connect btn present: true
  navigator.serial defined: true
  unsupported.hidden: true
  connect.disabled: false
  status text: "Not connected."
  row count initial: 1
  default offset value: "0x10000"
  feature cards count: 8
  screen images count: 6
  addrow works: 2
  esptool import ok: "function/function"     # ESPLoader + Transport both imported from the CDN
=== console messages (errors/warnings) === (none)
=== uncaught exceptions === (none)
=== gallery images loaded (naturalWidth>0) === 4/6   # other 2 are below-the-fold lazy images
```

**Bug found and fixed during testing.** A first screenshot showed the **Disconnect** button visible at rest even though it has the `hidden` attribute — `.btn { display: inline-block }` was overriding the UA `[hidden]` style. Added `[hidden] { display: none !important; }`. Re-verified:

```
disconnect hidden initially: none        # computed display
progress hidden initially:  none
flash-btn disabled initially: true
# after simulating a successful connect (the toggle the connect handler performs):
connect display: none    disconnect display: block    flash-btn disabled: false
```

Clicking **Flash** with no loader connected is a no-op (guarded by `if (!esploader) return`) and threw nothing. I also eyeballed full-page and flasher screenshots: feature grid, device-screen gallery (renders the real preview PNGs), split table, and the flasher (Connect + rows + Advanced + Flash + console) all lay out correctly on desktop width.

**Not verified (no hardware).** I could not plug in a LilyGO T5S3 and flash a real device, so the serial handshake, bootloader sync in manual download mode, and a full write/verify were not run. Before relying on it, a human with the board should: build `firmware.bin` (`pio run`), open the Pages site (or serve `docs/` locally after copying `tools/preview/out/*.png` into `docs/img/`) in Chrome/Edge, put the board in download mode (hold BOOT, tap RESET, release BOOT), click **Connect**, pick the `usbmodem` port, **Flash** the app at `0x10000`, then tap RESET and confirm the new firmware boots. The deploy workflow itself also needs Pages set to the "GitHub Actions" source once.


Closes #11

🤖 Opened by issue-fixer.