### PR TITLE
Confirm route receipt on the device so the "Send" button reflects it

### DIFF
--- a/companion-ios/Sources/BLEManager.swift
+++ b/companion-ios/Sources/BLEManager.swift
@@ -86,7 +86,8 @@ final class BLEManager: NSObject, ObservableObject {
     @Published var clock24h = true      // device status-bar clock format
     @Published var usbDrive = true      // expose device SD as a USB drive
     @Published var lastUploadProgress: Double? = nil   // 0...1 while sending
-    @Published var routeSent = false                   // last route reached the device
+    @Published var routeSent = false                   // last route's writes were queued
+    @Published var routeReceived = false               // device confirmed it got the route
     @Published var lastMessage: String? = nil
 
     // Ride download
@@ -797,6 +798,15 @@ final class BLEManager: NSObject, ObservableObject {
         case 0x20: deviceRoutes.append(String(decoding: d[1...], as: UTF8.self))
         case 0x21: loadingRoutes = false; deviceRoutes.sort()
         case 0x22: break  // delete ack
+        case 0x23:        // device received + parsed the route
+            lastUploadProgress = nil
+            routeSent = true
+            routeReceived = true
+        case 0x24:        // device got the upload but couldn't read the route
+            lastUploadProgress = nil
+            routeSent = false
+            routeReceived = false
+            lastMessage = "Device couldn’t read the route — try sending again"
         default: break
         }
     }
@@ -897,6 +907,7 @@ final class BLEManager: NSObject, ObservableObject {
 
         lastUploadProgress = 0
         routeSent = false
+        routeReceived = false
         Task { @MainActor in
             for (idx, packet) in packets.enumerated() {
                 p.writeValue(packet, for: c, type: .withResponse)
@@ -904,6 +915,9 @@ final class BLEManager: NSObject, ObservableObject {
                 try? await Task.sleep(nanoseconds: 12_000_000)  // pace writes
             }
             lastUploadProgress = nil
+            // The writes are queued; the button now shows "Sent". Firmware ≥ this
+            // release notifies back (0x23/0x24) so we can upgrade that to a real
+            // "Received by device" confirmation — see handleRouteNotify.
             routeSent = true
             lastMessage = "Route “\(name)” sent — \(maneuvers.count) turns"
         }
@@ -974,6 +988,7 @@ extension BLEManager: CBCentralManagerDelegate {
             status = DeviceStatus()
             rides = []; loadingRides = false; downloadingName = nil
             deviceRoutes = []; loadingRoutes = false
+            lastUploadProgress = nil; routeSent = false; routeReceived = false
             sensors = []; scanningSensors = false
             startScan()
         }

--- a/companion-ios/Sources/RouteView.swift
+++ b/companion-ios/Sources/RouteView.swift
@@ -43,6 +43,7 @@ struct RouteView: View {
                             minutes: Int(route.expectedTravelTime / 60),
                             progress: ble.lastUploadProgress,
                             sent: ble.routeSent,
+                            received: ble.routeReceived,
                             canSend: ble.state == .connected
                         ) {
                             let coords = route.polyline.coordinates
@@ -74,7 +75,9 @@ struct RouteView: View {
             .sheet(isPresented: $showSaved) { SavedRoutesSheet() }
             .sheet(isPresented: $showMaps) { MapsView() }
             .onAppear { model.requestLocation() }
-            .onChange(of: model.destinationName) { ble.routeSent = false }
+            .onChange(of: model.destinationName) {
+                ble.routeSent = false; ble.routeReceived = false
+            }
         }
     }
 
@@ -313,6 +316,7 @@ private struct RouteSummaryCard: View {
     let minutes: Int
     let progress: Double?
     let sent: Bool
+    let received: Bool
     let canSend: Bool
     let send: () -> Void
     let clear: () -> Void
@@ -354,7 +358,10 @@ private struct RouteSummaryCard: View {
                 } else if sent {
                     HStack(spacing: 8) {
                         Image(systemName: "checkmark.circle.fill").foregroundStyle(Palette.good)
-                        Text("Sent to device").font(TypeScale.body).foregroundStyle(Palette.good)
+                        // "Received" once the device confirms (0x23); until then
+                        // (or on older firmware that never acks) show "Sent".
+                        Text(received ? "Received by device" : "Sent to device")
+                            .font(TypeScale.body).foregroundStyle(Palette.good)
                         Spacer()
                         Button("Send again", action: send)
                             .font(.system(size: 13, weight: .semibold)).foregroundStyle(Palette.accent)

--- a/src/ble_server.cpp
+++ b/src/ble_server.cpp
@@ -95,7 +95,9 @@ class SettingsCb : public NimBLECharacteristicCallbacks {
 //   [0x02] data      : rest is raw GPX bytes, appended in order
 //   [0x03] end track : finalize geometry -> parse + activate
 //   [0x04] maneuver  : [i32 lat_e7][i32 lon_e7][utf8 instruction]
-//   [0x05] end nav   : all maneuvers received -> raise nav prompt
+//   [0x05] end nav   : all maneuvers received -> raise nav prompt, then the
+//                      device notifies [0x23] received-ok / [0x24] parse-failed
+//                      so the phone can confirm receipt instead of guessing
 //   [0x06] list      : device notifies [0x20][name].. then [0x21] done
 //   [0x07] delete    : rest is a route filename to remove
 constexpr size_t ROUTE_MAX = 256 * 1024;  // 256 KB GPX cap (PSRAM)
@@ -108,6 +110,11 @@ enum RouteReq { RREQ_NONE, RREQ_LIST, RREQ_DELETE };
 volatile RouteReq routeReq = RREQ_NONE;
 char routeReqName[48];
 
+// Receipt acknowledgement for the phone. onWrite can't safely notify from the
+// BLE callback, so 0x05 stashes the outcome here and the server loop notifies.
+volatile bool routeTrackLoaded = false;   // did the last 0x03 track parse OK
+volatile int  pendingRouteAck  = 0;       // 0 none, 1 received-ok, 2 parse-failed
+
 class RouteCb : public NimBLECharacteristicCallbacks {
     void onWrite(NimBLECharacteristic* c, NimBLEConnInfo&) override {
         std::string v = c->getValue();
@@ -118,6 +125,7 @@ class RouteCb : public NimBLECharacteristicCallbacks {
 
         if (op == 0x01) {  // start
             routeLen = 0;
+            routeTrackLoaded = false;
             routes::clearManeuvers();
             size_t n = plen < sizeof(routeName) - 1 ? plen : sizeof(routeName) - 1;
             memcpy(routeName, payload, n);
@@ -132,6 +140,7 @@ class RouteCb : public NimBLECharacteristicCallbacks {
             if (routeBuf && routeLen > 0) {
                 routeBuf[routeLen < ROUTE_MAX ? routeLen : ROUTE_MAX - 1] = 0;
                 bool ok = routes::loadFromMemory(routeName, routeBuf, routeLen);
+                routeTrackLoaded = ok;
                 Serial.printf("[srv] route track end: %u bytes, %s\n",
                               (unsigned)routeLen, ok ? "loaded" : "parse failed");
             }
@@ -149,6 +158,7 @@ class RouteCb : public NimBLECharacteristicCallbacks {
             routes::finishManeuvers();
             Serial.printf("[srv] navigation ready: %d maneuvers\n",
                           routes::maneuverCount());
+            pendingRouteAck = routeTrackLoaded ? 1 : 2;   // tell the phone
         } else if (op == 0x06) {  // list routes
             routeReq = RREQ_LIST;
         } else if (op == 0x07 && plen > 0) {  // delete route
@@ -1051,6 +1061,12 @@ void task(void*) {
         if (sensorReq == SREQ_LIST) {
             sensorReq = SREQ_NONE;
             sendSensorList();
+        }
+        // Confirm route receipt to the phone (no SD access needed, so this runs
+        // even while a host computer is using the card).
+        if (routeChr && pendingRouteAck) {
+            int a = pendingRouteAck; pendingRouteAck = 0;
+            notifyByte2(a == 1 ? 0x23 : 0x24);
         }
 
         vTaskDelay(pdMS_TO_TICKS(100));


### PR DESCRIPTION
## What the issue was

> when i send a route from the ios app to the device it doesnt update the button
> to indicate it was sent or received or anything.

When you send a route, the app writes the GPX to the device over BLE but the device
never tells the app anything back. The "Send" button's confirmation was therefore
purely **optimistic** — the app flipped it after merely *queueing* the BLE writes,
with no signal that the device actually received or parsed the route. There was no
"received" state at all, so the strongest, most trustworthy feedback ("the device
got it") was impossible to show.

## The fix

Add a real device → phone acknowledgement and surface it on the button.

**Device (`src/ble_server.cpp`)** — after a full route upload (the always-last
`0x05` "end nav" packet), the firmware notifies back on the route characteristic:
- `0x23` — route received **and** parsed OK
- `0x24` — upload received but the track couldn't be parsed

The outcome is stashed from the BLE write callback and the notify is sent from the
server task loop (matching how the existing route list/delete acks are done, since
you can't safely notify from inside `onWrite`).

**App (`companion-ios`)** — `BLEManager` handles the new opcodes:
- `0x23` → sets a new `routeReceived` flag; the button confirmation upgrades from
  "Sent to device" to **"Received by device"**.
- `0x24` → clears the sent state and posts "Device couldn't read the route — try
  sending again" so the button doesn't falsely claim success.

`RouteView` shows "Received by device" once confirmed, and both flags reset on a new
destination and on disconnect.

### Backward compatible
The optimistic "Sent to device" path is kept. Against firmware that predates this
change (no ack), the button still shows "Sent to device" exactly as before — no
regression. Against new firmware it strengthens to "Received by device". So the
button always indicates *something*, and now it can honestly say the device got it.

Opcodes `0x23`/`0x24` were previously unused on the route characteristic (existing
ones are `0x20` name, `0x21` list-done, `0x22` delete-ack), so there's no collision.

## Testing

**iOS app — type-checks clean** (full `xcodebuild` can't run in this environment; see
"Not verified" below):

```
$ SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
$ swiftc -typecheck -sdk "$SDK" -target arm64-apple-ios17.0-simulator \
    -import-objc-header Sources/BikeGPS-Bridging-Header.h \
    -ISources/H3 -ISources/H3/include Sources/*.swift && echo OK
OK
```
No errors or warnings across all 15 Swift sources.

**Reproducing the original behavior (by code trace):** In `RouteView` → `RouteSummaryCard`,
the confirmation was driven only by `ble.routeSent`, which `uploadRoute` sets `true`
immediately after the write loop finishes queueing packets — before the device has
acknowledged anything. `handleRouteNotify` had cases only for `0x20`/`0x21`/`0x22`;
the device sent no receipt notification, so there was no way to show a device-confirmed
state. After the fix, `handleRouteNotify` gains `0x23`/`0x24` and the card renders
`received ? "Received by device" : "Sent to device"`.

**Opcode wiring checked end to end:** app writes `0x01`–`0x05`; firmware `RouteCb`
reads `0x01`–`0x05` and now replies `0x23`/`0x24`, which the app's `handleRouteNotify`
consumes. The notify block runs unconditionally in the server loop guarded by
`if (routeChr && pendingRouteAck)`, outside the SD-host guard (it needs no SD access).

### Not verified
- **Full app build / on-simulator UI run.** `xcodebuild -sdk iphonesimulator` fails in
  this environment at the asset-catalog step with
  `No simulator runtime version from ["23A339"] available to use with iphonesimulator SDK version 23A337`
  — an installed-runtime vs SDK mismatch, unrelated to this change (it fails the same
  way on unmodified `main`). I verified the Swift via `swiftc -typecheck` instead.
  A human should build and run the app in Xcode and confirm the Route tab shows the
  "Received by device" state end to end.
- **Firmware build/flash.** The ESP32 firmware can't be built here: platformio needs
  the vendored board repo `vendor/T5S3-4.7-e-paper-PRO`, which is gitignored and not
  present (clone per `platformio.ini`), and a first-time build would be very slow.
  The C++ change is small and mirrors the existing list/delete-ack pattern, but a
  human should `pio run` (and ideally flash a board, send a route, and watch for the
  serial line plus the app flipping to "Received by device"). Since the app is
  backward compatible, merging the app side alone is safe even before firmware ships.


Closes #17

🤖 Opened by issue-fixer.