### PR TITLE
Website tile layout + rescue orphaned analysis notes

### DIFF
--- a/docs/mapgen-ui.js
+++ b/docs/mapgen-ui.js
@@ -5,7 +5,8 @@ import { latLngToCell, gridDisk, cellToBoundary }
   from "https://cdn.jsdelivr.net/npm/h3-js@4.1.0/+esm";
 
 // H3 res-6 tiling, mirroring the app's companion-ios/Sources/H3/h3shim.c so the
-// website builds the exact same per-hex tiles (/maps/tiles/<h3id>.ebm).
+// website builds the exact same per-hex tiles
+// (/maps/tiles/<first 6 of h3id>/<rest>.ebm).
 const H3_RES = 6;
 function cellBbox(cell) {
   const verts = cellToBoundary(cell);         // [[lat, lng], ...]
@@ -33,15 +34,29 @@ function coveringCells(bb) {
   }
   return out;
 }
-// Keep a tile only if it holds road geometry — the app drops tiles whose road
-// encode is header-only. Reads the EBM2 index for any non-zero tile offset.
-function ebmHasRoads(bytes) {
+// Keep a tile if it holds ANYTHING — roads, water, sea fill or parks.
+//
+// This used to test roads alone, which threw away every hex that is pure water:
+// buildEbm() appends WTR2/PRK2 sections after the road index, so an ocean hex
+// has real content and an empty road index. Dropping it meant a bay rendered as
+// blank paper. (The phone app had the identical bug — see MapBuilder.isEmpty.)
+function ebmHasContent(bytes) {
   const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const nx = dv.getInt32(28, true), ny = dv.getInt32(32, true);
   for (let k = 0; k < nx * ny; k++) {
-    if (dv.getUint32(36 + k * 8, true) !== 0) return true;
+    if (dv.getUint32(36 + k * 8, true) !== 0) return true;   // a road tile
   }
-  return false;
+  // No roads: anything past the header + index is a water/park/sea section.
+  return bytes.length > 36 + nx * ny * 8;
+}
+
+// Where a tile lives on the card: /maps/tiles/<first 6 of id>/<rest>.ebm.
+// Must match tileDirFor() in src/map_store.cpp — an H3 id's leading characters
+// are a geographic key, so one area lands in one directory.
+function tilePath(id) {
+  return id.length > 6
+    ? `maps/tiles/${id.slice(0, 6)}/${id.slice(6)}.ebm`
+    : `maps/tiles/${id}.ebm`;
 }
 
 const $ = (id) => document.getElementById(id);
@@ -241,16 +256,17 @@ function init() {
       for (let ci = 0; ci < cells.length; ci++) {
         const c = cells[ci];
         const ebm = buildEbm(json, { s: c.s, w: c.w, n: c.n, e: c.e });
-        if (ebmHasRoads(ebm)) files.push({ name: `maps/tiles/${c.id}.ebm`, data: ebm });
+        if (ebmHasContent(ebm)) files.push({ name: tilePath(c.id), data: ebm });
         setStatus(`Building tiles… ${ci + 1}/${cells.length}`);
         if (ci % 6 === 5) await new Promise((r) => setTimeout(r, 0));  // keep UI live
       }
       if (files.length === 0) {
-        throw new Error("No roads found in that area — try a different or larger box.");
+        throw new Error("Nothing found in that area — try a different or larger box.");
       }
 
       // Package as a ZIP laid out for the SD card: unzip onto the card root and
-      // the tiles land at /maps/tiles/<h3id>.ebm — exactly where the app puts them.
+      // the tiles land at /maps/tiles/<first 6 of h3id>/<rest>.ebm — exactly where
+      // the app and firmware put them.
       const zip = zipStore(files);
       const bytes = files.reduce((a, f) => a + f.data.length, 0);
       const blob = new Blob([zip], { type: "application/zip" });
@@ -259,7 +275,7 @@ function init() {
       genDownload.download = `bikegps-tiles-${name}.zip`;
       genDownload.textContent = `⬇ Download ${files.length} tiles (${fmtBytes(zip.length)})`;
       genDownload.hidden = false;
-      log(`Done: ${files.length} tiles, ${fmtBytes(bytes)}. Unzip onto the SD card root → /maps/tiles/. These are the same H3 tiles the app builds.`);
+      log(`Done: ${files.length} tiles, ${fmtBytes(bytes)}. Unzip onto the SD card root → /maps/tiles/<area>/. These are the same H3 tiles the app builds.`);
       setStatus("Tiles ready — download the ZIP below.", "ok");
     } catch (err) {
       log("Error: " + (err && err.message ? err.message : String(err)));

--- a/docs/mapgen.js
+++ b/docs/mapgen.js
@@ -25,11 +25,16 @@ export const OVERPASS_ENDPOINTS = [
   "https://maps.mail.ru/osm/tools/overpass/api/interpreter",
 ];
 
+// Coastline uses a PADDED bbox (%CS,%CW,%CN,%CE), everything else the drawn
+// one. Sea fill needs the COAST, and a box drawn out in open water contains
+// none — no coastline ways means no sea rings, so those hexes came out blank.
+// Only the coastline filter is widened, so this does not drag in roads for the
+// whole padded area.
 const QUERY = `[out:json][timeout:90];
 (
   way["highway"~"^(motorway|trunk|primary|secondary|tertiary|residential|unclassified|living_street|pedestrian|cycleway|footway|path|track|steps)"](%S,%W,%N,%E);
   way["natural"="water"](%S,%W,%N,%E);
-  way["natural"="coastline"](%S,%W,%N,%E);
+  way["natural"="coastline"](%CS,%CW,%CN,%CE);
   way["leisure"="park"](%S,%W,%N,%E);
   way["landuse"~"^(grass|forest|meadow|recreation_ground|cemetery|village_green)$"](%S,%W,%N,%E);
   way["natural"~"^(wood|scrub|grassland|heath)$"](%S,%W,%N,%E);
@@ -590,8 +595,14 @@ export function buildEbm(json, { s, w, n, e, tileDeg = TILE_DEG, simplifyM = SIM
 // retry pass. `onStatus(text)` reports which mirror is being tried.
 export async function fetchOverpass({ s, w, n, e }, onStatus = () => {}) {
   const bbox = { S: String(s), W: String(w), N: String(n), E: String(e) };
-  const q = QUERY.replace(/%S/g, bbox.S).replace(/%W/g, bbox.W)
-                 .replace(/%N/g, bbox.N).replace(/%E/g, bbox.E);
+  // ~0.35 deg (~35 km) reaches the shore from anywhere a box would sensibly be
+  // drawn. Matches the padding MapBuilder.fetchCoastline uses in the app.
+  const PAD = 0.35;
+  const q = QUERY
+    .replace(/%CS/g, String(s - PAD)).replace(/%CW/g, String(w - PAD))
+    .replace(/%CN/g, String(n + PAD)).replace(/%CE/g, String(e + PAD))
+    .replace(/%S/g, bbox.S).replace(/%W/g, bbox.W)
+    .replace(/%N/g, bbox.N).replace(/%E/g, bbox.E);
   const body = "data=" + encodeURIComponent(q);
 
   const total = OVERPASS_ENDPOINTS.length * 2;

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -112,7 +112,7 @@
   <div class="wrap">
     <p class="kicker">02 — Generate an offline map</p>
     <h2>Build offline map tiles</h2>
-    <p class="sub">Pick an area and the browser bakes the very same <code>H3</code> map tiles the companion app builds — one <code>.ebm</code> per hexagon under <code>/maps/tiles</code> on the SD card. Everything runs locally from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> data (via <a href="https://overpass-api.de/">Overpass</a>); nothing is uploaded. (The app additionally bakes in elevation; that&rsquo;s the one thing the browser leaves out.)</p>
+    <p class="sub">Pick an area and the browser bakes the very same <code>H3</code> map tiles the companion app builds — one <code>.ebm</code> per hexagon under <code>/maps/tiles/&lt;area&gt;/</code> on the SD card. Everything runs locally from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> data (via <a href="https://overpass-api.de/">Overpass</a>); nothing is uploaded. (The app additionally bakes in elevation; that&rsquo;s the one thing the browser leaves out.)</p>
 
     <div class="flash-steps">
       <div class="flash-step">

--- a/investigations/archive/README.md
+++ b/investigations/archive/README.md
@@ -1,0 +1,17 @@
+# Archived analysis
+
+Working documents from earlier investigations, recovered from agent worktrees
+under `.claude/worktrees/` before those were deleted. They were never committed,
+yet `src/power_mgmt.cpp` and `sdkconfig.defaults.pm` cited `CPU_SLEEP_SPIKE.md`
+by name — a reference that pointed at nothing for anyone who cloned the repo.
+
+Point-in-time, not maintained. Where they disagree with
+`../battery-life.md` or `../pm-rebuild-baseline.md`, those are current.
+
+| File | What it covers |
+|---|---|
+| `cpu-sleep-spike.md` | The original CPU light-sleep spike: why the stock Arduino framework compiles PM out, and what enabling it would take |
+| `cpu-sleep-libbuild.md` | Rebuilding the Arduino S3 libraries with `CONFIG_PM_ENABLE` via esp32-arduino-lib-builder |
+| `display-ghosting-analysis.md`, `display-ghosting-v3.md` | E-paper ghosting and grey drift |
+| `battery-analysis.md` | Early power apportionment, superseded by the measurements in `../battery-life.md` |
+| `navigation-analysis.md` | Route/turn-by-turn analysis, predating the algorithm fixes and host tests in `tools/route_test` |

--- a/investigations/archive/battery-analysis.md
+++ b/investigations/archive/battery-analysis.md
@@ -1,0 +1,198 @@
+# Battery-Life Analysis — Open E-Paper Bike Computer (LilyGO T5S3 4.7" PRO)
+
+Firmware `v0.84`, ESP32-S3 @ 240 MHz, 1500 mAh cell. Analysis of the real ride-day
+diagnostic log `bikegps-diag 6.log` (623 lines, 108 battery samples over 3.73 h)
+plus a read of the `src/` power consumers.
+
+---
+
+## 1. Log analysis (measured)
+
+### Discharge rate & runtime
+The device charged/topped-off for the first ~1 h, then discharged continuously from
+`01:03` to the end of the log.
+
+| Metric | Value |
+|---|---|
+| Discharging samples (I<0) | 84 of 108 |
+| Mean discharge current | **−181 mA** (median −182, σ 11.6) |
+| Active-riding mean | −185 to −190 mA |
+| Idle (GPS searching / post-ride, no active ride) | **−162 to −166 mA** |
+| SOC slope | 100 % → 67 %, i.e. **−12.2 %/h** |
+| Fuel-gauge coulomb slope | 1495 → 1002 mAh = **−182 mAh/h** |
+| Voltage sag | 4109 mV (100 %) → 3763 mV (67 %) — healthy Li-ion curve, no brownout |
+
+**Estimated runtime from full (1500 mAh):**
+- To 0 %: `1500 / 181 ≈ ` **8.2 h**
+- Usable (100 %→~5 %): **~7.4 h**
+- Coulomb-based agrees: `1500 / 182 ≈ 8.2 h`
+
+So this build gets roughly **8 hours** of GPS-recording ride time — modest for a 1500 mAh
+cell; the drain is high and dominated by a large *baseline*, not by peaks.
+
+### Phase breakdown
+
+| Window | n | Mean mA | Notes |
+|---|---|---|---|
+| Pre-ride, GPS searching `01:03–01:10` | 4 | −162 | no ride, no HR, phone connected |
+| Ride start + HR connect `01:10–01:21` | 6 | −187 | recording begins `01:10`, HR up `01:11` |
+| Riding `01:21–02:13` | 26 | −190 | peaks to −214 |
+| Riding `02:13–03:03` | 25 | −182 | |
+| Ride end + FIT download `03:03–03:20` | 8 | −180 | ride saved 28.84 km / 7817 s at `03:20:51` |
+| Post-ride idle `03:21+` | 13 | −166 | recording stopped, HR dropped |
+
+**Key structural finding: the baseline is ~165 mA and active riding only adds ~20–25 mA.**
+The device is expensive *just sitting there powered on* — the levers that matter are the
+always-on consumers (backlight, CPU/BT, GPS), not the per-second refresh.
+
+### Anomalies
+- **Unreliable `charging`/`discharging` word.** The fuel-gauge `getIsCharging()` flag
+  (`main.cpp:65,83`) is noisy: many samples read "charging" while current is clearly
+  negative, e.g. `01:03 … -174mA charging`. **Trust the current sign, not the word.**
+  (The log format should print the state from `ma < 0`, not the gauge flag.)
+- **Three unexplained power-on resets in the first hour** — boots at log lines 47/120/169,
+  all `reset: power-on / power-loss [1]` (`ESP_RST_POWERON`), with **no preceding
+  `shutdown:` line**. These are during bench setup/charging (there's also a deliberate
+  `gps power-cycle test` at `00:13` and an `auto-sleep` at `00:54`), so likely the battery
+  connector / USB being handled — but a true brownout would look identical. Worth a
+  glance; not implicated in ride drain.
+- **Current spikes to −214 mA** at `01:39` and several −200+ readings while riding —
+  consistent with the periodic GL16 full-refresh (every 24 DU), map redraws, and SD FIT
+  flushes coinciding. Brief; small energy.
+- **BLE link instability:** repeated `reason 520` (supervision timeout) disconnects, with a
+  reconnect storm at `02:38–02:40` (8 reconnects in 2 min). Each reconnect re-runs
+  `updateConnParams` and restarts advertising — minor power, but a symptom of the
+  aggressive 30 ms / latency-0 link (see §3).
+
+---
+
+## 2. Power budget — apportioning the ~165 mA baseline
+
+No per-rail instrumentation exists in the log, so this is a datasheet-plus-measured-delta
+estimate. The firm anchors are: idle baseline ≈ **165 mA**, active adds ≈ **20 mA**, and
+the idle→active delta is small.
+
+| Subsystem | Est. avg mA | Confidence | Reasoning |
+|---|---|---|---|
+| **Backlight (front LED)** | **25–55** | **medium/high** | Default level is **2 of 3** (`settings.cpp:13 bl=2`), PWM **110/255 ≈ 43 %** into the PT4103 boost driver (`config.h:39`, `ui_dashboard.cpp:87,91`). On an e-paper device this is *always on unless the rider turns it off*, and is a prime suspect for why baseline is 165 mA and not ~110. |
+| **ESP32-S3 @ 240 MHz + BT, never light-sleeps** | 55–80 | medium | Every task busy-polls: UI loop 30 ms (`ui_dashboard.cpp:1313`), GPS 50 ms (`gps_service.cpp:718`), BLE server 100 ms, sensors 1 s. FreeRTOS idle almost never runs, so the core stays at 240 MHz with the BT controller active. |
+| **GPS (CASIC receiver + 3V3 rail)** | 20–30 | high | Rail (`IOEXP_PIN_RADIO_POWER`) is driven HIGH at boot (`main.cpp:164`) and **held on continuously**; only toggled by the power-cycle test and shutdown. A CASIC receiver tracking draws ~20–30 mA. |
+| **E-paper refresh (1 Hz DU)** | 10–20 | medium | Full re-render + DU push once/sec while values change (`ui_dashboard.cpp:1198`), panel powered off between passive updates (`refresh()` `epd_poweroff` at :252). ~0.3 s of panel draw per second. Present in *both* idle and active baselines. |
+| **BLE: phone link + advertising + sensor scan** | 8–18 | medium | Phone link at 15–30 ms, latency 0 (`ble_server.cpp:576`); active scan 30 ms/100 ms = 30 % duty while it runs. See §3 for the scan-forever bug. |
+| **LoRa (SX126x on shared rail, unused)** | 1–5 | low | Rail powers LoRa too; chip is only CS-deselected (`ride_recorder.cpp:232`), **never put to sleep** — idles at a few mA. |
+| **Fuel gauge / RTC / IO-expander / touch (I2C)** | 2–5 | low | small housekeeping. |
+
+Rough sum ≈ 120–210 mA, centering on the observed ~165 mA. The two dominant, *avoidable*
+chunks are **backlight (if left on)** and **CPU/BT never sleeping**.
+
+---
+
+## 3. Ranked recommendations
+
+Ordered by value ÷ risk. Savings are estimates against the ~181 mA active baseline; each is
+independently testable by logging mean current before/after over a fixed window (the log
+already prints signed mA every 2 min — that is the measurement rig).
+
+### R1 — Stop the all-ride active BLE scan for unpaired sensors ✅ *(drafted, see §4)*
+**Save ~5–12 mA (~3–6 % → +0.2–0.5 h). Risk: very low. High confidence.**
+`ble_sensors.cpp:354` computes `allConnected` over **all three** sensor kinds (HR / Power /
+Cadence). If the rider only paired an HR strap (as in this log — HR connects `01:11`, power
+& cadence never), Power and Cadence can never connect, so `allConnected` stays false and —
+because `ride_recorder::isRecording()` holds `wantScan` true (`:364`) — the radio
+**active-scans at 30 % duty for the entire 2 h 11 m ride** hunting for sensors that don't
+exist. The code comment even warns about this case but the check doesn't honor it.
+*Fix:* only let *paired* kinds (non-empty `settings::sensorAddr(k)`) gate scanning. Once the
+paired HR is up, scanning stops. **Testable:** compare mean mA during recording with only an
+HR strap paired, before vs. after.
+
+### R2 — Default the backlight OFF (or auto-off in daylight)
+**Save ~25–55 mA (~15–30 % → +1.5–3 h) if the rider had it on. Risk: low (UX/config).**
+Default level is **2** (`settings.cpp:13`). E-paper is readable in daylight without a
+frontlight; a bike computer should default to **0 (off)** and let the rider bump it. This is
+the single largest potential win but it's a *policy* change (the rider may want the light),
+so it's R2 not R1. Cheap variants: default to level 1, or add an auto-off timeout that drops
+the backlight after N seconds of no touch (like the display idle logic already does).
+**Testable:** log mean mA at each of the 4 levels for 2 min each.
+
+### R3 — Relax the phone BLE connection parameters when idle
+**Save ~3–10 mA. Risk: low–medium. Medium confidence.**
+`ble_server.cpp:576` requests 15–30 ms interval, **latency 0**, for *every* connection to
+keep bulk transfers (ride download / OTA) fast. But the steady state is a **1 Hz status
+notify** (`ble_server.cpp:1156`) — 30 ms/latency-0 forces both the ESP32 and the phone to
+wake ~33×/s for nothing. *Fix:* after a transfer completes (or if none is active), call
+`updateConnParams` with a longer interval + non-zero slave latency (e.g. 30–60 ms, latency
+4 → effective ~150 ms wake), and tighten back to fast params at the start of a
+download/OTA. This may also calm the `reason 520` reconnect storm. **Risk:** iOS caps
+latency and can renegotiate; test that downloads/OTA still run at full speed.
+
+### R4 — Duty-cycle / idle the GPS rail when stopped and not recording
+**Save up to ~20–30 mA while parked; ~0 while riding. Risk: medium.**
+The GPS rail is on 100 % of the time (`main.cpp:164`). While *not recording and stopped*,
+the receiver doesn't need continuous 1 Hz fixes. Options, cheapest first: (a) rely on the
+existing 10-min auto-sleep (`ui_dashboard.cpp:1082`) — already good; (b) put the CASIC into
+its low-power/periodic mode when stopped; (c) power the rail down between fixes. **Caveat:**
+we already tuned this rail for first-fix time — cutting power loses the hot-start RAM and
+hurts TTFF, so any duty-cycling must keep backup power or only engage when clearly idle.
+Net ride savings are small (you need GPS while riding); the win is a parked device.
+Also cheap: explicitly put the unused **LoRa SX126x to sleep** at boot (~1–5 mA).
+
+### R5 — Light-sleep the CPU between 1 Hz work
+**Potentially save ~20–40 mA. Risk: medium–high. Lower confidence.**
+Every task busy-polls on short `vTaskDelay`s, so the core never idles enough to clock down.
+Automatic light-sleep (`esp_pm_config` with `light_sleep_enable`) could gate the core
+between BLE/GPS events, but ESP32-S3 automatic light sleep with an **active BT connection
+and OPI PSRAM at 120 MHz** is delicate, and the UI task's 30 ms poll would defeat it anyway.
+Would require reworking UI/touch to be event-driven (interrupt-woken) rather than polled.
+High effort, real payoff, but the riskiest — do last, behind R1–R4.
+
+### R6 — CPU downclock to 160 MHz — ❌ do NOT (documented hazard)
+`main.cpp:137–142` records that a 160 MHz downclock was **removed** because the OPI PSRAM
+panicked at the lower clock and the device boot-looped. Leave at 240 MHz unless octal-PSRAM
+stability at 160 MHz is proven first. Listed only to close the loop.
+
+### Recommendation summary
+
+| # | Change | Est. save | Risk | Effort |
+|---|---|---|---|---|
+| R1 | Don't scan for unpaired sensors mid-ride *(drafted)* | 5–12 mA | very low | tiny |
+| R2 | Backlight default OFF / auto-off | 25–55 mA | low (UX) | tiny |
+| R3 | Relax phone conn params when idle | 3–10 mA | low–med | small |
+| R4 | GPS rail idle when parked + sleep LoRa | ≤20–30 mA parked | med | med |
+| R5 | CPU light-sleep between events | 20–40 mA | med–high | large |
+| R6 | ~~160 MHz downclock~~ | — | unsafe | — |
+
+Doing **R1 + R2 + R3** alone plausibly moves active drain from ~181 mA toward ~120–140 mA,
+i.e. runtime from ~8 h toward **~10–12 h**, with little risk.
+
+---
+
+## 4. Drafted change (uncommitted, NOT flashed): R1
+
+`src/ble_sensors.cpp`, in `task()` — the `allConnected` computation now only counts *paired*
+sensor kinds, so an unpaired Power/Cadence kind no longer pins `wantScan` true for the whole
+ride:
+
+```cpp
+// "All connected" means every PAIRED sensor is connected. A kind the
+// user never paired (no saved address) can never connect, so counting
+// it here would leave allConnected=false forever and keep the radio
+// active-scanning for the entire ride (recording holds wantScan true) —
+// burning power hunting for a power meter / cadence sensor that doesn't
+// exist. Only paired kinds gate scanning; once they're up, scanning stops.
+bool allConnected = true;
+for (int k = 0; k < KIND_COUNT; ++k) {
+    bool paired = settings::sensorAddr(k)[0] != 0;
+    if (paired && !sensors[k].connected) allConnected = false;
+}
+```
+
+- **Why safe:** purely narrows *when* the radio scans; no change to pairing, connection, or
+  data flow. A rider with all sensors paired sees identical behavior. Scanning still resumes
+  briefly if a paired sensor drops (`onDisconnect` clears `connected`) or during the Sensors
+  screen / 30 s post-interaction window.
+- **Verify before flashing:** confirm `settings::sensorAddr(int)` is safe to call from the
+  BLE task each second (it reads NVS-backed cached strings — cheap; used identically at
+  `ble_sensors.cpp:214`). Then measure mean mA during a recording with only an HR strap
+  paired, before vs. after.
+
+_Left uncommitted; nothing flashed._

--- a/investigations/archive/cpu-sleep-libbuild.md
+++ b/investigations/archive/cpu-sleep-libbuild.md
@@ -1,0 +1,338 @@
+# CPU Sleep — Option A: rebuild the Arduino **core 2.x** libs with PM enabled
+
+**Goal:** turn the already-in-tree light-sleep wiring (`src/power_mgmt.{h,cpp}`,
+called from `main.cpp`) from a graceful no-op into a live light-sleep config —
+**without** migrating to Arduino core 3.x / pioarduino. We stay on
+`espressif32@6.5.0` (Arduino 2.0.14) / can bump to `@6.13.0` (2.0.17), and rebuild
+just the precompiled ESP32-S3 libraries with `CONFIG_PM_ENABLE=y` (+ tickless
+idle + BT modem sleep) using **`espressif/esp32-arduino-lib-builder`**.
+
+**Status of THIS run:** I produced the complete, verified-as-far-as-safe build
+recipe (exact repo/branch, the precise IDF-4.4 sdkconfig deltas, the PlatformIO
+integration diff) and settled the BLE-clock question from the vendor config. I
+**did not execute the multi-GB from-source build** in this environment because
+**Docker's daemon is down and the disk is at 96% (18 GB free)** — starting a
+full IDF-4.4 install + S3 build there risks filling the user's disk. The exact
+runnable script to finish it on a machine with headroom is in §2. Nothing was
+flashed.
+
+---
+
+## 0. Why the stock framework can't sleep (confirmed this run)
+
+`~/.platformio/packages/framework-arduinoespressif32` is
+`3.20017.241212` = **Arduino core 2.0.17, ESP-IDF 4.4.7** (verified:
+`tools/sdk/esp32s3/include/esp_common/include/esp_idf_version.h` → 4.4.7).
+
+In `tools/sdk/esp32s3/sdkconfig`:
+| Option | Stock | Line |
+|---|---|---|
+| `CONFIG_PM_ENABLE` | `# ... is not set` | 1147 |
+| `CONFIG_FREERTOS_USE_TICKLESS_IDLE` | absent | — |
+| `CONFIG_BT_CTRL_MODEM_SLEEP` | `# ... is not set` | 467 |
+| `CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240` | `=y` | 910 |
+| `CONFIG_ESP32S3_RTC_CLK_SRC_INT_RC` | `=y` | 988 |
+
+`nm tools/sdk/esp32s3/lib/libesp_pm.a` shows `esp_pm_configure` present as a
+**defined stub** → the drafted firmware links & runs on stock, it just gets
+`ESP_ERR_NOT_SUPPORTED` and logs "PM unavailable". Confirmed the drafted
+`src/power_mgmt.cpp` handles exactly that (`begin()` returns false on
+`ESP_ERR_NOT_SUPPORTED`).
+
+### The precompiled-lib layout that matters for integration
+`tools/sdk/esp32s3/` has a common `lib/` (holds **`libesp_pm.a`**, 171 KB) plus
+per-memory-type override dirs. The board is `qio_opi`
+(`vendor/.../boards/T5-ePaper-S3.json` → `"memory_type": "qio_opi"`), so the app
+links `lib/*` **overridden by** `qio_opi/*`, which contains only the
+PSRAM-mode-sensitive libs:
+```
+qio_opi/  libbootloader_support.a  libesp_hw_support.a  libesp_system.a
+          libfreertos.a  libspi_flash.a  sections.ld  include/sdkconfig.h
+```
+Verified `qio_opi/include/sdkconfig.h` has `CONFIG_SPIRAM_MODE_OCT 1` +
+`CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240 1` but **no** `CONFIG_PM_ENABLE` /
+`FREERTOS_USE_TICKLESS_IDLE` / `BT_CTRL_MODEM_SLEEP`. So PM is off in both the
+compiled `.a`s and the compile-time header. A correct rebuild must regenerate
+**both** the common `lib/` and the `qio_opi/` override (esp. `libfreertos.a`,
+which carries tickless idle) — the lib-builder does this automatically (see §1).
+
+### IMPORTANT naming correction vs the prior spike
+The prior spike's `sdkconfig.defaults.pm` uses **IDF-5.x** Kconfig names
+(`CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240`, `CONFIG_RTC_CLK_SRC_INT_RC`,
+`CONFIG_SPIRAM_MODE_OCT`, `CONFIG_SPIRAM_LEAKAGE_WORKAROUND`) because it targeted
+the pioarduino/IDF-5 path. **For Option A (IDF 4.4.7) the names are different** —
+S3-scoped options are `ESP32S3`-prefixed. Use the deltas in §1.2 below, not the
+IDF-5 file.
+
+---
+
+## 1. The lib-builder build
+
+### 1.1 Repo & branch
+- Repo: `https://github.com/espressif/esp32-arduino-lib-builder`
+- Branch: **`release/v4.4`** (there is no `idf-release_v4.4` *tag*; the 4.4 line
+  lives on the branch, HEAD `3eb9cb06` as of this run). This branch's
+  `tools/install-esp-idf.sh` checks out **ESP-IDF v4.4.x** and Arduino core
+  **2.0.x**, matching the framework we ship against. (The `idf-release_v5.x`
+  tags are the 3.x line — do NOT use them for Option A.)
+
+### 1.2 The sdkconfig deltas (IDF 4.4.7 names)
+Realized as a config fragment `configs/defconfig.pm` (build.sh appends any config
+name you pass as a positional arg → `configs/defconfig.<name>`). Exact contents:
+
+```ini
+# ---- Power management: automatic light sleep, NO DFS ----
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
+CONFIG_PM_SLP_IRAM_OPT=y
+CONFIG_PM_RTOS_IDLE_OPT=y
+# Keep CPU pinned at 240; runtime uses esp_pm_configure(min==max==240) so DFS
+# never clocks the APB down while 80 MHz OPI PSRAM is live (avoids the boot loop):
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+# RTC slow clock = internal 150 kHz RC (board has NO 32k xtal on the S3 — §4):
+CONFIG_ESP32S3_RTC_CLK_SRC_INT_RC=y
+# BLE controller modem sleep, LP clock from RTC slow (survives light sleep):
+CONFIG_BT_CTRL_MODEM_SLEEP=y
+CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y
+# Sleep leakage workarounds (already on in stock; keep explicit):
+CONFIG_ESP_SLEEP_PSRAM_LEAKAGE_WORKAROUND=y
+CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND=y
+```
+
+Notes on the choices:
+- `CONFIG_PM_DFS_INIT_AUTO` does **not** exist in IDF 4.4 (it's IDF-5). DFS is
+  suppressed purely at runtime by `min_freq_mhz == max_freq_mhz == 240` in
+  `power_mgmt::begin()` — no build option needed. Do **not** add it.
+- Leave `CONFIG_SPIRAM_MODE_OCT` / `CONFIG_SPIRAM_SPEED_80M` to the lib-builder's
+  own `configs/defconfig.opi_ram` + `defconfig.80m` (the `opi_ram` mem-variant),
+  which is exactly how the stock `qio_opi` libs are produced. Don't pin PSRAM
+  mode in `defconfig.pm` — it must stay per-mem-variant.
+- Put `defconfig.pm` in the build so it lands in **every S3 sub-build**. build.sh
+  builds each variant as `defconfig.common;defconfig.esp32s3;<mem/flash>` — the
+  cleanest way to force PM into all of them (incl. the `qio_opi` `libfreertos.a`
+  and the generated `qio_opi/include/sdkconfig.h`) is to append PM to the S3
+  base. Either (a) `cat configs/defconfig.pm >> configs/defconfig.esp32s3`, or
+  (b) pass `pm` as a trailing config to a `-b` sub-build. Option (a) is the
+  reproducible one for a full `-t esp32s3` run (see script).
+
+### 1.3 The runnable build script (finish on a box with disk + Docker/toolchain)
+Save as `build-pm-libs.sh`, run **outside the git repo** (e.g. `~/lib-builder-pm`):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+WORK="$HOME/lib-builder-pm"            # NOT inside the tdisplay worktree
+rm -rf "$WORK" && mkdir -p "$WORK" && cd "$WORK"
+
+git clone -b release/v4.4 --recurse-submodules \
+    https://github.com/espressif/esp32-arduino-lib-builder .
+
+# --- inject PM config into the ESP32-S3 base defconfig ---
+cat >> configs/defconfig.esp32s3 <<'EOF'
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
+CONFIG_PM_SLP_IRAM_OPT=y
+CONFIG_PM_RTOS_IDLE_OPT=y
+CONFIG_ESP32S3_RTC_CLK_SRC_INT_RC=y
+CONFIG_BT_CTRL_MODEM_SLEEP=y
+CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y
+CONFIG_ESP_SLEEP_PSRAM_LEAKAGE_WORKAROUND=y
+CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND=y
+EOF
+# (CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y is already present in that file.)
+
+# Build ONLY the esp32s3 target (idf_libs + bootloaders + all 5 mem variants).
+# First run installs ESP-IDF 4.4.x + the xtensa toolchain (~3–4 GB) and compiles
+# everything (~15–40 min). Needs Python 3, git, cmake, ninja, jq (all present
+# here except idf.py, which install-esp-idf.sh provides).
+./build.sh -t esp32s3
+
+# Output tree lands under:
+#   components/arduino/tools/esp32-arduino-libs/esp32s3/   (the new tools/sdk/esp32s3)
+# containing lib/, qio_opi/, include/, ld/, sdkconfig, flags/, etc.
+```
+
+**Docker alternative (recommended when the host toolchain is uncooperative):**
+```bash
+docker run --rm -v "$PWD":/work -w /work \
+    espressif/esp32-arduino-lib-builder:release-v4.4 \
+    /bin/bash -c "cat configs/defconfig.pm >> configs/defconfig.esp32s3 && ./build.sh -t esp32s3"
+```
+(Requires the Docker daemon running — it is **down** here.)
+
+**Verify the rebuilt libs before integrating** (on the build box):
+```bash
+S3=components/arduino/tools/esp32-arduino-libs/esp32s3
+grep -E 'CONFIG_PM_ENABLE|FREERTOS_USE_TICKLESS_IDLE|BT_CTRL_MODEM_SLEEP' $S3/sdkconfig
+grep -E 'CONFIG_PM_ENABLE|CONFIG_SPIRAM_MODE_OCT' $S3/qio_opi/include/sdkconfig.h
+# Expect CONFIG_PM_ENABLE=y in both, plus SPIRAM_MODE_OCT in the qio_opi header.
+xtensa-esp32s3-elf-nm $S3/lib/libesp_pm.a | grep esp_pm_impl_switch_freq  # now the real impl, not the stub
+```
+
+---
+
+## 2. PlatformIO integration (in the worktree)
+
+Copy the rebuilt S3 SDK tree over a **local** copy of the framework package (so
+the stock global package is untouched), then point PlatformIO at that copy.
+
+```bash
+# from the repo root
+FWSRC=~/.platformio/packages/framework-arduinoespressif32
+cp -R "$FWSRC" ./framework-arduinoespressif32-pm
+# overlay the rebuilt S3 sdk (from the build box output):
+rsync -a --delete \
+  ~/lib-builder-pm/components/arduino/tools/esp32-arduino-libs/esp32s3/ \
+  ./framework-arduinoespressif32-pm/tools/sdk/esp32s3/
+```
+
+`platformio.ini` change (exact diff):
+```diff
+ [env:t5s3-pro]
+ platform = espressif32@6.5.0
+ board = T5-ePaper-S3
+ framework = arduino
++; Use the locally-rebuilt PM-enabled Arduino 2.0.17 libraries. Keeps the
++; espressif32@6.5.0 platform + build scripts; only the precompiled tools/sdk
++; is swapped. Path is relative to this ini file.
++platform_packages =
++    framework-arduinoespressif32 @ file://./framework-arduinoespressif32-pm
+ upload_speed = 921600
+ monitor_speed = 115200
+ monitor_filters = esp32_exception_decoder
+```
+
+Also drop the dead PSRAM define while here (confirmed consumed nowhere; prior
+spike §0):
+```diff
+ build_flags =
+     -DBOARD_HAS_PSRAM
+-    -DPSRAM_SPEED=120MHz
++    ; -DPSRAM_SPEED=120MHz  ; dead define; OPI PSRAM is 80 MHz
+```
+
+`.gitignore` the local copy: `framework-arduinoespressif32-pm/` (it's ~200 MB;
+the reproducible input is the script in §1.3, not the binary tree). If you'd
+rather vendor it, commit only `tools/sdk/esp32s3/{lib,qio_opi,include,ld,sdkconfig}`.
+
+> The `power_mgmt.{h,cpp}` + `main.cpp` hooks + the drafted `sdkconfig.defaults.pm`
+> live in the **main working tree** (uncommitted), not on committed `main` and
+> not in this worktree (which branches from an earlier commit). Before building,
+> make sure `src/power_mgmt.{h,cpp}` and the `power_mgmt::begin()/tick()` calls
+> are present in whatever tree you compile.
+
+---
+
+## 3. Verification
+
+**Done this run:**
+- Framework identified as Arduino 2.0.17 / IDF 4.4.7; PM confirmed compiled out
+  (sdkconfig + `qio_opi/include/sdkconfig.h` + `nm libesp_pm.a` stub).
+- lib-builder `release/v4.4` cloned & inspected; build system traced end-to-end
+  (`build.sh` assembles `defconfig.common;defconfig.$target;<variant>` for
+  `idf_libs` **and** each `mem_variant`, so a base-level PM delta reaches the
+  `qio_opi` libs). `configs/defconfig.pm` fragment authored with correct 4.4
+  names. jq/cmake/ninja present.
+- BLE LP-clock question resolved from hardware config (§4).
+
+**NOT done (blocked by environment):** the actual from-source compile and a
+`pio run -e t5s3-pro` against the rebuilt framework. **Reason:** Docker daemon
+down + disk at 96% (18 GB free) — a full IDF-4.4 install + S3 build could exhaust
+the disk and harm the user's system. No safe way to produce real PM-enabled `.a`s
+here. (A header-only flip of `CONFIG_PM_ENABLE` without rebuilding `libesp_pm.a`
+was deliberately NOT done — it would compile but still call the disabled stub, a
+misleading half-state.)
+
+**Post-build verification checklist (once §1.3 runs on a capable box):**
+1. `grep CONFIG_PM_ENABLE $S3/qio_opi/include/sdkconfig.h` → `=y`.
+2. `pio run -e t5s3-pro` against the §2 framework → still links (the drafted
+   firmware already compiles on stock; PM symbols are unchanged in signature).
+3. Boot log check (no flash — read serial only if someone is at the device):
+   `power_mgmt::begin()` should now log
+   `pm: esp_pm_configure(min=max=240, light_sleep=1) -> ESP_OK`
+   instead of `pm: light sleep UNAVAILABLE`.
+
+---
+
+## 4. BLE low-power-clock decision — RESOLVED
+
+**Decision: internal 150 kHz RC, `CONFIG_ESP32S3_RTC_CLK_SRC_INT_RC=y`, and BLE
+controller LP clock `CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y`. Do NOT select
+EXT_CRYS / EXT_32K_XTAL.**
+
+Evidence the board has **no 32.768 kHz crystal on the ESP32-S3**:
+- Vendor factory/grayscale sdkconfig
+  (`vendor/.../examples/grayscale_test/sdkconfig`) ships
+  `CONFIG_ESP32S3_RTC_CLK_SRC_INT_RC=y` with `EXT_CRYS`/`EXT_OSC` **not set** —
+  LilyGO's own config uses the internal RC.
+- The pinmap (`vendor/.../docs/pinmap.md` §5) lists only the **PCF8563TS** RTC on
+  I²C (SDA=39, SCL=40, INT=2, VRTC via the J12 coin cell). No ESP32-S3
+  `32K_XP`/`32K_XN` crystal is wired. The PCF8563 is a *separate I²C* RTC and
+  does not feed the SoC's RTC slow clock.
+
+Why RTC_SLOW (not main XTAL): the main XTAL is **gated during light sleep**, so
+`CONFIG_BT_CTRL_LPCLK_SEL_MAIN_XTAL` would force the BLE controller to hold a
+no-light-sleep lock → **no CPU sleep while connected**. Sourcing the controller's
+LP clock from the RTC slow clock (fed by the internal RC) keeps it ticking through
+sleep. **Caveat:** the internal RC drifts ~5%, widening BLE wake windows slightly
+— a little extra radio power and, at long connection intervals, a small risk of
+supervision-timeout disconnects. Mitigations: keep a generous supervision timeout
+(the drafted `updateConnParams(... 400)` = 4 s) and measure (§5C). Fitting a 32k
+crystal to the S3 is the only way to tighten this, and is out of scope.
+
+---
+
+## 5. On-bench measurement plan (needs an inline current meter; do after flashing)
+
+Use a Nordic PPK2 or µCurrent+scope on the battery lead. Average current over
+≥60 s per condition; scope the sleep/active duty cycle if possible.
+
+**A. Idle draw, before vs after (the headline).**
+1. Stock framework, on the desk, GPS on, BLE advertising, no phone, screen static
+   → record mA.
+2. PM framework, same → expect the CPU/idle portion to drop as the core sleeps
+   between the ~30 ms UI polls. Report the absolute mA delta (radio/PSRAM
+   self-refresh/EPD bias/sensors are unchanged, so the delta is the CPU win).
+3. Phone connected: (a) legacy 15–30 ms conn interval, (b) relaxed 150–300 ms
+   idle interval (if the `ble_server.cpp` relax change is in). Quantify the
+   connection-interval contribution.
+
+**B. GPS reliability (must not regress).** Cold + warm start, PM on vs off: TTFF
+and fix hold. Watch the SD diag `gps ...: chars= ck=ok/bad`; a rising bad-checksum
+count or stalled `chars` under PM = FIFO overflow (dropped NMEA). The GPS task's
+50 ms poll bounds every sleep to ~48 bytes (< 128-byte HW FIFO) at 9600 baud, so
+no loss is expected. If it regresses, enable the UART1 wake path
+(`#define PM_GPS_UART_WAKEUP` — requires moving `SerialGPS` to `Serial1`, since
+the S3 can only wake from UART0/1). Ride ≥15 min moving vs a PM-off control.
+
+**C. BLE stability.** Phone connected 30+ min at the idle interval; count
+unexpected disconnects (diag "phone disconnected reason"), esp. supervision
+timeout (0x08) — this is where the RC drift would show. Run a full ride
+download / OTA / map upload with PM on: verify the fast interval snaps back
+(throughput unchanged) and re-relaxes after.
+
+**D. Map-render time (guard vs a PSRAM regression).** PSRAM stays 80 MHz OPI, so
+render time should be unchanged. Time a fixed map pan/redraw PM-off vs PM-on;
+confirm ~0 delta. (This is the go/no-go metric if DFS/40 MHz PSRAM is ever
+explored — not now.)
+
+**E. Wake correctness.** Touch + both buttons wake and respond after a long idle;
+the 10 min deep-sleep auto-off still fires; USB replug mid-idle restores the
+console (the no-sleep lock re-acquires).
+
+---
+
+## 6. Remaining steps to finish (ordered)
+1. On a machine with Docker **or** ~15 GB free disk, run the §1.3 script
+   (`./build.sh -t esp32s3`) → produces the PM-enabled `esp32s3` SDK tree.
+2. Run the §1.2 verify greps on the output (`CONFIG_PM_ENABLE=y` in `sdkconfig`
+   **and** `qio_opi/include/sdkconfig.h`).
+3. Overlay into a local framework copy + apply the §2 `platformio.ini` diff.
+4. Ensure `src/power_mgmt.{h,cpp}` + the `main.cpp` hooks are in the tree, then
+   `pio run -e t5s3-pro` → expect a clean link.
+5. (Someone at the device) flash, read serial for the `-> ESP_OK` PM log, then
+   run the §5 bench plan.

--- a/investigations/archive/cpu-sleep-spike.md
+++ b/investigations/archive/cpu-sleep-spike.md
@@ -1,0 +1,362 @@
+# CPU Sleep Spike — automatic light sleep on the e-paper bike computer
+
+**Goal:** make the ESP32-S3 sleep between the ~1 Hz workloads instead of running
+the CPU flat-out at 240 MHz, without dropping GPS fixes or BLE, and without
+re-triggering the OPI-PSRAM boot loop.
+
+**Result up front:** a PM-enabled build **is achievable** on this stack, but
+**not with the stock precompiled Arduino framework** — power management is
+compiled out of it, so `esp_pm_configure()` returns `ESP_ERR_NOT_SUPPORTED` at
+runtime. Enabling light sleep requires rebuilding the framework from source with
+`CONFIG_PM_ENABLE=y` (+ tickless idle + BT modem sleep). The firmware-side
+wiring is drafted and **compiles cleanly against the stock framework today**
+(graceful no-op until the framework is rebuilt). The recommended safe runtime
+config is **light-sleep-only with no DFS (min = max = 240 MHz)**, which sidesteps
+the PSRAM problem entirely.
+
+---
+
+## 0. Verification of the blocker (confirmed)
+
+The precompiled Arduino framework ships PM compiled out. In
+`~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/sdkconfig`:
+
+- `# CONFIG_PM_ENABLE is not set`
+- `# CONFIG_FREERTOS_USE_TICKLESS_IDLE` — absent
+- `# CONFIG_BT_CTRL_MODEM_SLEEP is not set` (line 467)
+- `CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y` (line 910)
+
+`esp_pm.h` confirms the runtime behavior (lines 63–64): `esp_pm_configure()`
+returns `ESP_ERR_NOT_SUPPORTED` "if `CONFIG_PM_ENABLE` is not enabled in
+sdkconfig". The `esp_pm_configure` symbol *is* present in `libesp_pm.a` (it is
+the disabled stub), so **the drafted firmware links and runs safely on stock** —
+it just won't sleep. Both the pinned `espressif32@6.5.0` (Arduino 2.0.14) and the
+installed `@6.13.0` (Arduino 2.0.17) are Arduino 2.x with PM off; this is a
+framework-build property, not a version quirk.
+
+### PSRAM finding (important — corrects an assumption)
+
+The board JSON (`vendor/.../boards/T5-ePaper-S3.json`) uses
+`"memory_type": "qio_opi"` → **octal (OPI) PSRAM**. The `-DPSRAM_SPEED=120MHz`
+build flag in `platformio.ini` **is consumed nowhere** — not in the project
+(`grep` of `src/`), not in the Arduino core/tools. It is a dead define. The
+stock `qio_opi` variant runs **OPI PSRAM at 80 MHz** (`CONFIG_SPIRAM_SPEED_80M`).
+So the device is almost certainly **already at 80 MHz**, not 120 MHz, and the
+`main.cpp:137-142` comment ("runs 120 MHz OPI PSRAM") appears inaccurate. This
+*simplifies* the sleep story: we do **not** need to change PSRAM speed at all.
+
+The real constraint that boot-looped 160 MHz (`main.cpp:137-142`) is that **80 MHz
+OPI PSRAM timing is derived assuming a 240 MHz CPU/APB**; reducing the clock while
+PSRAM is live corrupts it. The fix is not to change PSRAM but to **never run DFS**
+— see §2.
+
+---
+
+## 1. Recommended build path
+
+**Rebuild the framework from source with Arduino as an ESP-IDF component, on the
+community `pioarduino` platform, driven by a project `sdkconfig.defaults`.**
+
+This is option (b) "Arduino-as-an-ESP-IDF-component" executed on platform (a)
+`pioarduino`. Rationale:
+
+- Flipping a compiled-out Kconfig like `CONFIG_PM_ENABLE` is **impossible with
+  the prebuilt-library `framework = arduino` flow** (both official and
+  pioarduino ship the same precompiled `libesp_pm.a`). You must compile the IDF
+  + Arduino from source. `framework = arduino, espidf` does exactly that, and the
+  board already declares both frameworks (`"frameworks": ["arduino","espidf"]`).
+- The **official `espressif32` platform is EOL/deprecated**; its component build
+  is unmaintained. **`pioarduino`** is the actively-maintained continuation
+  (IDF 5.1/5.3, Arduino core 3.x, ESP32-S3 well supported) and makes the
+  `arduino, espidf` build reliable. With the component build, PlatformIO's IDF
+  integration auto-reads `sdkconfig.defaults` from the project root — no exotic
+  ini keys needed.
+
+**Cost to flag:** pioarduino moves you from **Arduino core 2.0.x → 3.0.x
+(IDF 4.4 → 5.x)**. That is a framework-major migration with real API churn to
+work through (Arduino 3.x `Serial`/`analog`/`ledc` signatures, USB stack,
+possibly `NimBLE-Arduino` — currently `@^2.2.3`, which supports both, good). The
+first from-source build downloads a new platform + IDF 5.x toolchain (**multi-GB,
+~10 min**) and compiles everything (**~15–40 min, several GB of `.pio`**).
+
+### Alternative (keep Arduino 2.0.17, no code migration)
+
+Use **`esp32-arduino-lib-builder`** to rebuild just the precompiled 2.0.17
+libraries with a patched sdkconfig (`CONFIG_PM_ENABLE`, etc.), then keep the
+stock `espressif32@6.5.0` platform pointed at your custom `tools/sdk`. No app
+migration, but heavier one-time tooling (Docker/clone/menuconfig) and you now
+maintain a fork of the libs. **Choose this if avoiding the 2.x→3.x migration
+matters more than build-tooling simplicity.** Otherwise pioarduino is cleaner
+long-term.
+
+### `platformio.ini` diff (pioarduino path)
+
+```diff
+ [env:t5s3-pro]
+-platform = espressif32@6.5.0
++; Community fork with a from-source Arduino-as-IDF-component build (PM-capable).
++; Pin a specific pioarduino release; 53.03.xx == IDF 5.3 / Arduino core 3.x.
++platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
+ board = T5-ePaper-S3
+-framework = arduino
++framework = arduino, espidf          ; build Arduino from source as an IDF component
+ upload_speed = 921600
+ monitor_speed = 115200
+ monitor_filters = esp32_exception_decoder
++
++; ESP-IDF picks this up automatically from the project root and rebuilds the
++; affected components. (Drafted as sdkconfig.defaults.pm in this spike — rename
++; to sdkconfig.defaults for the real build.)
++; board_build.sdkconfig files are auto-discovered; no extra key required.
+
+ build_flags =
+     -DBOARD_HAS_PSRAM
+-    -DPSRAM_SPEED=120MHz
++    ; -DPSRAM_SPEED=120MHz   ; REMOVED: dead define, consumed nowhere; PSRAM is 80 MHz OPI
+     -DARDUINO_USB_CDC_ON_BOOT=1
+     ...
+```
+
+The **sdkconfig options** to set live in `sdkconfig.defaults` — see the drafted
+`sdkconfig.defaults.pm` in this worktree. Key lines:
+
+```ini
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
+CONFIG_PM_SLP_IRAM_OPT=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y      ; stay at 240; runtime uses min=max=240
+CONFIG_SPIRAM_MODE_OCT=y                   ; keep OPI PSRAM
+CONFIG_SPIRAM_SPEED_80M=y                  ; keep 80 MHz (unchanged)
+CONFIG_BT_CTRL_MODEM_SLEEP=y
+CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y        ; BLE LP clock survives light sleep
+CONFIG_RTC_CLK_SRC_INT_RC=y                ; internal RC (no 32k XTAL assumed)
+```
+
+USB/serial-console note: with native USB CDC (`ARDUINO_USB_MODE=0`,
+`ARDUINO_USB_CDC_ON_BOOT=1`) **light sleep gates the USB-OTG PHY and drops the
+CDC link** — the serial monitor churns connect/disconnect and GPS telemetry
+becomes unusable while sleeping. The drafted firmware handles this by **holding a
+`ESP_PM_NO_LIGHT_SLEEP` lock whenever the CDC port is open** (`power_mgmt::tick`),
+so the bench console works when plugged in and the device only sleeps on battery
+— which is exactly when sleep matters. No USB console loss in the field.
+
+---
+
+## 2. PSRAM decision
+
+**Keep octal PSRAM at 80 MHz. Do NOT enable DFS. Run light-sleep-only with
+`min_freq_mhz == max_freq_mhz == 240`.**
+
+Why this is safe: during light sleep the CPU/PLL are powered down and **PSRAM is
+retained in self-refresh** (`CONFIG_ESP_SLEEP_PSRAM_LEAKAGE_WORKAROUND=y` is
+already set in the stock cfg and kept in ours). On wake the PLL is restored to
+240 MHz **before any code — and therefore any PSRAM access — runs**. Because the
+CPU is never *running instructions against PSRAM* at a reduced clock, the
+80 MHz-needs-240 MHz timing constraint is never violated. This is precisely the
+distinction from the removed `setCpuFrequencyMhz(160)` experiment, which ran the
+CPU (and PSRAM accesses) at 160 MHz continuously and corrupted PSRAM.
+
+- **No framebuffer / map-render performance cost** — the CPU and PSRAM run at
+  full 240/80 whenever awake. Sleep is transparent to render code.
+- **DFS (min < 240) is explicitly rejected for v1.** It would clock the APB down
+  while PSRAM is live = the 160 MHz boot-loop failure mode. If DFS is ever wanted
+  for extra awake-time savings, PSRAM must first drop to **40 MHz (and likely
+  Quad mode)** and map-render/framebuffer throughput must be re-measured — a
+  bigger, riskier change. Not recommended now.
+
+---
+
+## 3. esp_pm wiring (drafted)
+
+New module **`src/power_mgmt.{h,cpp}`** (drafted, uncommitted). The core call:
+
+```cpp
+esp_pm_config_esp32s3_t cfg = {};
+cfg.max_freq_mhz = 240;
+cfg.min_freq_mhz = 240;          // == max: light sleep only, no DFS (PSRAM-safe)
+cfg.light_sleep_enable = true;
+esp_err_t err = esp_pm_configure(&cfg);   // ESP_ERR_NOT_SUPPORTED on stock -> logged
+```
+
+Called from `main.cpp setup()` **after** all peripherals are up
+(`ui_dashboard::begin()`), so the UART/BLE/EPD drivers are installed first.
+`power_mgmt::tick()` is called from `loop()` to manage the USB-CDC no-sleep lock.
+
+### Tasks that poll, and what tickless idle needs
+
+Tickless idle only sleeps when **every** task is blocked. Current cadences:
+
+| Task | File:line | Delay | Notes |
+|------|-----------|-------|-------|
+| `ui`  | `ui_dashboard.cpp:1313` | **30 ms** | highest-rate poll — the limiter |
+| `gps` | `gps_service.cpp:718` | 50 ms | drains UART FIFO |
+| `srv` (BLE) | `ble_server.cpp` task | 100 ms | status notify |
+| `ble` (sensors) | `ble_sensors.cpp:390` | 1000 ms | |
+| `rec` | `ride_recorder.cpp:398` | 1000 ms (`RECORD_INTERVAL_MS`) | |
+| `bat` | `main.cpp:87` | 30000 ms | |
+| `loop()` | `main.cpp:258` | 1000 ms | |
+
+All tasks already `vTaskDelay()` (none busy-spin), and touch/buttons are
+interrupt-driven (`touchIrq`, `boardBtnIrq`), so the system **will** sleep
+between polls. **With no code change, the CPU sleeps in ≤30 ms chunks** — the UI
+task's 30 ms poll wakes it, it does a few µs of work, and it sleeps again,
+sleeping ~90%+ of each idle second. That alone is the bulk of the win.
+
+**Minimal change to deepen sleep (recommended, but left to the display agent):**
+the UI task's 30 ms cadence exists mostly for touch/button *fallback* polling,
+which is already interrupt-backed. Raising the UI idle-loop `vTaskDelay` (e.g. to
+~150–200 ms) when the screen is static would let the CPU sleep in ~150 ms chunks
+and cut wake overhead ~5×. **This edit lives in the display/refresh loop
+(`ui_dashboard.cpp`), which another agent is reworking — I did not touch it.** It
+is safe for GPS (see §4) as long as the GPS task keeps its ≤100 ms poll.
+
+---
+
+## 4. GPS UART across sleep (no dropped NMEA)
+
+`SerialGPS` = `Serial2` (`gps_service.cpp:16`), `begin()` at
+`gps_service.cpp:190-196`: `setRxBufferSize(1024)` then `begin(9600, ...)`. The
+1024-byte buffer is the **software ring**, filled by the UART ISR. The hardware
+FIFO is **128 bytes**. During light sleep the ISR can't run, so only the 128-byte
+HW FIFO buffers incoming bytes: at 9600 baud (960 B/s) it fills in **~133 ms**.
+
+**Primary mechanism (no code change needed): bounded sleep.** Tickless idle only
+sleeps until the *next* task wakeup. The GPS task's own **50 ms** poll
+(`gps_service.cpp:718`) bounds every sleep to ≤50 ms → ~48 bytes accumulate, well
+under 128. Even if the UI idle delay is raised to 200 ms (§3), the **GPS task's
+50 ms poll still bounds the sleep** and drains the FIFO. Rule: **keep the GPS
+poll ≤ ~100 ms** and no NMEA is lost. Current design already satisfies this.
+
+**Optional belt-and-suspenders: UART wake source.** `esp_sleep_enable_uart_wakeup`
++ `uart_set_wakeup_threshold` wake the SoC on RX edges before the FIFO overflows.
+Caveat (`esp_sleep.h:297` + S3 silicon): **only UART0/UART1 can wake the S3 from
+light sleep — UART2 cannot.** GPS is on UART2, so to use this you must move
+`SerialGPS` to `Serial1` (a one-line change; pins are passed explicitly in
+`begin()`, and UART1 is otherwise free). The drafted `power_mgmt.cpp` includes
+this path behind `#ifdef PM_GPS_UART_WAKEUP`, disabled by default since the
+bounded-sleep guarantee already covers 9600 baud. Enable it only if the GPS poll
+is ever raised above ~100 ms.
+
+---
+
+## 5. BLE coexistence (modem sleep + connection interval)
+
+Two independent sleeps must line up:
+
+1. **Controller modem sleep** (`CONFIG_BT_CTRL_MODEM_SLEEP` + `..._MODE_1`): the
+   BLE radio powers down between connection events. For it to coexist with light
+   sleep, the controller's low-power clock must keep ticking while the SoC sleeps
+   → **`CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW`** (RTC slow clock), *not* the main
+   XTAL (gated in light sleep; using it forces the controller to hold a
+   no-light-sleep lock and you get **no CPU sleep while connected**). We source
+   the RTC slow clock from the **internal 150 kHz RC** (`CONFIG_RTC_CLK_SRC_INT_RC`)
+   unless the board wires a 32.768 kHz crystal to the ESP32 (VERIFY on the
+   schematic — the PCF8563 is a *separate I2C* RTC and does not count). Internal
+   RC drifts ~5%, which widens BLE wake windows slightly (a little more power,
+   occasional connection slop) — acceptable; measure.
+
+2. **Connection interval.** Modem sleep only saves power in proportion to how
+   long the radio can sleep between events = the connection interval. The current
+   code requests **15–30 ms and never relaxes it** (`ble_server.cpp` onConnect:
+   `updateConnParams(handle, 12, 24, 0, 400)`). (Note: the spec brief said an
+   idle 150–300 ms interval "was just raised" — **it is not in the tree**; the
+   code keeps 15–30 ms always.) A 15–30 ms interval wakes the radio ~33–66×/s and
+   caps CPU light-sleep windows.
+
+   **Drafted change (`ble_server.cpp`):** relax to **150–300 ms with slave
+   latency 4** when idle, snap back to 15–30 ms during any bulk transfer
+   (OTA/map/ride/log/sensor-stream). Implemented via a stored `s_connHandle` and
+   `applyConnInterval(bool fast)`, driven from the server task by a `bleBusy`
+   check. 1 Hz status notifications are unaffected (a peripheral may notify
+   immediately regardless of slave latency). This is what turns modem sleep into
+   an actual idle-current win while a phone stays connected.
+
+NimBLE specifics: no host-side API change beyond `updateConnParams`; the
+controller config is all in `sdkconfig.defaults`. `NimBLE-Arduino@^2.2.3` is
+compatible with both the current 2.x and the pioarduino 3.x cores.
+
+---
+
+## 6. Build attempt (this spike)
+
+- Symlinked the gitignored `vendor/` board support into the worktree.
+- Compiled `pio run -e t5s3-pro` on the **stock** `espressif32@6.5.0` framework
+  **with all drafted PM code included** (`power_mgmt.*`, `main.cpp`,
+  `ble_server.cpp`). Purpose: prove the source integrates, compiles, and links
+  against the real toolchain (the `esp_pm_*` / `esp_sleep_*` symbols exist).
+  **Result: see the end of this file / the final report** — a clean stock build
+  means the firmware is safe to keep in-tree today and will "just work" once the
+  framework is rebuilt (the PM calls flip from `NOT_SUPPORTED` no-ops to live).
+- **Not done (the heavy remaining step):** switching to `pioarduino` +
+  `framework = arduino, espidf` and doing the from-source PM-enabled build. That
+  downloads a new platform/IDF 5.x toolchain (multi-GB) and rebuilds everything
+  (~15–40 min), and carries the Arduino 2.x→3.x migration. Deferred as out of
+  scope for a no-flash spike; the exact config to do it is in
+  `sdkconfig.defaults.pm` + the ini diff above.
+
+---
+
+## 7. Risks
+
+1. **Framework migration (pioarduino / Arduino 3.x).** API churn across the
+   codebase; must recompile/fix the whole app. Mitigation: the lib-builder
+   alternative keeps 2.0.17.
+2. **OPI PSRAM + any accidental DFS = boot loop.** Enforced by `min == max ==
+   240`. Never set `min_freq_mhz < 240` while PSRAM stays 80 MHz OPI.
+3. **BLE stability on internal-RC LP clock.** ~5% drift may cause occasional
+   supervision-timeout disconnects at 150–300 ms interval. Mitigation: keep
+   supervision timeout generous (600 = 6 s, as drafted) and/or fit a 32k XTAL.
+4. **USB console lost during sleep.** Mitigated by the no-sleep lock while CDC is
+   open; still means field-battery runs have no live console (expected).
+5. **Wake latency.** Light-sleep wake is ~tens of µs–ms; touch/button IRQ
+   response gains a small latency. Should be imperceptible at ≤30 ms cadence.
+6. **NMEA loss if GPS poll is later slowed.** Bounded-sleep guarantee holds only
+   for GPS poll ≤ ~100 ms; enable the UART1 wake path if that changes.
+7. **Actual current win is unverified without hardware** — see the bench plan.
+
+---
+
+## 8. Bench measurement plan (current meter required)
+
+Use an inline power meter (e.g. a Nordic PPK2 or a µCurrent + scope on the
+battery lead) at each step. Measure **average** current over ≥60 s, plus the
+sleep/active duty cycle if the meter can scope it.
+
+**A. Idle draw, before vs after (headline number).**
+1. Baseline (stock framework), device on the desk, GPS on, BLE advertising, no
+   phone, screen static → record mA.
+2. PM build, same conditions → record mA. Expect the average to drop toward the
+   light-sleep floor between the ~30 ms wakes. Order-of-magnitude expectation:
+   the 240 MHz CPU core is a large share of the non-radio budget; if the CPU is
+   asleep ~90% of idle time, expect a **meaningful double-digit-percent drop in
+   the CPU/idle portion** of system current (radio, PSRAM self-refresh, EPD bias,
+   and sensors are unchanged). Report the absolute mA delta — that is the win.
+3. Repeat with a phone connected: (a) at the old 15–30 ms interval, (b) at the
+   drafted 150–300 ms idle interval. Quantify the connection-interval savings.
+
+**B. GPS-fix reliability (must not regress).**
+- Cold start and warm start, PM on vs off: TTFF and whether it holds a fix.
+- Watch the SD diag log `gps ...: chars=`, `ck=ok/bad` — a rising bad-checksum
+  count or stalled `chars` under PM = dropped NMEA (FIFO overflow). Confirm the
+  bounded-sleep assumption holds; if not, enable the UART1 wake path (§4).
+- Ride for ≥15 min moving; confirm no fix dropouts vs a PM-off control ride.
+
+**C. BLE stability.**
+- Phone connected 30+ min at the idle interval: count unexpected disconnects
+  (`diag` "phone disconnected reason") — especially supervision timeouts (reason
+  0x08). Compare internal-RC vs (if fitted) 32k-XTAL LP clock.
+- Run a full ride download / OTA / map upload with PM on: verify the fast
+  interval snaps back (throughput unchanged vs baseline) and re-relaxes after.
+
+**D. Map-render time (guard against a PSRAM regression).**
+- Since PSRAM stays 80 MHz OPI, render time should be **unchanged**. Time a fixed
+  map pan/redraw (add a `millis()` delta around the map render, or reuse existing
+  timing logs) PM-off vs PM-on; confirm no delta. *If* DFS/40 MHz PSRAM is ever
+  explored, re-run this as the go/no-go metric.
+
+**E. Wake correctness spot-checks.**
+- Touch and both buttons wake and respond after a long idle.
+- Auto-sleep (deep) at the 10 min timeout still fires (`ui_dashboard.cpp:1082`).
+- USB replug mid-idle: console returns (no-sleep lock re-acquires).

--- a/investigations/archive/display-ghosting-analysis.md
+++ b/investigations/archive/display-ghosting-analysis.md
@@ -1,0 +1,194 @@
+# E-Paper Ghosting Analysis: solid-black-over-a-line trails
+
+Panel: LilyGO T5S3 4.7" PRO (ED047TC1), driven by the vendored `epdiy`
+high-level API. Firmware refresh policy lives in `src/ui_dashboard.cpp`.
+
+## 1. Root cause
+
+The trail is not primarily a DU/GL16 "weak drive" problem — it is a
+**consequence of epdiy's high-level API being fully differential**, combined
+with DU/GL16 being non-inverting.
+
+### 1a. epdiy only drives pixels that changed value
+
+Every on-screen update goes through `epd_hl_update_screen()` →
+`epd_hl_update_area()`, which first computes a diff of the new frame
+(`front_fb`) against what is on glass (`back_fb`):
+
+- `vendor/.../epdiy/src/highlevel.c:118` — `epd_difference_image_cropped(front_fb, back_fb, …)`
+- `vendor/.../epdiy/src/render.c:389-391` — a pixel is marked dirty **iff its
+  4-bit value changed**:
+  ```c
+  col_dirtyness[x/2] |= (t ^ f) << (4 * (x % 2));
+  dirty |= (t ^ f);           // t = new (to), f = on-glass (from)
+  ```
+- `vendor/.../epdiy/src/highlevel.c:127-129` — if nothing changed, it returns
+  immediately and drives nothing.
+
+Only dirty pixels are handed to the waveform (`highlevel.c:139`, via
+`MODE_PACKING_1PPB_DIFFERENCE`). **A pixel that is black in both the old and new
+frame has `t ^ f == 0`, so it receives no waveform at all — for ANY mode,
+including `MODE_GC16`.**
+
+### 1b. Why that produces the trail
+
+When an area that contained a thin black mark (road line, position ring, text)
+becomes **solid black**:
+
+- The surrounding pixels go white→black. They are dirty, so they are driven
+  black by the current waveform.
+- The old mark's pixels go black→black. They are **not dirty**, so they are
+  **never re-driven**. They keep whatever micro-reflectance their earlier drive
+  history left them at.
+
+Fresh-driven black and "sat-there" black differ slightly in reflectance, so the
+old mark shows through the new fill as a faint outline. This is independent of
+how strong the surrounding drive is — even a perfect GC16 on the *changed*
+pixels cannot equalize a pixel it never touches.
+
+### 1c. Why DU/GL16 make it worse, and why the current "clean" doesn't fix it
+
+Panel modes for the ED047TC1 (`vendor/.../waveforms/epdiy_ED047TC1.h`):
+
+| Mode | type | phases | character |
+|------|------|--------|-----------|
+| DU   | 1 | 5  | mono, **non-inverting**, fast |
+| GC16 | 2 | 30 | grayscale, **flashing / inverting** |
+| GL16 | 5 | 30 | grayscale, **non-inverting**, no flash |
+| WHITE_TO_GL16 | 16 | 15 | from-white fast repaint |
+| BLACK_TO_GL16 | 17 | 15 | from-black fast repaint |
+
+DU (`ui_dashboard.cpp:226`) and GL16 (`:238`) are non-inverting: a white→black
+transition is a single push, so even the *driven* pixels don't fully saturate,
+leaving them a touch lighter than a GC16-cleared black and widening the
+old-vs-new-black gap.
+
+Critically, the existing "deep clean" does **not** cure this artifact. The GC16
+path at `ui_dashboard.cpp:238` calls `epd_hl_update_screen(&hl, MODE_GC16, …)`,
+which is still the **differential** path — it re-flashes only pixels that
+changed since the last push and therefore skips the static-black old mark. The
+only place the firmware truly clears it today is `epd_fullclear()` at boot /
+shutdown (`ui_dashboard.cpp:122`, `highlevel.c:185`), which sets `front_fb` to
+all-white *first* so that every non-white pixel becomes dirty and gets driven —
+a non-differential clear. That path is never used during normal riding.
+
+Current heuristic, for reference (`ui_dashboard.cpp`):
+- `refresh()` `:216-242` chooses DU vs GL16/GC16.
+- `ghostDebt` / `GHOST_GL16_EVERY` `:185-186` — DU updates before a clean.
+- `ghostCleanPending` / settle timer `:191-192`, fired at `:1193-1194`.
+- Map settle forces GC16 (`forceClean && screen == SCREEN_MAP`) at `:237` — but
+  differentially, so it cannot reach the trail.
+
+## 2. What paperboy (and general e-paper practice) does
+
+zephray/Wenting Zhang's **paperboy** (gitlab.com/zephray/paperboy) is a 60 Hz
+E-Ink Game Boy emulator — the same person behind the Modos 60 fps e-ink
+monitor. It solves fast refresh by **bypassing the vendor waveform LUT
+entirely**: it uses the panel's raw row/column interface to run a continuous
+scan with its own per-pixel drive state and a greyscale + dither blend
+(`main/msg/msg.c`, `main/main.c`). That is exactly the direction this repo's
+`smooth_epd.cpp` M1 self-test is prototyping (Modos-style continuous drive).
+
+Its ghosting cure is the classic, non-differential flush. `ui_clear_ghosting()`
+(`main/ui.c`) drives the **whole frame** through a hard inverting cycle,
+ignoring any diff:
+
+```c
+void ui_clear_ghosting(void) {
+    uint8_t *fb = msg_flip();
+    for (int i = 0; i < 5; i++) { memset(fb, 0x00, EPD_VIDEO_FB_SIZE); fb = msg_flip(); } // black
+    for (int i = 0; i < 5; i++) { memset(fb, 0xFF, EPD_VIDEO_FB_SIZE); fb = msg_flip(); } // white
+}
+```
+
+It is triggered **on demand** (a touch action `TP_ACTION_CLEAR_SCREEN`), not
+per-region and not on a fixed cadence. General e-paper practice agrees:
+
+- The reliable ghost killer is a **non-differential full/inverting drive** (GC16
+  "global clean", or an explicit black→white flash) that touches *every* pixel
+  in the region, including unchanged ones.
+- Partial/DU updates accumulate "ghost debt"; a periodic full clear pays it off.
+- Higher-end controllers (and paperboy/Modos) track **per-pixel** drive state so
+  they can selectively re-saturate; that requires owning the waveform, which the
+  epdiy high-level API does not give us.
+
+Takeaway for us: within the epdiy diff model, the fix must **break the diff** so
+the static-black pixels get driven — i.e., flash the region to a uniform state
+first, then repaint.
+
+## 3. Ranked fix options
+
+### A. True non-differential clean, full-screen, gated (RECOMMENDED)
+Replace the ineffective differential GC16 settle-clean with a real
+`epd_fullclear`-style clean: set `front_fb` all-white, GC16 (glass + `back_fb`
+→ uniform white), restore the frame, repaint with GL16 from that known white
+state. Because the repaint drives every target-black pixel from the *same* white
+origin, the old mark and its surroundings end identically black — trail gone.
+- Visual quality: fully fixes the reported artifact.
+- Cost: one white flash + one non-flash repaint, ~1.4 s; only when triggered.
+- Battery: one GC16 flash worth of TPS current per clean — acceptable if rare.
+- Complexity: low (mirrors the proven boot path). Risk: low.
+- Mitigation for the flash/over-clean concern: gate it behind `ghostDebt`
+  (fire only after a real interaction has built up ghosting), and only on the
+  map screen where the artifact occurs. Quick taps keep the cheap GL16.
+
+### B. Scoped local clear-to-white then repaint (best quality/cost, more work)
+Same idea as A but limited to a bounding box (e.g. the map viewport, or the
+union of epdiy's own dirty rects since the last clean): `epd_clear_area(box)`
+→ resync `back_fb` for the box to white → `epd_hl_update_area(GL16, box)`.
+Flashes only the changed region, so it is faster (~0.5–0.8 s), lower power, and
+far less visually jarring (status bar / footer never flash).
+- Visual quality: fixes the artifact, less flash than A.
+- Cost/battery: lower than A (region-scoped).
+- Complexity: medium — must keep epdiy's `back_fb` in sync after the low-level
+  `epd_clear_area` (which bypasses the high-level state). Risk: medium
+  (back_fb desync → wrong subsequent diffs).
+
+### C. Per-pixel ghost-debt / continuous drive (paperboy/Modos style)
+Extend `smooth_epd` M2 into the real path: own the waveform, track per-pixel DU
+accumulation, force a GC16 cycle on pixels whose debt is high. Highest quality
+(could also kill DU tail-ghosting generally) but a large, risky rewrite that
+replaces epdiy's update path. Long-term direction, not a near-term fix.
+
+### D. Just raise GC16 clean frequency / lower the ghostDebt threshold
+Cheapest to type, but **ineffective for this specific artifact**: the current
+GC16 clean is differential and never touches the static-black mark. Only worth
+doing *in combination with* making the clean non-differential (i.e., it reduces
+to A). By itself it only adds flashes without fixing the trail.
+
+**Recommendation: A now, with B as the follow-up optimization.** A is the
+minimal, safe, self-contained change that actually removes the trail; B then
+trims its flash/battery cost by scoping it once A is validated on-glass. C is
+the eventual endgame via `smooth_epd`.
+
+## 4. Drafted fix (uncommitted)
+
+Implemented option A in `src/ui_dashboard.cpp`:
+
+1. Added `deepClean(int temp)` (before `refresh()`): saves the current frame to
+   `shadowFb`, sets `front_fb` all-white, runs a GC16 (drives glass and epdiy's
+   `back_fb` to uniform white), restores the frame, then repaints with GL16 from
+   that uniform white origin — non-flashing and outline-free. Falls back to a
+   plain GC16 if `shadowFb` is unallocated. This is the `epd_fullclear` pattern
+   already trusted at boot/shutdown, so it is safe.
+
+2. Added `GHOST_DEEP_MIN = 4` and routed the map settle-clean through
+   `deepClean()` only when `forceClean && screen == SCREEN_MAP && ghostDebt >=
+   GHOST_DEEP_MIN`. Light interactions (a couple of DU frames) still take the
+   cheap non-flash GL16; a clean only flashes once real DU ghosting has
+   accumulated. Raise `GHOST_DEEP_MIN` to flash less (more lingering ghost,
+   better battery); lower it for a cleaner panel.
+
+Net behaviour: during active tapping the fast DU path is unchanged; when the map
+settles after a real zoom/pan, the panel does one brief white flash and repaints
+clean, eliminating the solid-black-over-a-line trail. Idle/riding battery draw is
+unchanged (deepClean only runs on a map settle with built-up debt). Not flashed
+or tested on hardware — validate the flash cadence on-glass, and if it feels too
+frequent or too heavy, either bump `GHOST_DEEP_MIN` or move to option B
+(region-scoped clear).
+
+### Follow-up ideas
+- Scope `deepClean` to the map viewport rect (option B) to avoid flashing the
+  static status bar/footer.
+- Consider `MODE_EPDIY_WHITE_TO_GL16` (type 16, 15 phases) for the repaint pass —
+  it is the from-white fast path and could shave the repaint time.

--- a/investigations/archive/display-ghosting-v3.md
+++ b/investigations/archive/display-ghosting-v3.md
@@ -1,0 +1,136 @@
+# E-Paper Ghosting V3: region-scoped ghost clear
+
+Panel: LilyGO T5S3 4.7" PRO (ED047TC1), vendored `epdiy`. Rotation
+`EPD_ROT_INVERTED_PORTRAIT`: native fb is 960×540 (landscape), the app draws in
+540×960 (portrait). Refresh policy: `src/ui_dashboard.cpp`.
+
+Symptom (unchanged): when a map area that held a thin black mark (road, position
+ring, text) becomes SOLID BLACK, a faint trail of the old mark stays visible
+inside the black, in dark regions.
+
+## Why v1 and v2 both missed
+
+- **v1 (differential GC16 on settle):** epdiy is fully differential — a pixel
+  that is black before AND after gets no waveform (`render.c:390`,
+  `dirty |= (t ^ f)`), and re-pushing an unchanged settled frame diffs to nothing
+  and drives *nothing at all* (`highlevel.c:127` early-out). So the trail's
+  static-black pixels were never touched.
+- **v2 (full `epd_fullclear` on settle):** correct mechanism (flush to uniform
+  white, then repaint from that origin so every pixel is driven), but applied to
+  the WHOLE PANEL on every map settle. The user rejected it: far too many
+  full-screen flashes, and it needlessly flashed the status bar and footer.
+
+Both got the physics right eventually; the miss was **scope**. v3 keeps the
+"drive every pixel from a uniform white origin" mechanism but applies it to only
+the rectangle that changed.
+
+## What v3 does
+
+Three parts, all in `src/ui_dashboard.cpp` (see the diff at the end):
+
+### 1. Track the actual dirty region (per interaction burst)
+
+`ghostRectAccumulate(prev, cur)` diffs the just-rendered frame against the
+previous one — `shadowFb` still holds the previous frame at that point, so the
+diff is free of extra buffers — and unions the changed **native-fb** bounding box
+into an accumulator (`ghMinX/Y..ghMaxX/Y`). It runs only when
+`screen == SCREEN_MAP && du && active` (an active interactive map DU frame), so
+hands-off riding, idle, and every other screen never pay the O(fb) scan and never
+schedule a clean. Across a zoom/pan burst the accumulator grows to cover exactly
+where the marker/roads swept and left a trail.
+
+### 2. Convert to app coords and clamp to the map viewport
+
+`ghostRectToAppClamped()` inverts the `INVERTED_PORTRAIT` rotation
+(`native_x = app_y`, `native_y = epd_height()-1 - app_x`, from `epdiy.c` `_rotate`):
+a native box `(nx,ny,nw,nh)` becomes app rect
+`{ x = epd_height()-(ny+nh), y = nx, w = nh, h = nw }`. It then clamps the top to
+`ui::STATUS_H` (64) so **the status bar is never in the rect**, and to
+`W×H = 540×960` on the other edges. Result: an app-coordinate rectangle covering
+only the changed map content.
+
+### 3. Region-scoped non-differential clear + repaint
+
+`regionClean(r, temp)` — the paperboy "drive every pixel" lesson applied to one
+rectangle, entirely through the high-level area API so rotation and `back_fb`
+stay correct automatically:
+
+1. `epd_fill_rect(r, 0xFF, front)` — white-out the rect in `front_fb`
+   (app coords, rotation handled by epdiy).
+2. `epd_hl_update_area(&hl, MODE_GC16, temp, r)` — GC16 the rect: drives every
+   non-white pixel in it to white AND, crucially, the high-level buffer-update
+   loop (`highlevel.c:150-170`) copies `front → back_fb` for the rect, so
+   **epdiy's `back_fb` for the rect becomes white**. This is the fix for the v1
+   failure mode: without resetting `back_fb`, the repaint would diff to nothing
+   and drive nothing.
+3. `memcpy(front, shadowFb)` — restore the real frame.
+4. `epd_hl_update_area(&hl, MODE_GL16, temp, r)` — GL16 repaint: with `back_fb`
+   now uniform white in the rect, every target pixel differs from white and is
+   driven from the identical origin, so the old mark and its surroundings end
+   identically black. Trail gone.
+
+Because `epd_difference_image_cropped` resets and scopes the dirty
+lines/columns to the rect (`render.c:456-495`) and the app only wrote white
+inside the rect, the update is masked to the rect — **only the rect is ever
+driven; the status bar and footer are never touched.**
+
+**Why the high-level area API instead of the low-level `epd_clear_area` +
+manual `back_fb` poke:** `epd_clear_area` operates on the raw panel in native
+coordinates and bypasses `back_fb`, so pairing it with the repaint would require
+hand-writing `back_fb` in native/rotated layout — exactly the desync that
+caused v1's no-op. Routing the clear through `epd_hl_update_area(GC16)` instead
+gives the same non-differential region flush (GC16 is the inverting global-clean
+waveform) while epdiy keeps `back_fb` correct under rotation for free. Same
+guarantee, none of the manual-coordinate risk.
+
+### Dispatch
+
+In `refresh()`, the map settle-clean (`forceClean && screen == SCREEN_MAP`) now
+calls `regionClean(ghostRectToAppClamped())` when a dirty rect was accumulated,
+instead of the old full-screen GC16. `ghostRectReset()` clears the accumulator on
+every clean (and on page-out GL16), so stale rects never leak across screens. The
+nav-prompt modal keeps its intentional full GC16; all other cleans stay on the
+no-flash GL16.
+
+## What it clears, how big, how often
+
+- **Clears:** the union of what changed on the map during the interactive burst
+  (marker sweep + newly-solid-black areas), clamped to the map viewport. Drives
+  every pixel in that rect from uniform white, so the solid-black-over-a-line
+  trail is equalised away.
+- **Flashed rect size:** tight for a small change (a marker nudge → a box around
+  the marker), up to the full map viewport (`540 × up to ~896 px`, from
+  `STATUS_H` down) when a pan/zoom changes everything. **Never** the full panel,
+  and **never** the `540×64` status bar or anything above the map. Typical
+  zoom/pan lands near the viewport; small pans/marker moves are much smaller.
+- **How often:** once per interactive map burst, ~900 ms after the last tap
+  (`ghostCleanPending` + `GHOST_CLEAN_SETTLE_MS`), same trigger as the previous
+  settle-clean. **Not** per DU frame, **not** on idle, and **not** during
+  hands-off riding (no tap ⇒ `ghostCleanPending` never set ⇒ no scan, no clean).
+
+Versus v2: v2 flashed the entire 540×960 panel (incl. status bar + footer) via
+`epd_fullclear` (which also runs a 3-cycle `epd_clear`) on every settle. v3
+flashes only the changed sub-rect of the map, with a scoped GC16 clear + GL16
+repaint — far less area, no 3-cycle full clear, and the static chrome never
+moves.
+
+## Riding (hands-off) — deliberately not flashed
+
+As before, passive riding never schedules a clean (it would mean a flash while
+moving). If the trail is ever reported specifically during untouched riding, the
+minimal follow-up is to also accumulate + schedule on passive map DU; left out
+here to honor "riding shouldn't flash" and to keep the change interaction-scoped.
+
+## Verification
+
+Builds clean: `pio run -e t5s3-pro` → SUCCESS (RAM 37.2%, Flash 18.3%). Not
+flashed / not tested on glass — validate the rect size and the settle flash on
+hardware. If a full pan/zoom's viewport-sized flash still feels heavy, the rect
+is already the minimum that covers the change; the next lever is tightening the
+accumulation (e.g. clip to the marker's swept path) rather than the viewport.
+
+## Diff (v3 vs current `main` `src/ui_dashboard.cpp`)
+
+Region-clear helpers added before `refresh()`; `refresh()` reordered so the dirty
+rect is accumulated before `shadowFb` is overwritten; the map settle branch now
+calls `regionClean()` instead of a full-screen GC16. No other behavior changed.

--- a/investigations/archive/navigation-analysis.md
+++ b/investigations/archive/navigation-analysis.md
@@ -1,0 +1,167 @@
+# Turn-by-turn navigation bug — root-cause analysis
+
+**Symptom (from a real ride):** the route drawn on the map was correct, but the
+turn-by-turn prompts ran *several maneuvers ahead* of the rider — it announced
+turns far in advance and showed the wrong "upcoming" turn. The geometry is fine;
+the mapping from *current position → which maneuver is next* (and the distance to
+it) is wrong.
+
+All navigation logic lives in `src/routes.cpp` / `src/routes.h`. The BLE upload
+path (`src/ble_server.cpp`) and the UI glue (`src/ui_dashboard.cpp`,
+`src/ui_render.cpp`) were reviewed and are **not** at fault.
+
+---
+
+## 1. How a GPS fix flows to a displayed next-turn
+
+1. **GPS fix** — every valid fix (~1 Hz) calls
+   `routes::updateProgress(lat, lon)` from `src/gps_service.cpp:577`.
+
+2. **Project rider onto route** — `updateProgress` (`src/routes.cpp:294`):
+   - Searches a forward window `[progIdx-8, progIdx+120)` for the nearest route
+     point with `nearestRouteIdx` (`src/routes.cpp:302-305`).
+   - **If that window match is > 60 m away, it re-acquires against the *entire*
+     route** (`src/routes.cpp:306-310`, pre-fix) and takes the global match if
+     it is any bit closer.
+   - Sets `progIdx` to the chosen index (`src/routes.cpp:311`) — this is the
+     rider's along-route position, the single anchor everything else keys off.
+
+3. **Advance the maneuver cursor** — `advanceManeuverCursor`
+   (`src/routes.cpp:77-82`) walks `curManeuver` forward while a maneuver's
+   snapped position is behind the rider:
+   `cumM[maneuverIdx[curManeuver]] <= cumM[progIdx] - 5.0f`.
+
+4. **Report the next turn** — the banner calls `routes::nextTurn(...)`
+   (`src/ui_dashboard.cpp:595` → `src/routes.cpp:378`), which returns
+   `maneuvers[curManeuver].instr` and distance
+   `along = cumM[maneuverIdx[curManeuver]] - cumM[progIdx]`
+   (`src/routes.cpp:381`).
+
+Every output (which turn, and how far) is therefore a function of two indices:
+`progIdx` (from step 2) and `maneuverIdx[]` (snapped once at upload). If either
+is placed too far *forward* on the route, `advanceManeuverCursor` skips real
+turns and `nextTurn` reports a maneuver that is still ahead of the rider.
+
+The maneuver coordinates themselves are fine: they arrive as int32 `1e7`
+lat/lon over BLE (`src/ble_server.cpp:148-157`) and are stored as plain WGS84
+degrees — the same frame/units as the parsed route points. `finishManeuvers`
+(`src/routes.cpp:347`) runs `mapManeuversToRoute` *after* the geometry is loaded
+(`0x03` before `0x05` in the protocol), so the ordering is correct. No unit or
+coordinate-scaling mismatch exists.
+
+---
+
+## 2. Root cause
+
+**Primary: the whole-route re-acquire in `updateProgress` is unbounded
+(`src/routes.cpp:306-310`, pre-fix).**
+
+```cpp
+int idx = nearestRouteIdx(lat, lon, from, to, d2);   // forward window
+if (d2 > 60.0f * 60.0f) {                             // window match > 60 m
+    float fd2;
+    int fidx = nearestRouteIdx(lat, lon, 0, nPts, fd2);   // ENTIRE route
+    if (fidx >= 0 && fd2 < d2) { idx = fidx; d2 = fd2; }  // any bit closer wins
+}
+```
+
+On a route that passes near itself — a loop, an out-and-back, a lollipop, or any
+self-crossing — the **globally** nearest route point to the rider can belong to a
+*later* leg that runs alongside the rider's *current* leg. As soon as a single
+GPS fix drifts more than 60 m from the windowed match (normal urban jitter, tree
+cover, a momentary multipath spike, or riding slightly wide of the line), the
+fallback fires and snaps `progIdx` onto that later, parallel leg — jumping it far
+ahead along the route.
+
+This is self-latching. After the jump, the next fix's window is
+`[newProgIdx-8, newProgIdx+120)`; the rider's true point is now well *behind*
+`newProgIdx`, so the window match is again far (> 60 m), the global re-acquire
+fires again, and it re-selects the parallel-ahead leg. The tiny 8-point backward
+allowance (`src/routes.cpp:302`) cannot claw progress back. `progIdx` therefore
+stays inflated for the rest of the ride, `cumM[progIdx]` is too large,
+`advanceManeuverCursor` skips several maneuvers, and `nextTurn` reports turns
+that are still ahead — exactly the observed "several maneuvers ahead, for the
+whole ride" behaviour. The drawn route is unaffected because it is rendered from
+the raw point list, not from `progIdx`.
+
+**Secondary/compounding: maneuver snapping was also an unbounded global search
+(`mapManeuversToRoute`, `src/routes.cpp:66-73`, pre-fix).** It snapped each
+maneuver to its globally nearest route vertex with no ordering constraint. On the
+same self-passing routes, a maneuver on the return/overlapping leg could snap to
+the *earlier* leg's vertices, giving it a `cumM[]` far smaller than its true
+along-route position. `advanceManeuverCursor` then steps past that maneuver early
+— independently producing the "skip several turns" symptom even when `progIdx` is
+correct.
+
+Both defects share the same failure mode: *an unbounded nearest-point search on a
+route that comes back near itself.* This is the classic cause the ride report
+describes.
+
+---
+
+## 3. The fix (drafted — uncommitted in this worktree)
+
+All changes are self-contained in `src/routes.cpp`; no header or API change.
+
+### (a) Constrain the re-acquire in `updateProgress` — `src/routes.cpp:294`
+
+- Added persistent off-route state `offRouteFixes` (`src/routes.cpp:37`).
+- The whole-route re-acquire now fires **only** after the window match has been
+  far for **≥ 4 consecutive fixes** (a real detour / mid-route join, not a single
+  jittery sample), **and** only if the global candidate is **decisively** closer
+  — `fd2 < d2 * 0.25f`, i.e. less than *half* the distance (values are squared
+  metres). A merely-marginally-closer parallel leg can no longer steal progress.
+  On any on-route fix the counter resets.
+
+This keeps normal tracking driven purely by the bounded, monotonic forward
+window (immune to self-passing geometry), while still allowing genuine
+re-acquisition after a sustained detour.
+
+### (b) Monotonic maneuver snapping — `mapManeuversToRoute`, `src/routes.cpp:66`
+
+Maneuvers arrive in route order, so each snap search now starts at the previous
+maneuver's snapped index and runs forward (`from = idx` after each). A return-leg
+maneuver can no longer snap back onto an earlier overlapping leg, so its `cumM[]`
+is always its true along-route position.
+
+### Why this makes next-turn strictly position-driven
+
+`progIdx` now advances monotonically along the rider's actual leg and cannot leap
+onto a parallel later leg on a jittery fix; `maneuverIdx[]` is monotonic along the
+route. `advanceManeuverCursor` (`src/routes.cpp:78`) and `nextTurn`
+(`src/routes.cpp:381`) already compute correctly *given* trustworthy indices —
+they needed no change once the two index sources were made robust.
+
+---
+
+## 4. Verification
+
+**Reasoning walkthrough — out-and-back that overlaps (the reported scenario):**
+Rider outbound, `progIdx` tracks via the forward window (global fallback never
+needed; window match < 60 m). A single fix drifts 70 m off (jitter). *Before:*
+global re-acquire fires immediately, finds the overlapping return leg ~5 m away,
+`progIdx` jumps ~half the route ahead and latches → turns run many maneuvers
+ahead. *After:* one far fix only increments `offRouteFixes` to 1; the window
+still yields the (slightly far) correct outbound point, `progIdx` stays on the
+true leg; the next on-route fix resets the counter. Prompts stay locked to the
+rider.
+
+**Reasoning walkthrough — genuine detour / mid-route join:** rider off-route for
+several seconds. `offRouteFixes` climbs past 4; the global match is many times
+closer than the stale window match (`fd2 < d2/4`), so the re-acquire fires and
+`progIdx` correctly re-locks. Behaviour preserved.
+
+**Suggested host-side test (no hardware):** `nearestRouteIdx`, `cumM[]`,
+`advanceManeuverCursor`, `mapManeuversToRoute`, and the `updateProgress`
+projection are plain math with no Arduino/SD/BLE dependency. Extract them into a
+tiny host harness, build a synthetic out-and-back polyline (outbound then the
+reversed outbound offset a few metres, with maneuvers on both legs), feed a
+sequence of positions along the outbound leg with one or two injected > 60 m
+jitter fixes, and assert `progressIndex()` stays monotonic on the outbound half
+and `nextTurn` returns the correct next maneuver + a distance that decreases
+monotonically toward each turn. Repeat with a sustained off-route excursion to
+confirm re-acquire still recovers.
+
+**Tunables:** `offRouteFixes >= 4` (≈ 4 s at 1 Hz) and the `0.25f` closeness
+ratio are conservative; both can be relaxed if field logs show re-acquisition is
+too sluggish for a particular routing profile.

--- a/investigations/pm-rebuild-baseline.md
+++ b/investigations/pm-rebuild-baseline.md
@@ -189,7 +189,7 @@ pio pkg uninstall -p espressif32@6.5.0 && pio pkg install -e t5s3-painter
 ## 6. Loose end
 
 `power_mgmt.h`, `power_mgmt.cpp`, the runtime `pm:` log line and
-`sdkconfig.defaults.pm` all cite **`CPU_SLEEP_SPIKE.md`**, which is not in the
+`sdkconfig.defaults.pm` all cite **`investigations/archive/cpu-sleep-spike.md`**, which is not in the
 main tree — the only copy is under `.claude/worktrees/agent-a5d264ba6aeddbd5f/`.
 Four dangling references to the document that explains the problem. Restore it
 or repoint them at this file and `battery-life.md`.

--- a/sdkconfig.defaults.pm
+++ b/sdkconfig.defaults.pm
@@ -1,7 +1,8 @@
 # sdkconfig.defaults for the PM-enabled framework rebuild.
 #
 # Use with the `framework = arduino, espidf` component build (see
-# CPU_SLEEP_SPIKE.md). Rename to `sdkconfig.defaults` in the project root; the
+# investigations/archive/cpu-sleep-spike.md). Rename to `sdkconfig.defaults` in
+# the project root; the
 # ESP-IDF builder picks it up automatically and rebuilds the affected components
 # from source. These options do NOT take effect on the stock precompiled Arduino
 # framework — that ships with PM compiled out.

--- a/src/power_mgmt.cpp
+++ b/src/power_mgmt.cpp
@@ -50,7 +50,7 @@ bool begin() {
     s_enabled = (err == ESP_OK);
     if (err == ESP_ERR_NOT_SUPPORTED) {
         diag::log("pm: light sleep UNAVAILABLE — framework lacks CONFIG_PM_ENABLE"
-                  "/TICKLESS_IDLE (rebuild required; see CPU_SLEEP_SPIKE.md)");
+                  "/TICKLESS_IDLE (rebuild required; see investigations/archive/cpu-sleep-spike.md)");
         return false;
     }
     diag::log("pm: esp_pm_configure(min=max=240, light_sleep=%d) -> %s",

--- a/src/power_mgmt.h
+++ b/src/power_mgmt.h
@@ -3,8 +3,9 @@
 // Automatic light-sleep power management for the ESP32-S3.
 //
 // IMPORTANT: this only DOES anything on a framework built with CONFIG_PM_ENABLE
-// and CONFIG_FREERTOS_USE_TICKLESS_IDLE (see CPU_SLEEP_SPIKE.md). The stock
-// precompiled Arduino framework compiles those OUT, so esp_pm_configure()
+// and CONFIG_FREERTOS_USE_TICKLESS_IDLE (see
+// investigations/archive/cpu-sleep-spike.md). The stock precompiled Arduino
+// framework compiles those OUT, so esp_pm_configure()
 // returns ESP_ERR_NOT_SUPPORTED and this degrades to a logged no-op — the code
 // is safe to build (and even flash): it simply won't sleep until the framework
 // is rebuilt with power management enabled.


### PR DESCRIPTION
Two follow-ups to #27 that landed on the branch after it merged.

## The website was left behind

`docs/` builds the same H3 tiles the app does, and it still had the layout and the bug that #27 fixed everywhere else. Anyone using the browser generator instead of the phone would have got the old behaviour.

**Water-only hexes were dropped.**

```js
if (ebmHasRoads(ebm)) files.push(...)
```

`buildEbm()` appends the WTR2/PRK2 sections *after* the road index, so an ocean hex has real content and an empty road index — and was thrown away. A bay downloaded from the site rendered as blank paper. This is the same bug as `MapBuilder.isEmpty` in the app, in a second implementation. Now `ebmHasContent()`: any road tile, or anything past the header and index.

**Old flat layout.** Tiles were written as `maps/tiles/<id>.ebm`; now `maps/tiles/<first 6 of id>/<rest>.ebm`, matching `tileDirFor()` in `src/map_store.cpp`, so a ZIP unzipped onto the card root lands where the firmware and app put things. The firmware reads the flat layout too, so ZIPs already downloaded keep working.

**Unpadded coastline query.** A box drawn out in open water contains no coastline at all, so there were no sea rings and those hexes came out blank — the same root cause as the app's empty ocean tiles. The coastline filter now uses a bbox padded ~0.35° (~35 km) while everything else uses the drawn box, so only that one filter widens and roads for the padded area are not pulled in.

`tools/maps/build_map.py` is unaffected — it emits one whole-region `.ebm`, not per-tile files.

## Rescued analysis notes that were about to be lost

`src/power_mgmt.{h,cpp}` and `sdkconfig.defaults.pm` cited **`CPU_SLEEP_SPIKE.md`** by name. That file was never committed — it existed only as an uncommitted file inside an agent worktree under `.claude/worktrees/`. Four references pointing at nothing for anyone who cloned the repo, and about to point at nothing for us once those worktrees were cleaned up.

Six such documents are recovered into `investigations/archive/` and the references repointed. The README there says they are point-in-time working notes, not maintained, and which current document supersedes each where they disagree.

## Verification

Firmware builds; every `investigations/archive/cpu-sleep-spike.md` reference resolves to a file that exists; both JS files pass an ES-module syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT8JWmZ6nfgfU5HA1Meera