### PR TITLE
Start map area-selection zoomed out enough to show 3–4 tiles

### DIFF
--- a/companion-ios/Sources/MapsView.swift
+++ b/companion-ios/Sources/MapsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import MapKit
 import CoreLocation
+import Combine
 
 // Draw a box on the map; the app covers it with H3 hexagon tiles (~5.6 km
 // across), skips the ones already on the device, fetches OSM for the rest, and
@@ -12,9 +13,17 @@ struct MapsView: View {
     @EnvironmentObject var ble: BLEManager
     @Environment(\.dismiss) private var dismiss
 
-    @State private var cam: MapCameraPosition = .userLocation(fallback: .region(
+    // Res-6 H3 tiles are ~5.6 km across; start wide enough to show at least
+    // 3–4 of them across the screen (~0.25° ≈ 22 km) so a whole area is easy to
+    // box in one drag. `.userLocation` would snap to MapKit's default
+    // street-level zoom (far too tight for tile selection), so we center on the
+    // user ourselves once a fix arrives (see `locator`), keeping this fixed
+    // span. Falls back to a fixed region until then.
+    @State private var cam: MapCameraPosition = .region(
         MKCoordinateRegion(center: .init(latitude: 37.7764, longitude: -122.4346),
-                           span: MKCoordinateSpan(latitudeDelta: 0.15, longitudeDelta: 0.15))))
+                           span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25)))
+    @StateObject private var locator = MapLocator()
+    @State private var didCenter = false
     @State private var dragStart: CGPoint?
     @State private var dragEnd: CGPoint?
     @State private var box: (s: Double, w: Double, n: Double, e: Double)?
@@ -133,7 +142,16 @@ struct MapsView: View {
             }
             .navigationBarHidden(true)
             .safeAreaInset(edge: .bottom) { bottomBar }
-            .onAppear { ble.refreshDeviceMaps(); ble.refreshDeviceTiles() }
+            .onAppear { ble.refreshDeviceMaps(); ble.refreshDeviceTiles(); locator.start() }
+            // Center on the user's first fix, once, at our fixed tile-friendly
+            // span. Only before any interaction so it never yanks the map away
+            // from a box the user is drawing.
+            .onReceive(locator.$coordinate) { coord in
+                guard !didCenter, box == nil, !drawMode, let coord else { return }
+                didCenter = true
+                cam = .region(MKCoordinateRegion(center: coord,
+                    span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25)))
+            }
         }
     }
 
@@ -365,4 +383,30 @@ struct MapsView: View {
         let pad = 0.003
         return (s - pad, w - pad, n + pad, e + pad)
     }
+}
+
+// Publishes the user's location so the map can center itself at a fixed,
+// tile-friendly zoom on the first fix. (MapKit's `.userLocation` follow mode
+// gives no control over the zoom, so we position the camera ourselves.)
+@MainActor final class MapLocator: NSObject, ObservableObject, CLLocationManagerDelegate {
+    @Published var coordinate: CLLocationCoordinate2D?
+    private let manager = CLLocationManager()
+
+    override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    func start() {
+        manager.requestWhenInUseAuthorization()
+        manager.requestLocation()
+        if let c = manager.location?.coordinate { coordinate = c }
+    }
+
+    nonisolated func locationManager(_ m: CLLocationManager, didUpdateLocations locs: [CLLocation]) {
+        guard let c = locs.last?.coordinate else { return }
+        Task { @MainActor in self.coordinate = c }
+    }
+
+    nonisolated func locationManager(_ m: CLLocationManager, didFailWithError error: Error) {}
 }


### PR DESCRIPTION
## Problem

The map area-selection UI (`MapsView`, used to send maps to the device) started too zoomed in. The camera was initialized with `.userLocation(fallback:)`, which snaps to MapKit's *default* street-level follow zoom (roughly a few city blocks) once a location fix arrives. That gives no control over the zoom, so you land far too tight to box a whole area in one drag. Even the fallback region span (`0.15°` ≈ 16 km) only covered ~2–3 res-6 H3 tiles across the screen at San Francisco's latitude.

Res-6 H3 tiles — the map tiling unit — are ~5.6 km across. The issue asks for at least 3–4 tiles visible across the screen.

## Fix

`companion-ios/Sources/MapsView.swift`:

- Replaced the `.userLocation(fallback:)` camera with a fixed `.region` whose span is `0.25°` (≈ 22 km). On a portrait phone the width is the limiting dimension, so MapKit shows at least `0.25°` of longitude across the screen — ≈ 3.9 tiles at SF's latitude, comfortably meeting the 3–4 tile target — and more vertically.
- Added a small `MapLocator` (`CLLocationManagerDelegate`, matching the existing `CLLocationManager` pattern already used in `RouteView`/`BLEManager`) that publishes the user's location. On the *first* fix the view recenters on the user at that same fixed `0.25°` span, so we get "centered on me" without inheriting MapKit's tight default zoom.
- The recenter is guarded (`!didCenter, box == nil, !drawMode`) so it fires only once and never yanks the map away while a box is being drawn.

`NSLocationWhenInUseUsageDescription` is already present in `Info.plist` (the app already requests location elsewhere), so the added `requestWhenInUseAuthorization()` won't crash.

## Testing

The app is an iOS SwiftUI target. This sandbox has Xcode 26 + the iOS Simulator 26.0 SDK, but the installed simulator *runtime* build (`23A339`) doesn't match the SDK build (`23A337`), so a full `xcodebuild` fails at the asset-catalog (`actool`) step — an environment mismatch unrelated to the change:

```
Sources/Assets.xcassets: error: No simulator runtime version from ["23A339"]
available to use with iphonesimulator SDK version 23A337
```

To verify the Swift itself compiles, I type-checked every source file against the simulator SDK (this bypasses `actool`):

```
$ SDK=$(xcrun --sdk iphonesimulator26.0 --show-sdk-path)
$ swiftc -typecheck -sdk "$SDK" -target arm64-apple-ios17.0-simulator \
    -import-objc-header Sources/BikeGPS-Bridging-Header.h \
    -I Sources/H3/include -I Sources/H3 \
    $(ls Sources/*.swift)
swiftc exit: 0
=== error lines ===
0
```

Zero errors, zero warnings — the modified `MapsView.swift` (including the new `MapLocator`, the `Combine` import for `.onReceive`, and the `@StateObject`) compiles cleanly with the rest of the app.

Reproduction / behavior reasoning (span math, since I can't drive the simulator here):
- Before: `.userLocation` → MapKit default follow zoom (~city-block level) once located; fallback `0.15°` ≈ 16.6 km lat, and at SF (37.7°N) `0.15°` lon ≈ 13.2 km ≈ 2.3 tiles across — too few, matching the report.
- After: `0.25°` span → `0.25°` lon at SF ≈ 111 × 0.25 × cos(37.7°) ≈ 21.9 km ≈ **3.9 tiles across**, and MapKit's region-fit guarantees the requested span is fully visible (never less), so the horizontal count is a floor.

### Not verified
I could not launch the app in the simulator (runtime/SDK build mismatch above) or exercise the live location-recenter on device, so I verified compilation and reasoned through the zoom math rather than observing the map on screen. Before merging, a human should run the companion app on a simulator/device with a matching runtime, open the Maps (Route → tiles) area-selection screen, and confirm it opens showing ≥3–4 hex tiles across and recenters on the user at that zoom.


Closes #19

🤖 Opened by issue-fixer.