### PR TITLE
Add an in-browser offline-map generator to the project site

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Roads are classified into 4 render classes that map to line widths/dash styles;
 geometry is simplified and delta-encoded as 16-bit metre offsets to keep tiles
 tiny. Parsing/projection lives in `src/map_tiles.cpp`.
 
-### Two ways to create tiles
+### Three ways to create tiles
 
 **1. On the phone (primary).** In the Route tab, draw a box over the area you
 want. The app (`companion-ios/Sources/`):
@@ -144,6 +144,15 @@ want. The app (`companion-ios/Sources/`):
 for a bounding box, clips it into a square grid, and writes a single `EBM1`
 file you copy to `/maps/` — the legacy whole-map fallback used where no H3 tile
 covers the rider. See [`tools/README.md`](tools/README.md).
+
+**3. In the browser (region bake, no toolchain).** The
+[project site](https://raemondbw.github.io/epaper-bike-gps/#maps) has a
+*Generate an offline map* section: pick a bounding box on a map, and it fetches
+Overpass and encodes the same whole-region `EBM1` blob as `build_map.py`
+entirely client-side, then hands you a `<name>.ebm` to drop in `/maps/`. It's a
+JS port of `build_map.py` (`docs/mapgen.js`) — byte-for-byte identical output.
+No elevation grid (that's the phone's per-hex path), so it's the whole-map
+fallback layer, not the primary tile layer.
 
 ### On-device handling
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,8 @@
 <meta property="og:type" content="website">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%9A%B2%3C/text%3E%3C/svg%3E">
 <link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
 </head>
 <body>
 
@@ -20,6 +22,7 @@
       <a href="#features">Features</a>
       <a href="#screens">Screens</a>
       <a href="#split">Phone&nbsp;/&nbsp;device</a>
+      <a href="#maps">Generate maps</a>
       <a href="#flash">Flash firmware</a>
       <a href="https://github.com/RaemondBW/epaper-bike-gps">GitHub</a>
     </nav>
@@ -128,6 +131,54 @@
     </table>
   </section>
 
+  <section id="maps">
+    <h2>🗺️ Generate an offline map</h2>
+    <p class="sub">Pick an area, download a <code>.ebm</code> map, and drop it in <code>/maps</code> on the SD card — the device draws it offline, no phone needed. Everything runs locally in your browser from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> data (via <a href="https://overpass-api.de/">Overpass</a>); nothing is uploaded anywhere. This bakes a whole-region fallback map — the iOS app is still the way to author the per-hex tiles with baked-in elevation.</p>
+
+    <div class="flash-grid mapgen-grid">
+      <div class="card">
+        <div id="pickmap" class="pickmap" role="application" aria-label="Map area picker"></div>
+        <div class="pickmap-tools">
+          <button id="drawbox" class="btn secondary" type="button">✏️ Draw a box</button>
+          <button id="useview" class="btn secondary" type="button">Use current view</button>
+        </div>
+        <div class="bbox-fields">
+          <label>North<input id="bb-n" type="number" step="any" inputmode="decimal"></label>
+          <label>South<input id="bb-s" type="number" step="any" inputmode="decimal"></label>
+          <label>West<input id="bb-w" type="number" step="any" inputmode="decimal"></label>
+          <label>East<input id="bb-e" type="number" step="any" inputmode="decimal"></label>
+        </div>
+        <p id="bb-info" class="bbox-info">Pan and zoom to your area, then draw a box or use the current view.</p>
+      </div>
+
+      <div class="card">
+        <strong>1 &nbsp;Choose your area</strong>
+        <p style="color:var(--ink-soft);font-size:.95rem;margin:.5rem 0 0;">
+          Pan/zoom the map to where you ride, then <em>Draw a box</em> (drag across the map) or
+          <em>Use current view</em>. Keep it modest — a city or a county is fine; a whole state
+          is too much data for one download.
+        </p>
+        <strong style="display:block;margin-top:1rem;">2 &nbsp;Name &amp; generate</strong>
+        <label class="name-row">Map name
+          <input id="map-name" type="text" value="map" aria-label="Map name">
+        </label>
+        <div class="flash-controls" style="margin-top:12px;">
+          <button id="gen-btn" class="btn accent" type="button" disabled>Generate .ebm</button>
+          <span id="gen-status" class="status">Pick an area to begin.</span>
+        </div>
+        <div class="progress" hidden><i id="gen-bar"></i></div>
+        <p style="margin:12px 0 0;"><a id="gen-download" class="btn" hidden download>⬇ Download map</a></p>
+        <div class="console" id="gen-log" aria-live="polite"></div>
+        <strong style="display:block;margin-top:1rem;">3 &nbsp;Copy it to the SD card</strong>
+        <p style="color:var(--ink-soft);font-size:.95rem;margin:.5rem 0 0;">
+          Put <code>&lt;name&gt;.ebm</code> in the <code>/maps</code> folder on the device's SD card —
+          over the built-in USB-drive mode, or with a card reader. It shows up on the map screen
+          the next time you ride through that area.
+        </p>
+      </div>
+    </div>
+  </section>
+
   <section id="flash">
     <h2>⚡ Flash firmware from your browser</h2>
     <p class="sub">Powered by <a href="https://github.com/espressif/esptool-js">esptool-js</a> and the Web Serial API — the same approach as the <a href="https://github.com/adafruit/Adafruit_WebSerial_ESPTool">Adafruit WebSerial ESPTool</a>. Everything runs locally in your browser; nothing is uploaded anywhere.</p>
@@ -219,5 +270,8 @@
 </footer>
 
 <script type="module" src="flash.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script type="module" src="mapgen-ui.js"></script>
 </body>
 </html>

--- a/docs/mapgen-ui.js
+++ b/docs/mapgen-ui.js
@@ -1,0 +1,190 @@
+// DOM wiring for the in-browser offline-map generator. The encoding lives in
+// mapgen.js (a pure, testable library); this file is just the map picker + form.
+import { buildEbm, headerOnlySize, fetchOverpass } from "./mapgen.js";
+
+const $ = (id) => document.getElementById(id);
+const fieldN = $("bb-n"), fieldS = $("bb-s"), fieldW = $("bb-w"), fieldE = $("bb-e");
+const infoEl = $("bb-info");
+const genBtn = $("gen-btn"), genStatus = $("gen-status"), genLog = $("gen-log");
+const genDownload = $("gen-download");
+const barWrap = document.querySelector("#maps .progress");
+const nameEl = $("map-name");
+const drawBtn = $("drawbox"), useViewBtn = $("useview");
+
+// The generator section is optional on the page; bail cleanly if it's absent.
+if (genBtn) init();
+
+function init() {
+  let map = null, rect = null, drawing = false, downloadUrl = null;
+
+  // --- Leaflet map (optional — the numeric fields work without it) ----------
+  if (typeof L !== "undefined") {
+    map = L.map("pickmap", { zoomControl: true }).setView([37.7625, -122.44], 12);
+    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      attribution: "&copy; OpenStreetMap contributors",
+    }).addTo(map);
+    // Recompute size once laid out (in case the section was display:none-ish).
+    setTimeout(() => map.invalidateSize(), 200);
+
+    useViewBtn.addEventListener("click", () => {
+      const b = map.getBounds();
+      setBbox(b.getSouth(), b.getWest(), b.getNorth(), b.getEast(), false);
+    });
+
+    // Drag-to-draw a rectangle. Toggling the mode disables map panning so the
+    // drag paints a box instead of moving the map.
+    drawBtn.addEventListener("click", () => setDrawing(!drawing));
+
+    let dragStart = null;
+    map.on("mousedown", (e) => {
+      if (!drawing) return;
+      dragStart = e.latlng;
+      L.DomEvent.preventDefault(e.originalEvent);
+    });
+    map.on("mousemove", (e) => {
+      if (!drawing || !dragStart) return;
+      drawRect(L.latLngBounds(dragStart, e.latlng));
+    });
+    map.on("mouseup", (e) => {
+      if (!drawing || !dragStart) return;
+      const b = L.latLngBounds(dragStart, e.latlng);
+      dragStart = null;
+      setDrawing(false);
+      setBbox(b.getSouth(), b.getWest(), b.getNorth(), b.getEast(), false);
+    });
+  } else {
+    // No Leaflet (offline / blocked CDN): hide map affordances, keep the form.
+    const pm = $("pickmap");
+    if (pm) pm.style.display = "none";
+    drawBtn.style.display = "none";
+    useViewBtn.style.display = "none";
+  }
+
+  function setDrawing(on) {
+    drawing = on;
+    drawBtn.classList.toggle("active", on);
+    if (!map) return;
+    const el = map.getContainer();
+    el.style.cursor = on ? "crosshair" : "";
+    if (on) map.dragging.disable();
+    else map.dragging.enable();
+  }
+
+  function drawRect(bounds) {
+    if (!map) return;
+    if (!rect) rect = L.rectangle(bounds, { color: "#c65a1e", weight: 2, fillOpacity: 0.08 }).addTo(map);
+    else rect.setBounds(bounds);
+  }
+
+  // --- bbox state <-> fields -----------------------------------------------
+  function setBbox(s, w, n, e, fit) {
+    fieldS.value = round5(s); fieldW.value = round5(w);
+    fieldN.value = round5(n); fieldE.value = round5(e);
+    onFieldsChanged(fit);
+  }
+
+  function readFields() {
+    const s = parseFloat(fieldS.value), w = parseFloat(fieldW.value);
+    const n = parseFloat(fieldN.value), e = parseFloat(fieldE.value);
+    if ([s, w, n, e].some((v) => !isFinite(v))) return null;
+    return { s, w, n, e };
+  }
+
+  function onFieldsChanged(fit) {
+    const bb = readFields();
+    if (!bb) {
+      genBtn.disabled = true;
+      infoEl.textContent = "Enter or draw a bounding box.";
+      infoEl.className = "bbox-info";
+      return;
+    }
+    if (bb.s >= bb.n || bb.w >= bb.e) {
+      genBtn.disabled = true;
+      infoEl.textContent = "North must be above south and east must be right of west.";
+      infoEl.className = "bbox-info warn";
+      return;
+    }
+    if (map) {
+      drawRect(L.latLngBounds([bb.s, bb.w], [bb.n, bb.e]));
+      if (fit) map.fitBounds(rect.getBounds(), { padding: [20, 20] });
+    }
+    // Rough footprint so people don't ask for an entire country.
+    const midLat = (bb.s + bb.n) / 2;
+    const kmW = (bb.e - bb.w) * 111.32 * Math.cos((midLat * Math.PI) / 180);
+    const kmH = (bb.n - bb.s) * 110.57;
+    const areaKm2 = Math.round(kmW * kmH);
+    let msg = `Selected ≈ ${kmW.toFixed(0)} × ${kmH.toFixed(0)} km (${areaKm2.toLocaleString()} km²).`;
+    if (areaKm2 > 40000) {
+      genBtn.disabled = true;
+      infoEl.textContent = msg + " Too large — draw a smaller area (Overpass will refuse it).";
+      infoEl.className = "bbox-info warn";
+      return;
+    }
+    genBtn.disabled = false;
+    infoEl.className = "bbox-info";
+    infoEl.textContent = areaKm2 > 6000
+      ? msg + " Large — the download may take a minute or two."
+      : msg;
+  }
+
+  [fieldS, fieldW, fieldN, fieldE].forEach((f) =>
+    f.addEventListener("input", () => onFieldsChanged(false)));
+
+  // --- generate -------------------------------------------------------------
+  function log(msg) { genLog.textContent += msg + "\n"; genLog.scrollTop = genLog.scrollHeight; }
+  function setStatus(text, kind) { genStatus.textContent = text; genStatus.className = "status" + (kind ? " " + kind : ""); }
+
+  genBtn.addEventListener("click", async () => {
+    const bb = readFields();
+    if (!bb) return;
+    const name = (nameEl.value || "map").trim().replace(/[^A-Za-z0-9._-]/g, "_") || "map";
+
+    genBtn.disabled = true;
+    genDownload.hidden = true;
+    if (downloadUrl) { URL.revokeObjectURL(downloadUrl); downloadUrl = null; }
+    genLog.textContent = "";
+    barWrap.hidden = false;
+    barWrap.classList.add("indet");
+    setStatus("Downloading map data…");
+    log(`Bounding box  S ${bb.s}  W ${bb.w}  N ${bb.n}  E ${bb.e}`);
+
+    try {
+      const json = await fetchOverpass(bb, (s) => { setStatus("Downloading map data…"); log(s); });
+      log(`Got ${json.elements.length.toLocaleString()} OSM elements. Building…`);
+      setStatus("Building map…");
+      // Yield so the status paints before the (synchronous) encode.
+      await new Promise((r) => setTimeout(r, 0));
+
+      const ebm = buildEbm(json, bb);
+      if (ebm.length <= headerOnlySize(bb.s, bb.w, bb.n, bb.e)) {
+        throw new Error("No roads found in that area — try a different or larger box.");
+      }
+
+      const blob = new Blob([ebm], { type: "application/octet-stream" });
+      downloadUrl = URL.createObjectURL(blob);
+      genDownload.href = downloadUrl;
+      genDownload.download = `${name}.ebm`;
+      genDownload.textContent = `⬇ Download ${name}.ebm (${fmtBytes(ebm.length)})`;
+      genDownload.hidden = false;
+      log(`Done: ${name}.ebm, ${fmtBytes(ebm.length)}. Copy it into /maps on the SD card.`);
+      setStatus("Map ready — download below.", "ok");
+    } catch (err) {
+      log("Error: " + (err && err.message ? err.message : String(err)));
+      setStatus(err && err.message ? err.message : "Failed.", "err");
+    } finally {
+      barWrap.hidden = true;
+      barWrap.classList.remove("indet");
+      genBtn.disabled = false;
+    }
+  });
+
+  onFieldsChanged(false);
+}
+
+function round5(v) { return Math.round(v * 1e5) / 1e5; }
+function fmtBytes(n) {
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  return (n / (1024 * 1024)).toFixed(2) + " MB";
+}

--- a/docs/mapgen.js
+++ b/docs/mapgen.js
@@ -1,0 +1,262 @@
+// In-browser offline-map builder for the Open E-Paper Bike Computer.
+//
+// A straight port of tools/maps/build_map.py (and companion-ios MapBuilder.swift)
+// so the output is byte-compatible with the .ebm whole-region maps the firmware
+// reads from /maps/*.ebm. Fetch OSM ways from Overpass for a bounding box,
+// classify + simplify them, clip into the fixed lat/lon tile grid, and encode
+// the binary — all locally in the browser, nothing uploaded anywhere.
+//
+// Format (little-endian):
+//   'EBM1', f64 lat0, f64 lon0, f64 tileDeg, i32 nx, i32 ny,
+//   index[nx*ny] of (u32 offset, u32 length)  (0,0 = empty tile),
+//   tiles: u16 polylineCount, per polyline { u8 class, u16 pointCount,
+//          i16 x,y per point (metres E/N of the tile SW corner) }.
+//   class: 0 major road, 1 minor road, 2 path, 3 rail.
+
+export const TILE_DEG = 0.02;
+export const SIMPLIFY_M = 3.0;
+
+// Public Overpass instances, tried in order with a retry pass (mirrors the iOS
+// app). The busy main instance 504s under load, so rotating usually succeeds.
+export const OVERPASS_ENDPOINTS = [
+  "https://overpass-api.de/api/interpreter",
+  "https://maps.mail.ru/osm/tools/overpass/api/interpreter",
+];
+
+const QUERY = `[out:json][timeout:90];
+(
+  way["highway"~"^(motorway|trunk|primary|secondary|tertiary|residential|unclassified|living_street|pedestrian|cycleway|footway|path|track|steps)"](%S,%W,%N,%E);
+  way["railway"~"^(rail|light_rail)$"](%S,%W,%N,%E);
+);
+out body;
+>;
+out skel qt;`;
+
+const MAJOR = new Set(["motorway", "trunk", "primary", "secondary"]);
+const MINOR = new Set(["tertiary", "residential", "unclassified", "living_street", "pedestrian"]);
+const PATH = new Set(["cycleway", "footway", "path", "track", "steps"]);
+
+// OSM tags -> render class (0 major, 1 minor, 2 path, 3 rail), or null to drop.
+// Must agree with build_map.py / MapBuilder.swift.
+export function classify(tags) {
+  if (tags == null) return null;
+  if (tags.railway != null) return 3;
+  const hw = tags.highway || "";
+  // Sidewalks and crossings duplicate every street — noise on a bike map.
+  if (hw === "footway" && (tags.footway === "sidewalk" || tags.footway === "crossing")) return null;
+  const base = hw.split("_link")[0];
+  if (MAJOR.has(base)) return 0;
+  if (MINOR.has(base)) return 1;
+  if (PATH.has(base)) return 2;
+  return null;
+}
+
+// Ramer–Douglas–Peucker on projected metre coords. points: [[x,y], …].
+export function rdp(points, eps) {
+  const nPts = points.length;
+  if (nPts < 3) return points.slice();
+  const keep = new Array(nPts).fill(false);
+  keep[0] = keep[nPts - 1] = true;
+  const stack = [[0, nPts - 1]];
+  while (stack.length) {
+    const [a, b] = stack.pop();
+    const [ax, ay] = points[a];
+    const [bx, by] = points[b];
+    const dx = bx - ax, dy = by - ay;
+    const norm = Math.hypot(dx, dy) || 1e-9;
+    let worst = 0.0, wi = -1;
+    for (let i = a + 1; i < b; i++) {
+      const [px, py] = points[i];
+      const d = Math.abs(dx * (ay - py) - dy * (ax - px)) / norm;
+      if (d > worst) { worst = d; wi = i; }
+    }
+    if (worst > eps && wi >= 0) {
+      keep[wi] = true;
+      stack.push([a, wi]);
+      stack.push([wi, b]);
+    }
+  }
+  const out = [];
+  for (let i = 0; i < nPts; i++) if (keep[i]) out.push(points[i]);
+  return out;
+}
+
+// Python's int(round(x)): round-half-to-even, then truncate toward zero.
+// build_map.py rounds this way, so matching it keeps our bytes identical.
+function pyRound(x) {
+  const r = Math.round(x);
+  // Math.round rounds .5 up; Python rounds .5 to even. Correct the even case.
+  if (Math.abs(x - Math.trunc(x)) === 0.5) {
+    const f = Math.floor(x);
+    return (f % 2 === 0) ? f : f + 1;
+  }
+  return r;
+}
+
+// A tiny growable little-endian byte writer.
+class ByteWriter {
+  constructor() { this.bytes = []; }
+  get length() { return this.bytes.length; }
+  u8(v) { this.bytes.push(v & 0xff); }
+  ascii(s) { for (let i = 0; i < s.length; i++) this.bytes.push(s.charCodeAt(i) & 0xff); }
+  u16(v) { this.u8(v); this.u8(v >> 8); }
+  i16(v) { this.u16(v & 0xffff); }
+  u32(v) { this.u8(v); this.u8(v >> 8); this.u8(v >> 16); this.u8(v >> 24); }
+  i32(v) { this.u32(v >>> 0); }
+  f64(v) {
+    const b = new Uint8Array(8);
+    new DataView(b.buffer).setFloat64(0, v, true);
+    for (let i = 0; i < 8; i++) this.bytes.push(b[i]);
+  }
+  concat(other) { for (const x of other.bytes) this.bytes.push(x); }
+  toUint8Array() { return Uint8Array.from(this.bytes); }
+}
+
+// Byte size of a header-only (empty) map for a bbox — used to detect "no roads".
+export function headerOnlySize(s, w, n, e, tileDeg = TILE_DEG) {
+  const td = tileDeg;
+  const lat0 = Math.floor(s / td) * td;
+  const lon0 = Math.floor(w / td) * td;
+  const nx = Math.ceil((e - lon0) / td);
+  const ny = Math.ceil((n - lat0) / td);
+  return 36 + nx * ny * 8;
+}
+
+// Encode an already-fetched Overpass JSON object into an .ebm Uint8Array.
+export function buildEbm(json, { s, w, n, e, tileDeg = TILE_DEG, simplifyM = SIMPLIFY_M }) {
+  const nodes = new Map();
+  const ways = [];
+  for (const el of json.elements) {
+    if (el.type === "node" && el.lat != null && el.lon != null) {
+      nodes.set(el.id, [el.lat, el.lon]);
+    } else if (el.type === "way" && el.nodes) {
+      const cls = classify(el.tags || {});
+      if (cls != null) ways.push([cls, el.nodes]);
+    }
+  }
+
+  const td = tileDeg;
+  const midLat = (s + n) / 2;
+  const kx = 111320.0 * Math.cos((midLat * Math.PI) / 180); // m per deg lon
+  const ky = 110540.0;                                      // m per deg lat
+  const lat0 = Math.floor(s / td) * td;
+  const lon0 = Math.floor(w / td) * td;
+  const nx = Math.ceil((e - lon0) / td);
+  const ny = Math.ceil((n - lat0) / td);
+  if (nx <= 0 || ny <= 0) throw new Error("empty area");
+
+  const tileWm = td * kx, tileHm = td * ky;
+  const tiles = new Map(); // ty*nx+tx -> [[cls, [[x,y],…]], …]
+
+  const tileOf = (p) => [Math.floor(p[0] / tileWm), Math.floor(p[1] / tileHm)];
+
+  const emit = (tx, ty, cls, run) => {
+    if (run.length < 2 || tx < 0 || tx >= nx || ty < 0 || ty >= ny) return;
+    const ox = tx * tileWm, oy = ty * tileHm;
+    const pts = [];
+    for (const [x, y] of run) {
+      const lx = Math.max(-32000, Math.min(32000, pyRound(x - ox)));
+      const ly = Math.max(-32000, Math.min(32000, pyRound(y - oy)));
+      const last = pts[pts.length - 1];
+      if (last && last[0] === lx && last[1] === ly) continue;
+      pts.push([lx, ly]);
+    }
+    if (pts.length >= 2) {
+      const key = ty * nx + tx;
+      if (!tiles.has(key)) tiles.set(key, []);
+      tiles.get(key).push([cls, pts]);
+    }
+  };
+
+  for (const [cls, nids] of ways) {
+    const pts = [];
+    for (const id of nids) { const p = nodes.get(id); if (p) pts.push(p); }
+    if (pts.length < 2) continue;
+    const m = rdp(pts.map(([lat, lon]) => [(lon - lon0) * kx, (lat - lat0) * ky]), simplifyM);
+    if (m.length < 2) continue;
+    let run = [m[0]];
+    let cur = tileOf(m[0]);
+    for (let i = 1; i < m.length; i++) {
+      const p = m[i];
+      const t = tileOf(p);
+      run.push(p);
+      if (t[0] !== cur[0] || t[1] !== cur[1]) {
+        emit(cur[0], cur[1], cls, run);
+        run = [run[run.length - 2], p];
+        cur = t;
+      }
+    }
+    emit(cur[0], cur[1], cls, run);
+  }
+
+  // Serialize header.
+  const out = new ByteWriter();
+  out.ascii("EBM1");
+  out.f64(lat0); out.f64(lon0); out.f64(td);
+  out.i32(nx); out.i32(ny);
+
+  // Build each tile blob, then the index, then concat.
+  const blobs = new Map();
+  for (const [key, polys] of tiles) {
+    const b = new ByteWriter();
+    b.u16(Math.min(polys.length, 0xffff));
+    for (const [cls, pts] of polys) {
+      b.u8(cls);
+      b.u16(Math.min(pts.length, 0xffff));
+      for (const [x, y] of pts) { b.i16(x); b.i16(y); }
+    }
+    blobs.set(key, b);
+  }
+
+  let off = 36 + nx * ny * 8;
+  const index = new ByteWriter();
+  const ordered = [];
+  for (let ty = 0; ty < ny; ty++) {
+    for (let tx = 0; tx < nx; tx++) {
+      const b = blobs.get(ty * nx + tx);
+      if (b && b.length) {
+        index.u32(off); index.u32(b.length);
+        ordered.push(b); off += b.length;
+      } else {
+        index.u32(0); index.u32(0);
+      }
+    }
+  }
+  out.concat(index);
+  for (const b of ordered) out.concat(b);
+  return out.toUint8Array();
+}
+
+// Fetch raw Overpass JSON for a bbox, rotating through the mirrors with a
+// retry pass. `onStatus(text)` reports which mirror is being tried.
+export async function fetchOverpass({ s, w, n, e }, onStatus = () => {}) {
+  const bbox = { S: String(s), W: String(w), N: String(n), E: String(e) };
+  const q = QUERY.replace(/%S/g, bbox.S).replace(/%W/g, bbox.W)
+                 .replace(/%N/g, bbox.N).replace(/%E/g, bbox.E);
+  const body = "data=" + encodeURIComponent(q);
+
+  const total = OVERPASS_ENDPOINTS.length * 2;
+  let lastStatus = 0, lastError = null;
+  for (let attempt = 0; attempt < total; attempt++) {
+    const url = OVERPASS_ENDPOINTS[attempt % OVERPASS_ENDPOINTS.length];
+    let host = url;
+    try { host = new URL(url).host; } catch (_) {}
+    onStatus(`server ${host} (try ${attempt + 1}/${total})`);
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
+      if (resp.status === 200) return await resp.json();
+      lastStatus = resp.status;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 800));
+  }
+  if (lastStatus === 429) throw new Error("map servers are rate-limiting — wait a minute and retry");
+  if (lastStatus === 504 || lastStatus >= 500) throw new Error(`map servers are busy (${lastStatus}) — try again, or draw a smaller area`);
+  if (lastError) throw new Error(lastError.message || String(lastError));
+  throw new Error("no response from map servers");
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -167,3 +167,37 @@ footer a { color: var(--ink-soft); }
 footer .wrap { display: flex; gap: 18px; flex-wrap: wrap; justify-content: space-between; }
 
 code { font-family: var(--mono); background: #eceae2; padding: 1px 5px; border-radius: 4px; font-size: 0.9em; }
+
+/* --- offline-map generator --- */
+.mapgen-grid { align-items: start; }
+.pickmap {
+  height: 340px; border: 1px solid var(--line); border-radius: 8px;
+  overflow: hidden; background: #eceae2;
+}
+.pickmap-tools { display: flex; gap: 8px; margin: 12px 0; flex-wrap: wrap; }
+.pickmap-tools .btn { padding: 7px 14px; font-size: 0.9rem; }
+.btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.bbox-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.bbox-fields label {
+  display: flex; align-items: center; gap: 8px; font-size: 0.85rem; color: var(--ink-soft);
+}
+.bbox-fields input {
+  flex: 1; min-width: 0; font: inherit; font-family: var(--mono); font-size: 0.86rem;
+  padding: 7px 8px; border: 1px solid var(--line); border-radius: 6px; background: #fff;
+}
+.bbox-info { margin: 12px 0 0; font-size: 0.88rem; color: var(--ink-soft); }
+.bbox-info.warn { color: var(--bad); }
+.name-row {
+  display: flex; align-items: center; gap: 10px; margin-top: 10px; font-size: 0.95rem;
+}
+.name-row input {
+  flex: 1; min-width: 0; font: inherit; padding: 7px 9px;
+  border: 1px solid var(--line); border-radius: 6px; background: #fff;
+}
+/* Indeterminate progress while fetching/building. */
+.progress.indet > i {
+  width: 40%; animation: indet 1.1s ease-in-out infinite;
+}
+@keyframes indet {
+  0% { margin-left: -40%; } 100% { margin-left: 100%; }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -33,6 +33,17 @@ Copy the result to `/maps/` on the SD card. `sf_overpass.json` is a cached
 Overpass response for the San Francisco box so the build is reproducible
 offline.
 
+## 3. In the browser (region bake, no toolchain)
+
+The project site's *Generate an offline map* section
+([`docs/mapgen.js`](../docs/mapgen.js) + `docs/mapgen-ui.js`) is a JS port of
+`build_map.py`: pick a bounding box on a Leaflet map, and it fetches Overpass
+and encodes the same whole-region `EBM1` blob client-side, then downloads a
+`<name>.ebm` to drop in `/maps/`. Output is byte-for-byte identical to
+`build_map.py` for the same Overpass response, so the three paths stay in sync.
+Like `build_map.py`, it has no `ELV1` elevation block — that's the phone's
+per-hex path.
+
 ## Render classes
 
 Both paths classify OSM tags identically (`build_map.py` and `MapBuilder.swift`


### PR DESCRIPTION
Closes #15.

## What this does

Adds a **Generate an offline map** section to the project site
(`docs/index.html`, linked from the nav) that lets anyone build a downloadable
map for the SD card straight from the browser — no toolchain, no phone.

- Pan/zoom a Leaflet+OSM map to your riding area, then **Draw a box** (drag
  across the map) or **Use current view**. Numeric N/S/W/E fields stay in sync
  and are editable directly.
- Click **Generate .ebm**: it fetches OSM ways from Overpass (rotating through
  the same public mirrors the iOS app uses, with a retry pass), classifies +
  simplifies them, and encodes the `EBM1` blob **entirely client-side** — then
  hands you a `<name>.ebm` to drop in `/maps/` on the card.
- Live footprint readout (≈ km × km / km²), validation for bad boxes, a
  too-large guard, and a "no roads found" message for empty areas.

Everything runs locally in the browser; nothing is uploaded (same as the
existing Web Serial flasher).

## Design choice / scope

The encoder (`docs/mapgen.js`) is a straight JS port of
`tools/maps/build_map.py`, so it produces the **whole-region `/maps/*.ebm`
fallback map** the firmware already reads (`src/map_store.cpp` indexes any
`/maps/*.ebm` by its `EBM1` header bbox — see README "On-device handling").

I deliberately did **not** reimplement the phone's primary path (per-hex H3
res-6 tiles with a baked-in `ELV1` elevation grid): that needs an H3 library,
many Open-Meteo elevation round-trips, and multi-file/zip packaging, and it's
squarely the iOS app's job per the README's phone/device split. A whole-region
blob is a first-class, fully-supported device format (it's exactly what
`build_map.py` and `data/sf.ebm` produce), so it's the right, robust fit for a
zero-dependency browser tool. This is noted in the UI copy and the README.

The encoder is kept as a pure, dependency-free ES module so it's testable in
Node; `docs/mapgen-ui.js` is the thin DOM/Leaflet layer. README and
`tools/README.md` gain a "third way to create tiles" note.

## Testing

**1. Encoder is byte-for-byte identical to `build_map.py`.** I primed
`build_map.py`'s Overpass cache with a synthetic payload exercising every render
class, a 41-point road spanning tile boundaries (to hit RDP + the per-tile split
+ int16 clamping), `motorway_link` (→ base class), and dropped sidewalk/crossing
footways — then compared its output to `buildEbm()`:

```
$ python3 tools/maps/build_map.py --bbox 37.70 -122.45 37.74 -122.40 --name test --out /tmp/py.ebm
using cached test_overpass.json
7 ways, 61 nodes
grid 4 x 2 tiles of 0.02 deg
wrote /tmp/py.ebm: 0.00 MB, 13 polylines, 44 points

$ node /tmp/cmp.mjs      # buildEbm(same JSON) vs py.ebm
js len 325 py len 325
IDENTICAL ✅
```

Re-ran the compare against the final committed `docs/mapgen.js`: still
`IDENTICAL ✅`. (Python's round-half-to-even is matched explicitly in
`pyRound()`.)

**2. Modules parse as ESM.**
```
$ node --check docs/mapgen-ui.js  →  mapgen-ui.js OK
$ node --check docs/mapgen.js     →  mapgen.js OK
```

**3. Full UI driven in a real headless Chromium** (served over
`python3 -m http.server`, driven with the gstack browse tool):

- `#maps` section renders; Leaflet map loads OSM tiles (`9` tiles present).
- Generate button starts **disabled**; entering a valid bbox enables it, shows
  `Selected ≈ 4 × 4 km (19 km²)`, and draws the orange selection rectangle on
  the map (`1` `leaflet-interactive` path).
- Clicked **Generate** with `window.fetch` stubbed to return a small Overpass
  payload. Console log:
  ```
  Bounding box  S 37.7  W -122.45  N 37.74  E -122.4
  server overpass-api.de (try 1/4)
  Got 7 OSM elements. Building…
  Done: map.ebm, 150 B. Copy it into /maps on the SD card.
  ```
  Status → `Map ready — download below.`; download link → `map.ebm`,
  `⬇ Download map.ebm (150 B)`.
- **No-roads path** (empty `elements`): status `No roads found in that area — try
  a different or larger box.`, download stays hidden.
- **Invalid bbox** (north below south): info shows `North must be above south
  and east must be right of west.`, Generate re-disabled.
- Screenshot of the section confirmed the layout matches the site's style
  (map + rectangle, controls, fields, instructions, console).

The produced download is `new Blob([ebm])` of the exact Uint8Array proven
identical to `build_map.py` in test 1, so its bytes begin with `EBM1` and load
via the same `map_store.cpp`/`map_tiles.cpp` path as `data/sf.ebm`.

### Not verified (no hardware)
I did not flash firmware or mount an SD card, so I did not watch a
browser-generated `.ebm` render on the physical panel. That path is already
exercised by the existing `data/sf.ebm` (built by `build_map.py`), and the
byte-for-byte equality above ties the two together. Before merging, a good
end-to-end check is to generate a map for a real area on the deployed site, copy
`<name>.ebm` to `/maps/` on a card, and confirm it appears on the device's map
screen while riding through that area.


Closes #15

🤖 Opened by issue-fixer.