### PR TITLE
Fix app/device ascent mismatch: stop writing noisy GPS altitude into .fit records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tools/preview/preview
 # FIT test-harness binary and the .fit files it emits (rebuild via
 # tools/fit_test/run_fit_test.sh)
 tools/fit_test/fit_test
+tools/fit_test/ascent_test
 tools/fit_test/out/
 
 # Xcode archive / build output

--- a/src/fit_writer.cpp
+++ b/src/fit_writer.cpp
@@ -212,7 +212,12 @@ void FitWriter::writeRecord(const Record& r) {
     put32(&buf[1], fitTime(r.utc));
     put32(&buf[5], (uint32_t)(int32_t)llround(r.latitudeDeg * SEMICIRCLES_PER_DEG));
     put32(&buf[9], (uint32_t)(int32_t)llround(r.longitudeDeg * SEMICIRCLES_PER_DEG));
-    put16(&buf[13], (uint16_t)lround((r.altitudeM + 500.0f) * 5.0f));
+    // 0xFFFF is the FIT invalid marker: emit it rather than encoding a bogus
+    // altitude, so a point with no elevation is skipped by readers instead of
+    // being taken as a real value (which would corrupt ascent totals).
+    put16(&buf[13], isnan(r.altitudeM)
+                        ? 0xFFFF
+                        : (uint16_t)lround((r.altitudeM + 500.0f) * 5.0f));
     put32(&buf[15], (uint32_t)llround(r.distanceM * 100.0));
     put16(&buf[19], (uint16_t)lround(r.speedMs * 1000.0f));
     put16(&buf[21], r.powerW);

--- a/src/fit_writer.h
+++ b/src/fit_writer.h
@@ -11,12 +11,13 @@
 
 class FitWriter {
 public:
-    // One data point, 1 Hz. Use the INVALID_* constants for missing values.
+    // One data point, 1 Hz. Use the INVALID_* constants for missing values;
+    // altitudeM is left out of the record (field marked invalid) when NAN.
     struct Record {
         time_t   utc;
         double   latitudeDeg;
         double   longitudeDeg;
-        float    altitudeM;
+        float    altitudeM;   // NAN => no elevation for this point
         float    speedMs;
         double   distanceM;
         uint16_t powerW;      // INVALID_U16 if absent

--- a/src/ride_recorder.cpp
+++ b/src/ride_recorder.cpp
@@ -428,7 +428,12 @@ void task(void*) {
             r.latitudeDeg = s.latitude;
             r.longitudeDeg = s.longitude;
             // Record the map DEM elevation so the ride profile is accurate.
-            r.altitudeM = s.mapElevationValid ? s.mapElevationM : s.altitudeM;
+            // The raw GPS altitude is deliberately NOT used as a fallback: it's
+            // far too noisy (the summary's ascent ignores it for the same
+            // reason), and mixing it into the record stream with DEM values
+            // makes phone-side ascent totals disagree with the device. Mark the
+            // point's altitude invalid instead when the DEM has no value.
+            r.altitudeM = s.mapElevationValid ? s.mapElevationM : NAN;
             r.speedMs = s.speedKmh / 3.6f;
             r.distanceM = distanceM;
             r.powerW = s.powerW;

--- a/tools/fit_test/ascent_test.cpp
+++ b/tools/fit_test/ascent_test.cpp
@@ -1,0 +1,192 @@
+// Reproduces issue #12: the phone app's ascent must match the device's
+// end-ride summary. The device integrates ascent from the map DEM elevation
+// only (3 m hysteresis) and deliberately ignores the noisy GPS altitude. The
+// FIT record stream must therefore carry the same DEM elevation — and mark the
+// altitude invalid when the DEM has no value — never the raw GPS altitude.
+//
+// This harness builds a ride where the DEM drops out for a stretch (a tunnel /
+// tile gap) during which the GPS altitude sits ~45 m off the DEM. It compares:
+//   * device ascent   — map DEM only, 3 m hysteresis (ride_recorder.cpp)
+//   * app ascent (new) — FIT altitude = DEM, invalid where DEM missing
+//   * app ascent (old) — FIT altitude = DEM, GPS altitude where DEM missing
+// against a FIT decode that mirrors companion-ios/Sources/FITDecoder.swift.
+//
+// Build/run: tools/fit_test/run_ascent_test.sh
+
+#include "fit_writer.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* OUT_DIR = "tools/fit_test/out";
+fs::FS host(OUT_DIR);
+
+constexpr time_t RIDE_START = 1784223545;
+
+int failures = 0;
+void check(bool ok, const char* what) {
+    if (!ok) { printf("  FAIL: %s\n", what); failures++; }
+    else     { printf("  ok:   %s\n", what); }
+}
+
+std::string fullPath(const char* p) { return std::string(OUT_DIR) + p; }
+
+std::vector<uint8_t> readAll(const char* path) {
+    FILE* f = fopen(fullPath(path).c_str(), "rb");
+    if (!f) return {};
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    std::vector<uint8_t> buf((size_t)n);
+    if (n > 0 && fread(buf.data(), 1, (size_t)n, f) != (size_t)n) buf.clear();
+    fclose(f);
+    return buf;
+}
+
+// The device's ascent accumulation, verbatim from ride_recorder.cpp.
+double deviceAscent(const std::vector<float>& demElev,
+                    const std::vector<bool>& demValid) {
+    double climbedM = 0;
+    float base = 0;
+    bool baseValid = false;
+    for (size_t i = 0; i < demElev.size(); ++i) {
+        if (!demValid[i]) continue;
+        float elev = demElev[i];
+        if (!baseValid) { base = elev; baseValid = true; }
+        else if (elev > base + 3.0f) { climbedM += elev - base; base = elev; }
+        else if (elev < base - 3.0f) { base = elev; }
+    }
+    return climbedM;
+}
+
+// The app's ascent, mirroring FITDecoder.swift: decode the record stream, skip
+// altitudes encoded as 0xFFFF, integrate with the same 3 m hysteresis.
+double appAscentFromFit(const char* path) {
+    std::vector<uint8_t> b = readAll(path);
+    if (b.size() < 14) { printf("  (no file %s)\n", path); return -1; }
+    int headerSize = b[0];
+    int dataSize = b[4] | (b[5] << 8) | (b[6] << 16) | (b[7] << 24);
+    int end = headerSize + dataSize;
+    if (dataSize == 0 || end > (int)b.size() || end < headerSize) end = (int)b.size();
+
+    struct FieldDef { int num, size; };
+    struct MsgDef { int global; std::vector<FieldDef> fields; };
+    MsgDef defs[16];
+    bool defSet[16] = {false};
+
+    double ascent = 0;
+    bool haveBase = false;
+    double base = 0;
+    int i = headerSize;
+    while (i < end) {
+        uint8_t rec = b[i++];
+        if (rec & 0x40) {
+            int local = rec & 0x0F;
+            if (i + 5 > end) break;
+            int global = b[i + 2] | (b[i + 3] << 8);
+            int count = b[i + 4];
+            i += 5;
+            MsgDef d; d.global = global;
+            for (int c = 0; c < count; ++c) {
+                if (i + 3 > end) break;
+                d.fields.push_back({b[i], b[i + 1]});
+                i += 3;
+            }
+            defs[local] = d; defSet[local] = true;
+        } else {
+            int local = rec & 0x0F;
+            if (!defSet[local]) break;
+            const MsgDef& d = defs[local];
+            int off = i;
+            bool haveAlt = false; double alt = 0;
+            for (const auto& f : d.fields) {
+                if (off + f.size > end) break;
+                if (d.global == 20 && f.num == 2) {
+                    uint16_t v = b[off] | (b[off + 1] << 8);
+                    if (v != 0xFFFF) { alt = (double)v / 5.0 - 500.0; haveAlt = true; }
+                }
+                off += f.size;
+            }
+            i = off;
+            if (d.global == 20 && haveAlt) {
+                if (haveBase) {
+                    if (alt > base + 3) { ascent += alt - base; base = alt; }
+                    else if (alt < base - 3) { base = alt; }
+                } else { base = alt; haveBase = true; }
+            }
+        }
+    }
+    return ascent;
+}
+
+// Writes a ride to `path`. demValid[i]==false points get `invalidAlt` as the
+// record altitude: NAN models the new firmware, a GPS altitude models the old.
+void writeRide(const char* path, const std::vector<float>& demElev,
+               const std::vector<bool>& demValid,
+               const std::vector<float>& gpsAlt, bool useNanWhenInvalid) {
+    FitWriter w;
+    if (!w.begin(host, path, RIDE_START)) { printf("FAIL open %s\n", path); exit(1); }
+    double dist = 0;
+    for (size_t i = 0; i < demElev.size(); ++i) {
+        dist += 5.5;
+        FitWriter::Record r;
+        r.utc = RIDE_START + (time_t)i;
+        r.latitudeDeg = 37.7527 - i * 0.00005;
+        r.longitudeDeg = -122.4365 + i * 0.00001;
+        if (demValid[i])           r.altitudeM = demElev[i];
+        else if (useNanWhenInvalid) r.altitudeM = NAN;
+        else                        r.altitudeM = gpsAlt[i];
+        r.speedMs = 5.5f;
+        r.distanceM = dist;
+        r.powerW = FitWriter::INVALID_U16;
+        r.heartRate = FitWriter::INVALID_U8;
+        r.cadence = FitWriter::INVALID_U8;
+        w.writeRecord(r);
+    }
+    w.finish(RIDE_START + (time_t)demElev.size(), dist, (uint32_t)demElev.size());
+}
+
+}  // namespace
+
+int main() {
+    // A steady climb DEM: 100 m rising ~0.7 m/sample to ~170 m over 100 pts.
+    // The DEM drops out for samples [30,50): a tile gap. During the gap the GPS
+    // altitude sits ~45 m below the DEM (typical ellipsoid/geoid + noise), so
+    // the old fallback injects a -45 m dip and a +45 m spike into the profile.
+    const int N = 100;
+    std::vector<float> dem(N), gps(N);
+    std::vector<bool> valid(N, true);
+    for (int i = 0; i < N; ++i) {
+        dem[i] = 100.0f + 0.7f * i;
+        gps[i] = dem[i] - 45.0f + (i % 5);   // offset + jitter
+        if (i >= 30 && i < 50) valid[i] = false;
+    }
+
+    double devAscent = deviceAscent(dem, valid);
+
+    writeRide("/ascent_new.fit", dem, valid, gps, /*useNanWhenInvalid=*/true);
+    writeRide("/ascent_old.fit", dem, valid, gps, /*useNanWhenInvalid=*/false);
+
+    double appNew = appAscentFromFit("/ascent_new.fit");
+    double appOld = appAscentFromFit("/ascent_old.fit");
+
+    printf("device summary ascent (map DEM only):      %6.1f m\n", devAscent);
+    printf("app ascent, OLD firmware (GPS fallback):   %6.1f m\n", appOld);
+    printf("app ascent, NEW firmware (invalid marker): %6.1f m\n\n", appNew);
+
+    // The bug: the old GPS fallback makes the app disagree with the device.
+    check(fabs(appOld - devAscent) > 20.0,
+          "OLD firmware: app ascent diverges from device (reproduces the bug)");
+    // The fix: invalid marker => app matches the device within the FIT
+    // altitude quantization (0.2 m/LSB), not the ~50 m the old fallback caused.
+    check(fabs(appNew - devAscent) < 1.0,
+          "NEW firmware: app ascent matches device end-ride summary");
+
+    printf("\n%s\n", failures ? "ASCENT TEST FAILED" : "ascent test passed");
+    return failures ? 1 : 0;
+}

--- a/tools/fit_test/run_fit_test.sh
+++ b/tools/fit_test/run_fit_test.sh
@@ -13,6 +13,16 @@ clang++ -std=c++17 -O2 -Wall \
 
 ./tools/fit_test/fit_test
 
+# Issue #12: the phone app's ascent must match the device end-ride summary,
+# which means the record altitude carries the map DEM (invalid marker when
+# absent), never the noisy GPS altitude.
+echo
+clang++ -std=c++17 -O2 -Wall \
+    -I tools/fit_test/shim -I src \
+    tools/fit_test/ascent_test.cpp src/fit_writer.cpp \
+    -o tools/fit_test/ascent_test
+./tools/fit_test/ascent_test
+
 # empty.fit is deliberately unrecoverable (the device deletes it rather than
 # keeping a ride with no points), so it is not expected to parse.
 if python3 -c "import fitdecode" 2>/dev/null; then
@@ -20,7 +30,8 @@ if python3 -c "import fitdecode" 2>/dev/null; then
     python3 tools/fit_test/validate_fit.py \
         tools/fit_test/out/normal.fit \
         tools/fit_test/out/crashed.fit \
-        tools/fit_test/out/torn.fit
+        tools/fit_test/out/torn.fit \
+        tools/fit_test/out/ascent_new.fit
 else
     echo
     echo "(skipping parser validation — pip install fitdecode to enable)"


### PR DESCRIPTION
## Summary

The device's end-ride summary and the iOS app disagreed on total ascent. The device is right; the app was wrong — and the root cause was invalid altitude data in the `.fit` file, exactly as the issue suspected.

## Root cause

The device computes ascent **only** from the map DEM elevation (`s.mapElevationM`), with 3 m hysteresis, and deliberately ignores the GPS chip's altitude because it's far too noisy (`accumulateStats()` in `src/ride_recorder.cpp`, and the comment "the GPS chip's altitude is intentionally unused — it's far too noisy").

But the FIT record stream did not follow that rule. In the recorder task:

```cpp
r.altitudeM = s.mapElevationValid ? s.mapElevationM : s.altitudeM;
```

When the DEM lookup had no value (tile gap, no fix yet, etc.) it fell back to the raw GPS altitude. GPS altitude sits tens of meters off the DEM (ellipsoid-vs-geoid offset plus ±10–30 m noise), so the record stream ended up mixing two elevation sources in very different ranges.

The app (`companion-ios/Sources/FITDecoder.swift`) recomputes ascent from that record stream using the *same* 3 m-hysteresis algorithm as the device — but because the stream contained those GPS-altitude excursions, every drop-out injected a spurious dip-and-spike that inflated the app's ascent well above the device's figure.

## Fix

Never write the noisy GPS altitude into the `.fit`. Write the map DEM elevation when it's valid, and mark the altitude field **invalid** (`0xFFFF`, the standard FIT "no value" marker) when it isn't — so phone-side readers skip those points instead of treating a bogus value as real.

- `src/ride_recorder.cpp` — fallback is now `NAN` (invalid) instead of `s.altitudeM`.
- `src/fit_writer.cpp` — `writeRecord()` emits `0xFFFF` for a `NAN` altitude.
- `src/fit_writer.h` — documents the `NAN` → invalid convention on `Record::altitudeM`.

The app already handles this correctly: it treats `0xFFFF` altitude as nil, and its `Point.altitude` is already `Double?`, so invalid points are simply skipped by the ascent integrator (and everywhere else altitude is used).

## Testing

Full firmware requires the vendored LilyGO board repo + the ESP32 toolchain (see `platformio.ini`), which I did not build here — see "Not verified" below. The changed FIT-writer code path is compiled and exercised on the host via the project's existing `tools/fit_test` harness, which builds the real `src/fit_writer.cpp` with clang and validates output with a real FIT parser (`fitdecode`).

**Existing suite still passes (no regression), and files with invalid-altitude records parse cleanly:**

```
$ sh tools/fit_test/run_fit_test.sh
normal.fit     8909 bytes  clean finish
crashed.fit    8731 bytes  watchdog reset, never finished
             -> REPAIRED: 345 records, 1.90 km, 344 s
torn.fit       2784 bytes  -> REPAIRED: 100 records
empty.fit       106 bytes  -> EMPTY
normal.fit   -> ALREADY_FINISHED (skipped)
all host assertions passed
...
FIT parser validation (CRC enforced):
  tools/fit_test/out/normal.fit: OK — ... record=345, session=1
  tools/fit_test/out/crashed.fit: OK — ... record=345, session=1
  tools/fit_test/out/torn.fit: OK — ... record=100, session=1
  tools/fit_test/out/ascent_new.fit: OK — ... record=100, session=1
```

**New regression test (`tools/fit_test/ascent_test.cpp`) reproduces the bug and proves the fix.** It builds a ride with a steady DEM climb where the DEM drops out for a stretch during which GPS altitude is ~45 m off, then compares three ascent figures: the device summary (map DEM only), the app's FIT-decode ascent under the old GPS-fallback behavior, and under the new invalid-marker behavior. The app-side decode mirrors `FITDecoder.swift`'s 3 m-hysteresis algorithm.

```
device summary ascent (map DEM only):        66.5 m
app ascent, OLD firmware (GPS fallback):    118.0 m
app ascent, NEW firmware (invalid marker):   66.6 m

  ok:   OLD firmware: app ascent diverges from device (reproduces the bug)
  ok:   NEW firmware: app ascent matches device end-ride summary
```

- **Broken behavior reproduced:** old GPS fallback → app reports 118.0 m vs the device's 66.5 m (a ~78% overstatement, the kind of mismatch the screenshots show).
- **Fixed behavior observed:** with the invalid marker the app reports 66.6 m — matching the device to within FIT altitude quantization (0.2 m/LSB), not ~50 m off.
- **Edge case exercised:** a mid-ride DEM drop-out (samples 30–49) is the exact condition that triggered the fallback; those points are now skipped by both the device's ascent accumulator and the app's, so the two stay in agreement.
- The invalid-altitude `.fit` (`ascent_new.fit`, 100 records) passes the real `fitdecode` parser with CRC enforced, confirming Strava/intervals.icu-class readers accept `0xFFFF` altitude (the standard FIT "no value" encoding).

### Not verified

- **Full ESP32 firmware build** (`pio run`): not run — it needs the vendored `vendor/T5S3-4.7-e-paper-PRO` board repo and the espressif32 toolchain, which would have consumed most of the session to set up. The only firmware change outside the host-tested `fit_writer` is a one-line substitution in `src/ride_recorder.cpp` (`s.altitudeM` → `NAN`); `NAN` is provided by `<math.h>` via `Arduino.h`. Before merging, a human should run `pio run` to confirm a clean firmware compile, and ideally record a short ride through a known DEM gap to confirm the on-device summary and the app now agree.


Closes #12

🤖 Opened by issue-fixer.