### PR TITLE
Log why the battery percentage is missing, not just when it isn't

### DIFF
--- a/src/board_power.h
+++ b/src/board_power.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+
 // Board-level power helpers implemented in main.cpp (which owns the IO
 // expander instance).
 
@@ -13,3 +15,10 @@ bool board_side_button_pressed();
 // discharging) from the fuel gauge. Returns false if the gauge is absent.
 // Used by the `power` console command to measure the GPS rail's draw.
 bool board_read_power(uint16_t& mv, int16_t& ma);
+
+// Full fuel-gauge snapshot as one printable line: state of charge, voltage,
+// current, capacities, health, temperature and the raw status words. Same text
+// the battery task writes to the diagnostic log, on demand — for debugging a
+// missing / stuck battery percentage without waiting for the 2 min sample.
+// Writes into `out`; returns false (with a reason in `out`) if init() failed.
+bool board_gauge_report(char* out, size_t n);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,19 +94,111 @@ static ExtensionIOXL9555 ioExpander;
 static BQ27220 fuelGauge;
 static bool fuelGaugeOk = false;
 
+// Everything the BQ27220 will tell us in one pass. Logged RAW (no "looks
+// implausible, drop it" filtering) because the whole point is to tell a real
+// reading apart from a bus collision — which returns 0 or 0xFFFF and is
+// otherwise indistinguishable from a flat battery / missing gauge.
+struct GaugeSnapshot {
+    uint16_t soc = 0, mv = 0, rc = 0, fc = 0, dc = 0, soh = 0, tempRaw = 0;
+    int16_t  ma = 0;
+    uint16_t battStatus = 0, opStatus = 0;
+    bool     charging = false;
+};
+
+// Takes the I2C lock ONCE for the whole snapshot (~10 register reads, a couple
+// of ms) so the fields describe the same instant. Only called when a line is
+// about to be logged, never on the 30 s display poll — see batteryTask.
+static void gaugeRead(GaugeSnapshot& g) {
+    BQ27220BatteryStatus bs{};
+    BQ27220OperationStatus os{};
+    i2cLock();
+    g.soc     = fuelGauge.getStateOfCharge();
+    g.mv      = fuelGauge.getVoltage();
+    g.ma      = fuelGauge.getCurrent();
+    g.rc      = fuelGauge.getRemainingCapacity();
+    g.fc      = fuelGauge.getFullChargeCapacity();
+    g.dc      = fuelGauge.getDesignCapacity();
+    g.soh     = fuelGauge.getStateOfHealth();
+    g.tempRaw = fuelGauge.getTemperature();
+    fuelGauge.getBatteryStatus(&bs);
+    fuelGauge.getOperationStatus(&os);
+    i2cUnlock();
+    g.battStatus = bs.full;
+    g.opStatus   = os.full;
+    g.charging   = !bs.reg.DSG;
+}
+
+// The diagnostic tail shared by every gauge log line: temperature, health,
+// design capacity and the two status words (raw hex + the bits that explain a
+// missing reading). NOTE: no '%' character in here — the phone's diagnostics
+// chart takes the FIRST '%' on a "battery:" line as the state-of-charge
+// (DiagnosticsView.swift), so only the leading SOC may carry one.
+static void gaugeDetail(const GaugeSnapshot& g, char* out, size_t n) {
+    BQ27220BatteryStatus bs{};   bs.full = g.battStatus;
+    BQ27220OperationStatus os{}; os.full = g.opStatus;
+    int t10 = (int)g.tempRaw - 2732;          // gauge reports 0.1 K
+    int at  = t10 < 0 ? -t10 : t10;
+    snprintf(out, n,
+             "%s%d.%dC soh %u dc %umAh batt 0x%04x%s%s%s%s op 0x%04x%s sec%u",
+             t10 < 0 ? "-" : "", at / 10, at % 10, g.soh, g.dc,
+             g.battStatus,
+             bs.reg.BATTPRES ? " pres" : " NOBATT",
+             bs.reg.AUTH_GD  ? " auth" : "",
+             bs.reg.FC       ? " full" : "",
+             bs.reg.SYSDWN   ? " SYSDWN" : "",
+             g.opStatus,
+             os.reg.INITCOMP ? " init" : " NOINIT",
+             os.reg.SEC);
+}
+
+// One "battery:" line. The valid-reading form MUST keep its leading
+// "<soc>% <mv>mV <ma>mA <rc>/<fc>mAh <charging|discharging>" shape — the phone
+// app parses exactly that prefix to draw the drain chart. Detail is appended
+// after it. When the SOC is not plausible we log a differently-shaped line with
+// no '%' at all, so the phone skips it instead of charting a bogus 0 %.
+static void gaugeLogLine(const GaugeSnapshot& g, bool socValid, int tries) {
+    char detail[140];
+    gaugeDetail(g, detail, sizeof(detail));
+    if (socValid) {
+        diag::log("battery: %u%% %umV %dmA %u/%umAh %s %s", g.soc, g.mv, g.ma,
+                  g.rc, g.fc, g.charging ? "charging" : "discharging", detail);
+    } else {
+        // tries == 0 means the poll loop never ran (init() failed at boot), so
+        // the raw SOC below came from this snapshot rather than a retry round.
+        char how[28];
+        if (tries > 0) snprintf(how, sizeof(how), "after %d tries", tries);
+        else           snprintf(how, sizeof(how), "gauge uninitialised");
+        diag::log("battery: NO-SOC raw 0x%04x (%s), %umV %dmA "
+                  "rc %u fc %u %s", g.soc, how, g.mv, g.ma, g.rc, g.fc, detail);
+    }
+}
+
 static void batteryTask(void*) {
     uint32_t lastLog = 0;
     bool firstLog = true;
+    uint32_t failStreak = 0;
+    // A gauge whose init() failed is still polled here, purely so the log can
+    // say WHICH failure it is: registers that answer with a sane SOC prove the
+    // chip is on the bus and only the unseal/provisioning in init() went wrong,
+    // while 0xFFFF everywhere means nothing is answering at all. The display
+    // still shows nothing in this state — the reading is not trusted, because a
+    // failed init can also mean a wrong device ID or the wrong battery profile.
+    if (!fuelGaugeOk)
+        diag::log("battery: gauge init FAILED at boot — logging raw reads only, "
+                  "display stays blank");
     for (;;) {
+        uint16_t soc = 0;
+        int tries = 0;
         if (fuelGaugeOk) {
             // The fuel gauge shares the I2C bus with touch / IO expander / RTC;
             // a colliding read returns 0 or 0xFFFF. Only accept a plausible SOC
             // (1..100) and retry a few times — NEVER overwrite the last good
             // value with a failed read, or the battery display flickers/vanishes.
-            uint16_t soc = 0;
             for (int i = 0; i < 4; ++i) {
+                ++tries;
                 i2cLock(); uint16_t v = fuelGauge.getStateOfCharge(); i2cUnlock();
                 if (v >= 1 && v <= 100) { soc = v; break; }
+                soc = v;                         // keep the raw value for the log
                 vTaskDelay(pdMS_TO_TICKS(15));   // unlocked between tries
             }
             bool chg = false;
@@ -117,20 +209,33 @@ static void batteryTask(void*) {
                     s.charging = chg;
                 });
             }
-            // Log the battery every 2 min so drain rate can be tracked from the
-            // diagnostics log. Current is signed: negative = discharging (mA).
-            if (soc >= 1 && (firstLog || millis() - lastLog > 120000)) {
-                firstLog = false;
-                lastLog = millis();
-                i2cLock();
-                uint16_t mv = fuelGauge.getVoltage();
-                int16_t ma = fuelGauge.getCurrent();
-                uint16_t rc = fuelGauge.getRemainingCapacity();
-                uint16_t fc = fuelGauge.getFullChargeCapacity();
-                i2cUnlock();
-                diag::log("battery: %u%% %umV %dmA %u/%umAh %s", soc, mv, ma, rc, fc,
-                          chg ? "charging" : "discharging");
-            }
+        }
+        bool socValid = fuelGaugeOk && soc >= 1 && soc <= 100;
+
+        // A run of failed reads is exactly the "battery % vanished" symptom, so
+        // it gets logged the moment it starts (and again when it ends) instead
+        // of leaving a silent gap in the log where the samples should be.
+        bool firstFailure = false;
+        if (!socValid) {
+            firstFailure = (failStreak == 0);
+            ++failStreak;
+        } else if (failStreak) {
+            diag::log("battery: reads recovered after %u failed poll(s) (~%us)",
+                      (unsigned)failStreak, (unsigned)(failStreak * 30));
+            failStreak = 0;
+        }
+
+        // Sample every 2 min so drain rate can be tracked from the diagnostics
+        // log. Current is signed: negative = discharging (mA).
+        if (firstLog || firstFailure || millis() - lastLog > 120000) {
+            firstLog = false;
+            lastLog = millis();
+            GaugeSnapshot g;
+            gaugeRead(g);
+            // Report the SOC the display poll actually saw, not a fresh read —
+            // a second read that happens to succeed would hide the failure.
+            if (fuelGaugeOk) g.soc = soc;
+            gaugeLogLine(g, socValid, tries);
         }
         vTaskDelay(pdMS_TO_TICKS(30000));
     }
@@ -231,14 +336,21 @@ void setup() {
     pinMode(BOARD_BOOT_BTN, INPUT_PULLUP);
 
     fuelGaugeOk = fuelGauge.init();
+    // init() failing kills the battery display for the whole session, so record
+    // it — with the device number, which separates "wrong/absent chip" (anything
+    // but 0x0220) from "right chip, but unseal or profile check refused".
+    diag::log("gauge: init %s, device 0x%04x (expect 0x0220)",
+              fuelGaugeOk ? "ok" : "FAILED", fuelGauge.getDeviceNumber());
     // Prime the battery reading synchronously so the first UI frame after boot
     // (and right after an install) never shows a bogus 0%. The BQ27220 can need
     // a moment to report a valid state-of-charge, so retry briefly for non-zero.
     if (fuelGaugeOk) {
-        uint16_t soc = 0;
+        uint16_t soc = 0, raw = 0;
+        int tries = 0;
         for (int i = 0; i < 25; ++i) {                 // retry until a valid read
-            uint16_t v = fuelGauge.getStateOfCharge();
-            if (v >= 1 && v <= 100) { soc = v; break; }  // ignore 0 / 0xFFFF
+            ++tries;
+            raw = fuelGauge.getStateOfCharge();
+            if (raw >= 1 && raw <= 100) { soc = raw; break; }  // ignore 0 / 0xFFFF
             delay(20);
         }
         if (soc >= 1) {
@@ -247,6 +359,14 @@ void setup() {
                 s.batteryPercent = (uint8_t)soc;
                 s.charging = chg;
             });
+            diag::log("gauge: boot SOC %u%% after %d tr%s", soc, tries,
+                      tries == 1 ? "y" : "ies");
+        } else {
+            // The first frame will show "--%". Say so, and say what the gauge
+            // did answer: a steady 0x0000 or 0xFFFF here is the fingerprint of
+            // a dead/unresponsive gauge rather than a slow-to-settle one.
+            diag::log("gauge: NO valid boot SOC, last raw 0x%04x after %d tries",
+                      raw, tries);
         }
     }
     settings::begin();
@@ -401,6 +521,17 @@ bool board_read_power(uint16_t& mv, int16_t& ma) {
     ma = fuelGauge.getCurrent();
     i2cUnlock();
     return true;
+}
+
+bool board_gauge_report(char* out, size_t n) {
+    GaugeSnapshot g;
+    gaugeRead(g);                      // read even when init() failed — the raw
+    char detail[140];                  // registers are the evidence we want
+    gaugeDetail(g, detail, sizeof(detail));
+    snprintf(out, n, "soc %u%s %umV %dmA %u/%umAh %s %s", g.soc,
+             (g.soc >= 1 && g.soc <= 100) ? "%" : "% (INVALID)", g.mv, g.ma,
+             g.rc, g.fc, g.charging ? "charging" : "discharging", detail);
+    return fuelGaugeOk;
 }
 
 bool board_side_button_pressed() {

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1051,7 +1051,7 @@ static void printConsoleHelp() {
     Serial.println("  gpsver               query GPS module firmware version");
     Serial.println("  gpsraw <on|off>      echo raw receiver bytes");
     Serial.println("  sd                   SD mount state + cardType (NONE = card not answering)");
-    Serial.println("  power                battery voltage + current draw (mA)");
+    Serial.println("  power                battery voltage + draw (mA) + full fuel-gauge state");
     Serial.println("  bootloader           reboot into download mode for flashing");
     Serial.println("  reboot               restart the device");
     Serial.println("  timing               toggle frame-timing logs");
@@ -1102,7 +1102,13 @@ static void runConsoleLine(char* line) {
             Serial.printf("[power] %umV %dmA (%s)\n", mv, ma,
                           ma < 0 ? "discharging" : "charging/idle");
         else
-            Serial.println("[power] fuel gauge unavailable");
+            Serial.println("[power] fuel gauge init failed at boot "
+                           "(raw registers still read below)");
+        // Always dump the full gauge state: when the battery percentage is
+        // missing, the status words and the raw SOC are the whole diagnosis.
+        char rep[200];
+        board_gauge_report(rep, sizeof(rep));
+        Serial.printf("[gauge] %s\n", rep);
     } else if (!strcasecmp(cmd, "sd")) {
         // SD status without needing a boot log. The mount happens ~1.4 s into
         // boot, long before a USB-CDC host can attach, so for a long time the


### PR DESCRIPTION
## Problem

The battery percentage sometimes doesn't show up, and the diagnostic log is no help: every fuel-gauge log path was gated on a **valid** reading.

- `if (soc >= 1 && ...)` — a failing SOC read logged nothing.
- `fuelGaugeOk == false` (a failed `init()` at boot) disabled the whole battery task, silently, forever.

So the exact failure we need to diagnose produced a log indistinguishable from the device being switched off.

## What this adds

**Boot** — `gauge: init ok|FAILED, device 0x0220 (expect 0x0220)`. The device number separates *wrong/absent chip* from *right chip, but unseal/profile check refused*. Followed by `gauge: boot SOC 87% after 3 tries` or `gauge: NO valid boot SOC, last raw 0xffff after 25 tries`.

**Failures, not just successes** — a failed poll round logs the moment the streak starts (`battery: NO-SOC raw 0xffff (after 4 tries), 3912mV -142mA rc 1740 fc 2000 …`) and again when it ends (`battery: reads recovered after N failed poll(s)`).

**A failed `init()` no longer means silence** — the task keeps polling the raw registers and logging them. Sane values there prove the chip is on the bus and only provisioning failed. The display still ignores those reads; this is evidence, not a behaviour change.

**More sensor data on every sample** — temperature, state of health, design capacity, and both status words raw + decoded:

```
battery: 87% 3912mV -142mA 1740/2000mAh discharging 24.1C soh 98 dc 2000mAh batt 0x00c1 pres auth op 0x0526 init sec3
```

`NOBATT`, `SYSDWN`, `NOINIT` and the seal state are the bits that explain a missing percentage.

**`power` console command** dumps the same snapshot on demand, so a live device can be diagnosed without waiting for the 2-minute sample.

## Compatibility with the phone's drain chart

`DiagnosticsView.swift` parses the first `%` and the first `mA ` on a `battery:` line. The valid-sample prefix is therefore byte-identical and all detail is appended after it; failure lines contain no `%` at all, so the chart skips them rather than plotting a bogus 0 %.

Verified by running the app's actual parser logic against old-format, new-format and failure-form lines: old and new samples parse identically (`pct=87.0 mA=-142.0`), every diagnostic line is skipped.

## Testing

- `pio run -e t5s3-painter` (shipping) — SUCCESS
- `pio run -e t5s3-pro` (epdiy fallback) — SUCCESS
- No new compiler warnings in the changed files.
- Not yet run on hardware — the log lines above are from the format strings, not a device.

## Finding, deliberately not fixed here

`fuelGaugeOk = fuelGauge.init()` is the prime suspect. `init()` does unseal + data-memory provisioning and returns false on any of ~6 steps, and that false permanently disables battery reads for the session — even though the plain SOC/voltage registers answer fine on a *sealed* gauge. If the new log shows `init FAILED` alongside `device 0x0220` and sane raw SOC values, the fix is to gate reads on the device ID rather than on full provisioning. Left as a follow-up so this PR stays diagnostic-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7j9FFejmEKqjeVaFnxqZV