### PR TITLE
App: draw downloaded areas in the device's e-ink style; fix permission dead ends

### DIFF
--- a/companion-ios/OpenTrailPaper.xcodeproj/project.pbxproj
+++ b/companion-ios/OpenTrailPaper.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		05EFA1438A835BB33D929DF4 /* BarlowCondensed-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A97893E68863ECCF2D0D4400 /* BarlowCondensed-Medium.ttf */; };
 		1E84B7CD7869CDE2FAD486B0 /* BarlowCondensed-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 08F073C2FF3FF2C629AFE7E8 /* BarlowCondensed-Bold.ttf */; };
 		206AAAF21E4BC20EAB8D7C79 /* vertex.c in Sources */ = {isa = PBXBuildFile; fileRef = 861D40F3D0D6EE123389E135 /* vertex.c */; };
+		2593A42A317117DDFBAF716E /* EInkMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062C37A066E27E1DEC3AF253 /* EInkMapView.swift */; };
+		2896F748FD963A319E478447 /* EBMDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E924B930AF50BBF8472A7F /* EBMDecoder.swift */; };
 		292571D164EEF9C5316E8BAB /* linkedGeo.c in Sources */ = {isa = PBXBuildFile; fileRef = 878E3C8F7719672814B9A1C2 /* linkedGeo.c */; };
 		2A3194F4903302F4B2C27D19 /* polygon.c in Sources */ = {isa = PBXBuildFile; fileRef = 0CBC93C157DBF69D2E2C1823 /* polygon.c */; };
 		2D50FCD8D5DDF2010C20E161 /* RideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E83FB3A70437DD5D0F8629 /* RideView.swift */; };
@@ -40,6 +42,7 @@
 		CD0EDC65F5A9395EE7649CDE /* directedEdge.c in Sources */ = {isa = PBXBuildFile; fileRef = CC8F9A2A7C26F2C54766428B /* directedEdge.c */; };
 		D017F03AE055F1971F5815BA /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F3F907C8247AC1B8A63959 /* Theme.swift */; };
 		D18324D7B11DC7874A2252C3 /* mathExtensions.c in Sources */ = {isa = PBXBuildFile; fileRef = C79A61A359DA1F3938DE464C /* mathExtensions.c */; };
+		D51119ACFAB6419E07143355 /* EInkTileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD609424C1648F1D8704550 /* EInkTileStore.swift */; };
 		D6593DA4DB2D54C490D89D63 /* firmware.bin in Resources */ = {isa = PBXBuildFile; fileRef = 8573B3F08B3AD8A472D61A2D /* firmware.bin */; };
 		DA77B28069DBB60831A903C9 /* h3shim.c in Sources */ = {isa = PBXBuildFile; fileRef = 158AB26E91BB4024B25490AD /* h3shim.c */; };
 		E1BBBE95FA5BC48203720329 /* baseCells.c in Sources */ = {isa = PBXBuildFile; fileRef = CB4C7FC4CD9B1C363CD59A20 /* baseCells.c */; };
@@ -56,12 +59,14 @@
 
 /* Begin PBXFileReference section */
 		05C73BCF289591ECA86720C6 /* GPXExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXExporter.swift; sourceTree = "<group>"; };
+		062C37A066E27E1DEC3AF253 /* EInkMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EInkMapView.swift; sourceTree = "<group>"; };
 		08F073C2FF3FF2C629AFE7E8 /* BarlowCondensed-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "BarlowCondensed-Bold.ttf"; sourceTree = "<group>"; };
 		0CBC93C157DBF69D2E2C1823 /* polygon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = polygon.c; sourceTree = "<group>"; };
 		0D0FC030F1FACFFD44C96837 /* SensorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorsView.swift; sourceTree = "<group>"; };
 		119DE3CCD0BED37A2EED959F /* polygonAlgos.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = polygonAlgos.h; sourceTree = "<group>"; };
 		158AB26E91BB4024B25490AD /* h3shim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = h3shim.c; sourceTree = "<group>"; };
 		1727B3F48F1EFA384DE4B5C8 /* h3api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = h3api.h; sourceTree = "<group>"; };
+		18E924B930AF50BBF8472A7F /* EBMDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EBMDecoder.swift; sourceTree = "<group>"; };
 		21F000263728C013838D0605 /* faceijk.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = faceijk.c; sourceTree = "<group>"; };
 		22AE81B336FF77D1655400EA /* constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
 		27A939183F2903B61CA144FB /* bbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bbox.h; sourceTree = "<group>"; };
@@ -115,6 +120,7 @@
 		CB4C7FC4CD9B1C363CD59A20 /* baseCells.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = baseCells.c; sourceTree = "<group>"; };
 		CBBFA5634178A1D43462F629 /* BLEManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEManager.swift; sourceTree = "<group>"; };
 		CC8F9A2A7C26F2C54766428B /* directedEdge.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = directedEdge.c; sourceTree = "<group>"; };
+		CDD609424C1648F1D8704550 /* EInkTileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EInkTileStore.swift; sourceTree = "<group>"; };
 		D66117B8CB78BBC0949D8DF3 /* demo.fit */ = {isa = PBXFileReference; path = demo.fit; sourceTree = "<group>"; };
 		E15692F37161BEC610966D47 /* TileCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileCache.swift; sourceTree = "<group>"; };
 		E1B62C507D47EAD0BDDDD24F /* RideDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RideDetailView.swift; sourceTree = "<group>"; };
@@ -178,6 +184,9 @@
 				CBBFA5634178A1D43462F629 /* BLEManager.swift */,
 				D66117B8CB78BBC0949D8DF3 /* demo.fit */,
 				336612AF0918144CAB1C1FCD /* DiagnosticsView.swift */,
+				18E924B930AF50BBF8472A7F /* EBMDecoder.swift */,
+				062C37A066E27E1DEC3AF253 /* EInkMapView.swift */,
+				CDD609424C1648F1D8704550 /* EInkTileStore.swift */,
 				8573B3F08B3AD8A472D61A2D /* firmware.bin */,
 				590A2666A030966B6741EDAF /* FITDecoder.swift */,
 				05C73BCF289591ECA86720C6 /* GPXExporter.swift */,
@@ -336,6 +345,9 @@
 				5BC98F4BF77D1A33EF8F546B /* BLEManager.swift in Sources */,
 				021E5D177FE3BCD463AA49BF /* BikeGPSCompanionApp.swift in Sources */,
 				F71D1CFFCC25AD4A7A19D698 /* DiagnosticsView.swift in Sources */,
+				2896F748FD963A319E478447 /* EBMDecoder.swift in Sources */,
+				2593A42A317117DDFBAF716E /* EInkMapView.swift in Sources */,
+				D51119ACFAB6419E07143355 /* EInkTileStore.swift in Sources */,
 				A44F34DFEC944328672D82B2 /* FITDecoder.swift in Sources */,
 				90BE2D6324721EC08C93E435 /* GPXExporter.swift in Sources */,
 				431EACF518E6E7F25D9682EC /* H3Tiles.swift in Sources */,

--- a/companion-ios/OpenTrailPaper.xcodeproj/project.pbxproj
+++ b/companion-ios/OpenTrailPaper.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B1BE7F5A245A3C270036C6E2 /* algos.c in Sources */ = {isa = PBXBuildFile; fileRef = ABBED3B34B25D9BCAFA3FDB5 /* algos.c */; };
 		BE0814223F037C69E39B93D7 /* RidesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897B750389038E18EE9AC09 /* RidesView.swift */; };
 		C462314C3BD9E277B9F451A9 /* MapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C77C595BBAE5BCBD82A004 /* MapsView.swift */; };
+		C7F7382D5542409C17015EFB /* SketchIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ECF60CAA9C73957BC40AC2 /* SketchIcon.swift */; };
 		CD0EDC65F5A9395EE7649CDE /* directedEdge.c in Sources */ = {isa = PBXBuildFile; fileRef = CC8F9A2A7C26F2C54766428B /* directedEdge.c */; };
 		D017F03AE055F1971F5815BA /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F3F907C8247AC1B8A63959 /* Theme.swift */; };
 		D18324D7B11DC7874A2252C3 /* mathExtensions.c in Sources */ = {isa = PBXBuildFile; fileRef = C79A61A359DA1F3938DE464C /* mathExtensions.c */; };
@@ -83,6 +84,7 @@
 		6CDCF740EC9B89D5492FD0C7 /* h3Assert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = h3Assert.h; sourceTree = "<group>"; };
 		6FA4F76096362CE92F71ED36 /* latLng.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = latLng.h; sourceTree = "<group>"; };
 		73E0BFD770D75ABD5ABB61B8 /* alloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = alloc.h; sourceTree = "<group>"; };
+		73ECF60CAA9C73957BC40AC2 /* SketchIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SketchIcon.swift; sourceTree = "<group>"; };
 		756CD94A1C875E17A3321CC8 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		792C3E9270334E7AE1A24B68 /* directedEdge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = directedEdge.h; sourceTree = "<group>"; };
 		79F3F907C8247AC1B8A63959 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				A26EB50B7E6CF1B4A63235CA /* RouteView.swift */,
 				0D0FC030F1FACFFD44C96837 /* SensorsView.swift */,
 				BE5C27C920995C9292457A9C /* SettingsView.swift */,
+				73ECF60CAA9C73957BC40AC2 /* SketchIcon.swift */,
 				79F3F907C8247AC1B8A63959 /* Theme.swift */,
 				E15692F37161BEC610966D47 /* TileCache.swift */,
 				80ACFA8CA9080B22457972EF /* Fonts */,
@@ -360,6 +363,7 @@
 				79F918433F0C02EF0915A0EE /* RouteView.swift in Sources */,
 				5D1E2FE5B8652DC846C39AF7 /* SensorsView.swift in Sources */,
 				F5E522C16FCFE097E2072926 /* SettingsView.swift in Sources */,
+				C7F7382D5542409C17015EFB /* SketchIcon.swift in Sources */,
 				D017F03AE055F1971F5815BA /* Theme.swift in Sources */,
 				F6958E6E296967C90F9CDC75 /* TileCache.swift in Sources */,
 				B1BE7F5A245A3C270036C6E2 /* algos.c in Sources */,

--- a/companion-ios/README.md
+++ b/companion-ios/README.md
@@ -11,6 +11,13 @@ settings and push routes.
   it on the map, and send it to the head unit. The route is exported as GPX
   and streamed over BLE; the device saves it to `/routes` (and rides it
   even without an SD card).
+- **The map style** — areas you've downloaded are drawn the way the head unit
+  will draw them: black ink on paper, roads by class, water as a dot screen
+  and parks as a diagonal hatch (the screentones in `src/map_view.cpp`).
+  Areas the device also has get a green check. Everywhere else is plain Apple
+  Maps, so the edge of your offline coverage is visible at a glance. Both the
+  Route and Maps screens use it; the geometry is decoded from the same `.ebm`
+  tiles that get streamed to the device (`EBMDecoder.swift`).
 - **Settings** — edit FTP and timezone, push them to the device (saved in
   the device's flash, persist across reboots).
 

--- a/companion-ios/Sources/BLEManager.swift
+++ b/companion-ios/Sources/BLEManager.swift
@@ -74,6 +74,21 @@ struct DeviceStatus {
     var remainingKm = 0.0
 }
 
+/// How a system permission stands right now.
+///
+/// Kept as four cases rather than a Bool because each one calls for different
+/// UI: `notDetermined` means we still owe the user the system prompt,
+/// `denied` can only be undone in Settings, and `unavailable` (restricted by
+/// parental controls or an MDM profile) can't be undone at all — sending
+/// someone to Settings for that is a dead end.
+enum PermissionState: Equatable {
+    case notDetermined, granted, denied, unavailable
+
+    var isGranted: Bool { self == .granted }
+    /// Whether the Settings app can actually change this.
+    var fixableInSettings: Bool { self == .denied }
+}
+
 @MainActor
 final class BLEManager: NSObject, ObservableObject {
     enum ConnState: Equatable { case idle, scanning, connecting, connected, poweredOff }
@@ -93,6 +108,15 @@ final class BLEManager: NSObject, ObservableObject {
     // Permission state, surfaced so onboarding can reflect what's been granted.
     @Published var locationAuthorized = false
     @Published var bluetoothReady = false          // central powered on & allowed
+
+    // The precise state of each permission, so the UI can tell apart the three
+    // situations that need three different answers: not asked yet (we must ask),
+    // refused (only Settings can undo it), and restricted (nothing the user can
+    // do). `bluetoothPoweredOn` is deliberately separate — a switched-off radio
+    // is not a refused permission and must not be reported as one.
+    @Published var locationPermission: PermissionState = .notDetermined
+    @Published var bluetoothPermission: PermissionState = .notDetermined
+    @Published var bluetoothPoweredOn = false
 
     // Ride download
     @Published var rides: [RideFile] = []
@@ -193,6 +217,10 @@ final class BLEManager: NSObject, ObservableObject {
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         let a = locationManager.authorizationStatus
         locationAuthorized = (a == .authorizedWhenInUse || a == .authorizedAlways)
+        locationPermission = Self.state(of: a)
+        // Readable WITHOUT creating a central, which is the point: it tells us
+        // whether Bluetooth was already refused before we consider prompting.
+        bluetoothPermission = Self.state(of: CBCentralManager.authorization)
         // Show last-known on-device tiles immediately; a refresh confirms them.
         if let saved = UserDefaults.standard.stringArray(forKey: Self.tileCacheKey) {
             deviceTileIds = Set(saved)
@@ -221,6 +249,39 @@ final class BLEManager: NSObject, ObservableObject {
     func requestLocationPermission() {
         if locationManager.authorizationStatus == .notDetermined {
             locationManager.requestWhenInUseAuthorization()
+        }
+    }
+
+    /// Re-read both permissions. Called when the app comes back to the
+    /// foreground, because the user may have just changed them in Settings and
+    /// neither framework reports that while we're backgrounded.
+    func refreshPermissions() {
+        let a = locationManager.authorizationStatus
+        locationAuthorized = (a == .authorizedWhenInUse || a == .authorizedAlways)
+        locationPermission = Self.state(of: a)
+        bluetoothPermission = Self.state(of: CBCentralManager.authorization)
+        // Permission granted while we were away: bring the radio up now, so the
+        // device connects without the user having to hunt for a button.
+        if bluetoothPermission.isGranted { startCentral() }
+    }
+
+    private static func state(of a: CLAuthorizationStatus) -> PermissionState {
+        switch a {
+        case .notDetermined:                       return .notDetermined
+        case .authorizedWhenInUse, .authorizedAlways: return .granted
+        case .denied:                              return .denied
+        case .restricted:                          return .unavailable
+        @unknown default:                          return .notDetermined
+        }
+    }
+
+    private static func state(of a: CBManagerAuthorization) -> PermissionState {
+        switch a {
+        case .notDetermined:  return .notDetermined
+        case .allowedAlways:  return .granted
+        case .denied:         return .denied
+        case .restricted:     return .unavailable
+        @unknown default:     return .notDetermined
         }
     }
 
@@ -985,6 +1046,11 @@ extension BLEManager: CBCentralManagerDelegate {
         if isDemoUpdate { return }   // demo holds a fake connected state
         MainActor.assumeIsolated {
             bluetoothReady = (c.state == .poweredOn)
+            bluetoothPoweredOn = (c.state == .poweredOn)
+            // .unauthorized IS the refusal arriving; otherwise re-read, since
+            // the answer to our prompt lands here.
+            bluetoothPermission = c.state == .unauthorized
+                ? .denied : Self.state(of: CBCentralManager.authorization)
             switch c.state {
             case .poweredOn: startScan()
             case .poweredOff: state = .poweredOff
@@ -1207,6 +1273,7 @@ extension BLEManager: CLLocationManagerDelegate {
         MainActor.assumeIsolated {
             let a = m.authorizationStatus
             locationAuthorized = (a == .authorizedWhenInUse || a == .authorizedAlways)
+            locationPermission = Self.state(of: a)
             if wantsAiding, a == .authorizedWhenInUse || a == .authorizedAlways {
                 beginLocationUpdates()
             } else if a == .denied || a == .restricted {

--- a/companion-ios/Sources/BikeGPSCompanionApp.swift
+++ b/companion-ios/Sources/BikeGPSCompanionApp.swift
@@ -5,6 +5,7 @@ import UIKit
 struct BikeGPSCompanionApp: App {
     @StateObject private var ble = BLEManager()
     @StateObject private var appState = AppState()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
@@ -13,7 +14,22 @@ struct BikeGPSCompanionApp: App {
                 .environmentObject(appState)
                 .tint(Palette.accent)
         }
+        // Coming back from the Settings app is the one way a permission changes
+        // without either framework telling us, and it's exactly the path our own
+        // "Open Settings" buttons send people down.
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { ble.refreshPermissions() }
+        }
     }
+}
+
+/// Opens this app's page in the Settings app — the only place a refused
+/// permission can be granted again.
+@MainActor
+func openAppSettings() {
+    guard let url = URL(string: UIApplication.openSettingsURLString),
+          UIApplication.shared.canOpenURL(url) else { return }
+    UIApplication.shared.open(url)
 }
 
 // Lightweight app-wide UI state. Owns whether the first-run tutorial is

--- a/companion-ios/Sources/EBMDecoder.swift
+++ b/companion-ios/Sources/EBMDecoder.swift
@@ -1,0 +1,188 @@
+import Foundation
+import MapKit
+
+// Reads back the `.ebm` blobs this app builds (MapBuilder.swift) and the head
+// unit renders (src/map_tiles.cpp), so the phone can draw the SAME map the
+// device will — roads by class, water, parks.
+//
+// The projection deliberately mirrors projectBlobInto() rather than the
+// encoder: the device derives its scale factor from the grid header
+// (midLat = gridLat0 + tileDeg * gridNy / 2) instead of the bounding box the
+// encoder used, and those differ by a few metres. Reproducing what the DEVICE
+// computes is what makes this an honest preview.
+//
+// Format (little-endian), from MapBuilder:
+//   'EBM2', f64 lat0, f64 lon0, f64 tileDeg, i32 nx, i32 ny,
+//   index[nx*ny] of (u32 offset, u32 length)   (0,0 = empty sub-tile),
+//   sub-tiles: u16 polylineCount, per polyline { u8 class, u16 pointCount,
+//              i16 x,y per point (metres E/N of the SUB-TILE's SW corner) },
+//   then optional 'ELV1', then 'WTR2' and 'PRK2' polygon sections whose points
+//   are metres E/N of the GRID origin (lat0, lon0).
+enum EBM {
+
+    /// Render classes, numbered as in build_map.py / mapgen.js / the firmware's
+    /// MapFeatureClass enum.
+    enum FeatureClass: UInt8, CaseIterable {
+        case arterial = 0, primary = 1, secondary = 2, tertiary = 3, minor = 4, path = 5
+    }
+
+    /// One decoded tile, already projected into map points — the space the
+    /// overlay renderer draws in, so nothing has to be re-projected per frame.
+    struct Tile {
+        /// Roads grouped by class: one CGPath per class, all in MKMapPoint space.
+        let roads: [FeatureClass: CGPath]
+        let water: CGPath?
+        let parks: CGPath?
+        /// Rough cost measure (total points) for the memory budget.
+        let pointCount: Int
+    }
+
+    /// Decodes a blob, or nil if it isn't a well-formed EBM2.
+    static func decode(_ data: Data) -> Tile? {
+        var r = Reader(data)
+        guard r.magic("EBM2"),
+              let lat0 = r.f64(at: 4), let lon0 = r.f64(at: 12),
+              let tileDeg = r.f64(at: 20),
+              let nx32 = r.i32(at: 28), let ny32 = r.i32(at: 32) else { return nil }
+        let nx = Int(nx32), ny = Int(ny32)
+        // Bound the grid before trusting it for arithmetic: a corrupt header
+        // must not turn into a multi-gigabyte index walk.
+        guard nx > 0, ny > 0, nx <= 4096, ny <= 4096, tileDeg > 0,
+              36 + nx * ny * 8 <= data.count else { return nil }
+
+        // Exactly the device's scale factors (map_tiles.cpp:123).
+        let midLat = lat0 + tileDeg * Double(ny) / 2
+        let kx = 111320.0 * cos(midLat * .pi / 180)
+        let ky = 110540.0
+        guard kx > 1 else { return nil }          // degenerate near the poles
+        let tileWm = tileDeg * kx, tileHm = tileDeg * ky
+
+        // Metres E/N of the grid origin -> a map point.
+        func project(_ mx: Double, _ my: Double) -> CGPoint {
+            let p = MKMapPoint(CLLocationCoordinate2D(latitude: lat0 + my / ky,
+                                                      longitude: lon0 + mx / kx))
+            return CGPoint(x: p.x, y: p.y)
+        }
+
+        var roadPaths: [FeatureClass: CGMutablePath] = [:]
+        var points = 0
+
+        // --- roads, per sub-tile
+        let indexBase = 36
+        var dataEnd = indexBase + nx * ny * 8      // also where the sections start
+        for ty in 0..<ny {
+            for tx in 0..<nx {
+                let e = indexBase + (ty * nx + tx) * 8
+                guard let off32 = r.u32(at: e), let len32 = r.u32(at: e + 4) else { continue }
+                let off = Int(off32), len = Int(len32)
+                guard off > 0, len > 0, off + len <= data.count else { continue }
+                dataEnd = max(dataEnd, off + len)
+
+                let ox = Double(tx) * tileWm, oy = Double(ty) * tileHm
+                var p = off
+                guard let count = r.u16(at: p) else { continue }
+                p += 2
+                for _ in 0..<Int(count) {
+                    guard p + 3 <= off + len, let cls = r.u8(at: p),
+                          let n16 = r.u16(at: p + 1) else { break }
+                    p += 3
+                    let n = Int(n16)
+                    guard p + n * 4 <= off + len else { break }
+                    defer { p += n * 4 }
+                    guard let fc = FeatureClass(rawValue: cls), n >= 2 else { continue }
+                    let path = roadPaths[fc] ?? { let m = CGMutablePath(); roadPaths[fc] = m; return m }()
+                    for j in 0..<n {
+                        guard let mx = r.i16(at: p + j * 4),
+                              let my = r.i16(at: p + j * 4 + 2) else { break }
+                        let pt = project(ox + Double(mx), oy + Double(my))
+                        if j == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
+                    }
+                    points += n
+                }
+            }
+        }
+
+        // --- fill sections: optional ELV1 (skipped), then WTR2, then PRK2.
+        var q = dataEnd
+        if q + 44 <= data.count, r.magic("ELV1", at: q),
+           let gw = r.i32(at: q + 4), let gh = r.i32(at: q + 8),
+           gw > 0, gh > 0, gw <= 4096, gh <= 4096 {
+            q += 44 + Int(gw) * Int(gh) * 2
+        }
+        var water: CGPath? = nil, parks: CGPath? = nil
+        if let (path, next, n) = readFills(&r, at: q, magic: "WTR2", project: project) {
+            water = path; q = next; points += n
+        }
+        if let (path, _, n) = readFills(&r, at: q, magic: "PRK2", project: project) {
+            parks = path; points += n
+        }
+
+        let roads = roadPaths.mapValues { $0 as CGPath }
+        guard !roads.isEmpty || water != nil || parks != nil else { return nil }
+        return Tile(roads: roads, water: water, parks: parks, pointCount: points)
+    }
+
+    /// `<magic><u16 count>`, then each polygon as `<u16 pointCount><i16 x,y …>`
+    /// in metres E/N of the grid origin. Returns the combined path (rings are
+    /// closed, as the device closes them), where the section ends, and its size.
+    private static func readFills(_ r: inout Reader, at start: Int, magic: String,
+                                  project: (Double, Double) -> CGPoint)
+        -> (CGPath, Int, Int)? {
+        guard start >= 0, start + 6 <= r.count, r.magic(magic, at: start),
+              let count = r.u16(at: start + 4) else { return nil }
+        var q = start + 6
+        let path = CGMutablePath()
+        var total = 0
+        for _ in 0..<Int(count) {
+            guard let n16 = r.u16(at: q) else { break }
+            q += 2
+            let n = Int(n16)
+            guard q + n * 4 <= r.count else { break }
+            defer { q += n * 4 }
+            guard n >= 3 else { continue }
+            for j in 0..<n {
+                guard let mx = r.i16(at: q + j * 4),
+                      let my = r.i16(at: q + j * 4 + 2) else { break }
+                let pt = project(Double(mx), Double(my))
+                if j == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
+            }
+            path.closeSubpath()
+            total += n
+        }
+        return (path, q, total)
+    }
+
+    /// Bounds-checked little-endian reads. Every accessor returns nil rather
+    /// than trapping, so a truncated or corrupt tile degrades to "draws less"
+    /// instead of crashing the map.
+    private struct Reader {
+        let d: [UInt8]
+        init(_ data: Data) { d = [UInt8](data) }
+        var count: Int { d.count }
+
+        func u8(at i: Int) -> UInt8? { i >= 0 && i < d.count ? d[i] : nil }
+        func u16(at i: Int) -> UInt16? {
+            guard i >= 0, i + 2 <= d.count else { return nil }
+            return UInt16(d[i]) | (UInt16(d[i + 1]) << 8)
+        }
+        func i16(at i: Int) -> Int16? { u16(at: i).map { Int16(bitPattern: $0) } }
+        func u32(at i: Int) -> UInt32? {
+            guard i >= 0, i + 4 <= d.count else { return nil }
+            var v: UInt32 = 0
+            for k in (0..<4).reversed() { v = (v << 8) | UInt32(d[i + k]) }
+            return v
+        }
+        func i32(at i: Int) -> Int32? { u32(at: i).map { Int32(bitPattern: $0) } }
+        func f64(at i: Int) -> Double? {
+            guard i >= 0, i + 8 <= d.count else { return nil }
+            var bits: UInt64 = 0
+            for k in (0..<8).reversed() { bits = (bits << 8) | UInt64(d[i + k]) }
+            return Double(bitPattern: bits)
+        }
+        func magic(_ s: String, at i: Int = 0) -> Bool {
+            let m = Array(s.utf8)
+            guard i >= 0, i + m.count <= d.count else { return false }
+            return Array(d[i..<(i + m.count)]) == m
+        }
+    }
+}

--- a/companion-ios/Sources/EInkMapView.swift
+++ b/companion-ios/Sources/EInkMapView.swift
@@ -1,0 +1,554 @@
+import SwiftUI
+import MapKit
+
+// The map both the Route and Maps screens draw on: standard Apple Maps
+// everywhere, except the areas this phone has downloaded — those are painted as
+// the head unit will render them. Black ink on paper, roads by class, water as
+// a 75% dot screen, parks as a diagonal hatch, exactly the screentones in
+// src/map_view.cpp. Areas the device also has get a green check.
+//
+// UIKit rather than SwiftUI's Map: only MKOverlayRenderer can draw a patterned
+// fill locked to the map, and only MapKit's own overlay compositing keeps it
+// pinned frame-for-frame while panning. A SwiftUI Canvas layered over a Map
+// redraws a frame late and visibly swims.
+
+// MARK: - What the map draws
+
+/// A downloaded area with geometry ready to draw.
+struct EInkArea: Identifiable {
+    let id: String                     // H3 cell id
+    let hexagon: [CLLocationCoordinate2D]
+    let center: CLLocationCoordinate2D
+    let synced: Bool                   // the device has it too -> green check
+    let tile: EBM.Tile
+}
+
+/// A downloaded area we can't paint right now — its geometry is still decoding,
+/// it's one of many at a far-out zoom, or the phone no longer holds its tile
+/// data (cache cleared, or another phone sent it). Outlined rather than
+/// dropped, so coverage the user knows about never just vanishes.
+struct OutlineHex: Identifiable {
+    let id: String
+    let hexagon: [CLLocationCoordinate2D]
+    let center: CLLocationCoordinate2D
+    let synced: Bool
+}
+
+/// A hex in the area the user is selecting for download.
+struct SelectionHex: Identifiable {
+    enum Kind { case pending, done, excluded }
+    let id: String
+    let hexagon: [CLLocationCoordinate2D]
+    let kind: Kind
+}
+
+struct MapDestination: Equatable {
+    let name: String
+    let coordinate: CLLocationCoordinate2D
+    static func == (a: Self, b: Self) -> Bool {
+        a.name == b.name &&
+        a.coordinate.latitude == b.coordinate.latitude &&
+        a.coordinate.longitude == b.coordinate.longitude
+    }
+}
+
+/// A one-shot camera move. Identity is the token, so re-issuing the same target
+/// (tapping "recenter" twice) still moves the map.
+struct MapCameraCommand: Equatable {
+    enum Target {
+        case region(MKCoordinateRegion)
+        case rect(MKMapRect)
+        case followUser
+    }
+    let token = UUID()
+    let target: Target
+    static func == (a: Self, b: Self) -> Bool { a.token == b.token }
+}
+
+/// Screen point -> coordinate, for gestures SwiftUI still owns (the drag-a-box
+/// selection). Handed the live map view by the coordinator.
+@MainActor
+final class MapProjection: ObservableObject {
+    fileprivate weak var map: MKMapView?
+    func coordinate(at point: CGPoint) -> CLLocationCoordinate2D? {
+        guard let map, map.bounds.width > 0 else { return nil }
+        return map.convert(point, toCoordinateFrom: map)
+    }
+}
+
+// MARK: - The view
+
+struct EInkMapView: UIViewRepresentable {
+    var areas: [EInkArea] = []
+    var outlines: [OutlineHex] = []
+    var selection: [SelectionHex] = []
+    var route: MKPolyline? = nil
+    var destination: MapDestination? = nil
+    var camera: MapCameraCommand? = nil
+    /// Only turned on once location has actually been granted. MapKit asks for
+    /// location the moment it's told to show the blue dot, which would make
+    /// merely opening a tab raise a permission prompt out of nowhere — the ask
+    /// belongs to the tutorial, the recenter button and Settings, where it comes
+    /// with an explanation.
+    var showsUserLocation = false
+    var showsTrackingButton = false
+    var projection: MapProjection? = nil
+    var onTap: ((CLLocationCoordinate2D) -> Void)? = nil
+    var onLongPress: ((CLLocationCoordinate2D) -> Void)? = nil
+    /// Fires as the user pans/zooms, so the screen can ask the store for the
+    /// areas that just came into view.
+    var onRegionChange: ((MKCoordinateRegion) -> Void)? = nil
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.showsUserLocation = showsUserLocation
+        map.showsCompass = false
+
+        let tap = UITapGestureRecognizer(target: context.coordinator,
+                                         action: #selector(Coordinator.handleTap(_:)))
+        tap.delegate = context.coordinator
+        map.addGestureRecognizer(tap)
+        let press = UILongPressGestureRecognizer(target: context.coordinator,
+                                                 action: #selector(Coordinator.handleLongPress(_:)))
+        press.minimumPressDuration = 0.5
+        press.delegate = context.coordinator
+        map.addGestureRecognizer(press)
+
+        if showsTrackingButton {
+            let button = MKUserTrackingButton(mapView: map)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.backgroundColor = UIColor(Palette.surface)
+            button.layer.cornerRadius = 8
+            button.layer.borderWidth = 1
+            button.layer.borderColor = UIColor(Palette.hairline).cgColor
+            map.addSubview(button)
+            NSLayoutConstraint.activate([
+                button.trailingAnchor.constraint(equalTo: map.safeAreaLayoutGuide.trailingAnchor,
+                                                 constant: -16),
+                // Clear of the floating header pills on the Maps screen.
+                button.topAnchor.constraint(equalTo: map.safeAreaLayoutGuide.topAnchor,
+                                            constant: 60),
+                button.widthAnchor.constraint(equalToConstant: 40),
+                button.heightAnchor.constraint(equalToConstant: 40),
+            ])
+        }
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        let c = context.coordinator
+        c.onTap = onTap
+        c.onLongPress = onLongPress
+        c.onRegionChange = onRegionChange
+        projection?.map = map
+        if map.showsUserLocation != showsUserLocation {
+            map.showsUserLocation = showsUserLocation
+        }
+
+        // Overlays are expensive to rebuild, and SwiftUI calls this for any
+        // state change on the host view (a progress string, a text field). Only
+        // touch MapKit when what's actually drawn has changed.
+        let key = signature()
+        if key != c.contentKey {
+            c.contentKey = key
+            rebuildContent(map, coordinator: c)
+        }
+        if c.destination != destination {
+            c.destination = destination
+            map.annotations.compactMap { $0 as? DestinationAnnotation }.forEach(map.removeAnnotation)
+            if let d = destination {
+                map.addAnnotation(DestinationAnnotation(name: d.name, coordinate: d.coordinate))
+            }
+        }
+        if let camera, camera != c.lastCamera {
+            c.lastCamera = camera
+            apply(camera, to: map)
+        }
+    }
+
+    /// Everything that changes what's drawn, and nothing that doesn't. The route
+    /// is in here because overlays at the same level draw in insertion order —
+    /// it has to be re-added on top whenever the areas underneath are rebuilt,
+    /// or a downloaded area's paper simply paints over it.
+    private func signature() -> String {
+        let a = areas.map { "\($0.id)\($0.synced ? "*" : "")" }.joined(separator: ",")
+        let o = outlines.map { "\($0.id)\($0.synced ? "*" : "")" }.joined(separator: ",")
+        let s = selection.map { "\($0.id)\($0.kind)" }.joined(separator: ",")
+        let r = route.map { "\(ObjectIdentifier($0))" } ?? "-"
+        return "\(a)|\(o)|\(s)|\(r)"
+    }
+
+    private func rebuildContent(_ map: MKMapView, coordinator c: Coordinator) {
+        map.removeOverlays(map.overlays)
+        map.removeAnnotations(map.annotations.compactMap { $0 as? SyncedCheckAnnotation })
+
+        // Selection sits UNDER the e-ink areas: a hex already downloaded should
+        // read as downloaded, not as a pending selection tint.
+        for hex in selection {
+            var pts = hex.hexagon
+            guard pts.count >= 3 else { continue }
+            let poly = StyledPolygon(coordinates: &pts, count: pts.count)
+            poly.style = .selection(hex.kind)
+            map.addOverlay(poly, level: .aboveRoads)
+        }
+        for hex in outlines {
+            var pts = hex.hexagon
+            guard pts.count >= 3 else { continue }
+            let poly = StyledPolygon(coordinates: &pts, count: pts.count)
+            poly.style = .downloadedOutline(synced: hex.synced)
+            map.addOverlay(poly, level: .aboveRoads)
+            if hex.synced { map.addAnnotation(SyncedCheckAnnotation(coordinate: hex.center)) }
+        }
+        // .aboveLabels so Apple's road names don't print through the paper.
+        for area in areas {
+            guard let overlay = EInkOverlay(area: area) else { continue }
+            map.addOverlay(overlay, level: .aboveLabels)
+            if area.synced { map.addAnnotation(SyncedCheckAnnotation(coordinate: area.center)) }
+        }
+        // Last, so the route always sits on top of the paper.
+        if let route { map.addOverlay(route, level: .aboveLabels) }
+        c.route = route
+    }
+
+    private func apply(_ command: MapCameraCommand, to map: MKMapView) {
+        // Only break follow mode if it is actually engaged. Setting the tracking
+        // mode at all makes MapKit ask for location authorization, so doing it
+        // unconditionally raised a permission prompt the moment a map appeared —
+        // before the app had explained anything.
+        func stopFollowing() {
+            if map.userTrackingMode != .none { map.setUserTrackingMode(.none, animated: false) }
+        }
+        switch command.target {
+        case .region(let r):
+            stopFollowing()
+            map.setRegion(r, animated: true)
+        case .rect(let rect):
+            stopFollowing()
+            map.setVisibleMapRect(rect, animated: true)
+        case .followUser:
+            map.setUserTrackingMode(.follow, animated: true)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDelegate {
+        var onTap: ((CLLocationCoordinate2D) -> Void)?
+        var onLongPress: ((CLLocationCoordinate2D) -> Void)?
+        var onRegionChange: ((MKCoordinateRegion) -> Void)?
+        var contentKey = "\u{0}"          // never equal to a real signature
+        var route: MKPolyline?
+        var destination: MapDestination?
+        var lastCamera: MapCameraCommand?
+
+        @objc func handleTap(_ g: UITapGestureRecognizer) {
+            guard let map = g.view as? MKMapView, let onTap else { return }
+            onTap(map.convert(g.location(in: map), toCoordinateFrom: map))
+        }
+
+        @objc func handleLongPress(_ g: UILongPressGestureRecognizer) {
+            guard g.state == .began, let map = g.view as? MKMapView,
+                  let onLongPress else { return }
+            onLongPress(map.convert(g.location(in: map), toCoordinateFrom: map))
+        }
+
+        // Ride alongside MapKit's own pan/zoom rather than swallowing it.
+        func gestureRecognizer(_ g: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+
+        func mapView(_ map: MKMapView, regionDidChangeAnimated animated: Bool) {
+            onRegionChange?(map.region)
+        }
+
+        func mapView(_ map: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let eink = overlay as? EInkOverlay { return EInkRenderer(overlay: eink) }
+            if let poly = overlay as? StyledPolygon {
+                let r = MKPolygonRenderer(polygon: poly)
+                let (fill, stroke) = poly.style.colors
+                r.fillColor = fill
+                r.strokeColor = stroke
+                r.lineWidth = 1.5
+                return r
+            }
+            if let line = overlay as? MKPolyline {
+                let r = MKPolylineRenderer(polyline: line)
+                r.strokeColor = UIColor(Palette.accent)
+                r.lineWidth = 5
+                r.lineCap = .round
+                return r
+            }
+            return MKOverlayRenderer(overlay: overlay)
+        }
+
+        func mapView(_ map: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            if annotation is MKUserLocation { return nil }
+            if annotation is SyncedCheckAnnotation {
+                let id = "synced"
+                let v = map.dequeueReusableAnnotationView(withIdentifier: id)
+                    ?? MKAnnotationView(annotation: annotation, reuseIdentifier: id)
+                v.annotation = annotation
+                v.image = SyncedCheckAnnotation.image
+                v.canShowCallout = false
+                // Never let the checks fight the map for taps — the Maps screen
+                // hit-tests hexes underneath them.
+                v.isUserInteractionEnabled = false
+                return v
+            }
+            if let dest = annotation as? DestinationAnnotation {
+                let id = "destination"
+                let v = (map.dequeueReusableAnnotationView(withIdentifier: id) as? MKMarkerAnnotationView)
+                    ?? MKMarkerAnnotationView(annotation: dest, reuseIdentifier: id)
+                v.annotation = dest
+                v.markerTintColor = UIColor(Palette.accent)
+                v.canShowCallout = true
+                return v
+            }
+            return nil
+        }
+    }
+}
+
+// MARK: - Annotations
+
+private final class SyncedCheckAnnotation: NSObject, MKAnnotation {
+    let coordinate: CLLocationCoordinate2D
+    init(coordinate: CLLocationCoordinate2D) { self.coordinate = coordinate }
+
+    /// Drawn rather than tinted from an SF Symbol: `withTintColor` on a symbol
+    /// came out plain black here, and the mark has to hold its colour over both
+    /// paper and a dark water screentone. The white ring is what keeps it
+    /// legible on the dark half.
+    static let image: UIImage = {
+        let d: CGFloat = 22
+        return UIGraphicsImageRenderer(size: CGSize(width: d, height: d)).image { _ in
+            UIColor.white.setFill()
+            UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: d, height: d)).fill()
+            UIColor(Palette.good).setFill()
+            UIBezierPath(ovalIn: CGRect(x: 1.5, y: 1.5, width: d - 3, height: d - 3)).fill()
+            let check = UIBezierPath()
+            check.move(to: CGPoint(x: 6.2, y: 11.4))
+            check.addLine(to: CGPoint(x: 9.6, y: 14.8))
+            check.addLine(to: CGPoint(x: 15.8, y: 7.4))
+            check.lineWidth = 2.4
+            check.lineCapStyle = .round
+            check.lineJoinStyle = .round
+            UIColor.white.setStroke()
+            check.stroke()
+        }
+    }()
+}
+
+private final class DestinationAnnotation: NSObject, MKAnnotation {
+    let title: String?
+    let coordinate: CLLocationCoordinate2D
+    init(name: String, coordinate: CLLocationCoordinate2D) {
+        title = name
+        self.coordinate = coordinate
+    }
+}
+
+// MARK: - Flat hex overlays (selection + un-previewable device areas)
+
+private final class StyledPolygon: MKPolygon {
+    enum Style {
+        case selection(SelectionHex.Kind)
+        case downloadedOutline(synced: Bool)
+
+        var colors: (fill: UIColor, stroke: UIColor) {
+            switch self {
+            case .downloadedOutline(let synced):
+                let c = UIColor(synced ? Palette.good : Palette.faint)
+                return (c.withAlphaComponent(0.14), c)
+            case .selection(.done):
+                return (UIColor(Palette.good).withAlphaComponent(0.22), UIColor(Palette.good))
+            case .selection(.excluded):
+                return (UIColor(Palette.muted).withAlphaComponent(0.08),
+                        UIColor(Palette.muted).withAlphaComponent(0.55))
+            case .selection(.pending):
+                return (UIColor(Palette.accent).withAlphaComponent(0.16), UIColor(Palette.accent))
+            }
+        }
+    }
+    var style: Style = .selection(.pending)
+}
+
+// MARK: - The e-ink overlay
+
+private final class EInkOverlay: NSObject, MKOverlay {
+    let area: EInkArea
+    let boundingMapRect: MKMapRect
+    /// The hexagon in map-point space — the clip that makes a downloaded area
+    /// stop exactly at its edge, and lets neighbouring hexes meet seamlessly.
+    let hexPath: CGPath
+    var coordinate: CLLocationCoordinate2D { area.center }
+
+    init?(area: EInkArea) {
+        guard area.hexagon.count >= 3 else { return nil }
+        self.area = area
+        let path = CGMutablePath()
+        var rect = MKMapRect.null
+        for (i, c) in area.hexagon.enumerated() {
+            let p = MKMapPoint(c)
+            let pt = CGPoint(x: p.x, y: p.y)
+            if i == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
+            rect = rect.union(MKMapRect(origin: p, size: MKMapSize(width: 0, height: 0)))
+        }
+        path.closeSubpath()
+        hexPath = path
+        boundingMapRect = rect
+        super.init()
+    }
+}
+
+private final class EInkRenderer: MKOverlayRenderer {
+    private let area: EInkArea
+    private let hexPath: CGPath
+
+    init(overlay: EInkOverlay) {
+        area = overlay.area
+        hexPath = overlay.hexPath
+        super.init(overlay: overlay)
+    }
+
+    // Device ink: pure black, because the panel's fast refresh is 1-bit and
+    // cannot show a grey. Paper matches the app's warm off-white.
+    private static let ink = UIColor.black.cgColor
+    private static let paper = UIColor(Palette.paper).cgColor
+
+    /// Thin classes first so a motorway crosses on top of a footpath, as on the
+    /// device (it draws in the same order).
+    private static let drawOrder: [EBM.FeatureClass] =
+        [.path, .minor, .tertiary, .secondary, .primary, .arterial]
+
+    override func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in ctx: CGContext) {
+        // Map points -> this renderer's drawing space. Linear and rotation-free,
+        // so two probes describe it completely, and a prebuilt path (in map
+        // points) can be transformed instead of re-projected point by point.
+        let o = point(for: MKMapPoint(x: 0, y: 0))
+        let probe = point(for: MKMapPoint(x: 1024, y: 1024))
+        let scale = (probe.x - o.x) / 1024
+        guard scale > 0, zoomScale > 0 else { return }
+        var t = CGAffineTransform(translationX: o.x, y: o.y).scaledBy(x: scale, y: scale)
+        guard let hex = hexPath.copy(using: &t) else { return }
+
+        ctx.saveGState()
+        ctx.addPath(hex)
+        ctx.clip()
+
+        ctx.setFillColor(Self.paper)
+        ctx.fill(rect(for: overlay.boundingMapRect))
+
+        // The device sheds detail by metres-per-pixel; mirroring that keeps the
+        // preview honest AND bounds the work when zoomed out.
+        let metersPerPoint = MKMetersPerMapPointAtLatitude(area.center.latitude) / Double(zoomScale)
+
+        // Parks under water: a lake inside a park is water, not parkland.
+        if let parks = area.tile.parks, let p = parks.copy(using: &t) {
+            screentone(p, image: Self.hatchTone, cellPoints: 6,
+                       in: ctx, zoomScale: zoomScale, mapRect: mapRect, scale: scale)
+        }
+        if let water = area.tile.water, let p = water.copy(using: &t) {
+            screentone(p, image: Self.dotTone, cellPoints: 3,
+                       in: ctx, zoomScale: zoomScale, mapRect: mapRect, scale: scale)
+        }
+
+        ctx.setStrokeColor(Self.ink)
+        ctx.setLineCap(.round)
+        ctx.setLineJoin(.round)
+        for cls in Self.drawOrder {
+            guard let width = Self.width(cls, metersPerPoint: metersPerPoint),
+                  let path = area.tile.roads[cls], let p = path.copy(using: &t) else { continue }
+            ctx.saveGState()
+            // A path/trail is a dithered grey line on the panel; a fine dash is
+            // the closest thing that still reads as 1-bit here.
+            if cls == .path {
+                let d = 1.5 / Double(zoomScale)
+                ctx.setLineDash(phase: 0, lengths: [d, d])
+            }
+            ctx.setLineWidth(width / Double(zoomScale))
+            ctx.addPath(p)
+            ctx.strokePath()
+            ctx.restoreGState()
+        }
+        ctx.restoreGState()
+
+        // Edge last and unclipped, so the full stroke shows: green where the
+        // device has this area too, quiet hairline where it's only on the phone.
+        ctx.addPath(hex)
+        ctx.setStrokeColor(UIColor(area.synced ? Palette.good : Palette.faint).cgColor)
+        ctx.setLineWidth((area.synced ? 2.0 : 1.0) / Double(zoomScale))
+        ctx.strokePath()
+    }
+
+    /// Stroke width in screen points, or nil when the device would shed this
+    /// class at this zoom (map_view.cpp styleFor + map_tiles.cpp shedding).
+    private static func width(_ cls: EBM.FeatureClass, metersPerPoint mpp: Double) -> Double? {
+        switch cls {
+        case .path:      return mpp >= 4 ? nil : 1
+        case .minor:     return mpp >= 16 ? nil : 2
+        case .secondary: return mpp >= 32 ? nil : 3
+        case .tertiary:  return mpp >= 32 ? nil : 2
+        case .primary:   return mpp >= 16 ? 2 : 4
+        case .arterial:  return mpp >= 16 ? 2 : 5
+        }
+    }
+
+    /// Fills `path` with a 1-bit tone, drawn at a constant size on screen.
+    ///
+    /// The tile origin is snapped to a global grid in MAP-POINT space, with the
+    /// cell quantised to a power of two. Both matter: MapKit hands this renderer
+    /// one sub-rect at a time and each downloaded hex is a separate overlay, so
+    /// anchoring the pattern to anything local would print a visible seam at
+    /// every tile and hex boundary.
+    private func screentone(_ path: CGPath, image: CGImage?, cellPoints: Double,
+                            in ctx: CGContext, zoomScale: MKZoomScale,
+                            mapRect: MKMapRect, scale: Double) {
+        guard let image else { return }
+        let cellMapRaw = cellPoints / Double(zoomScale)
+        guard cellMapRaw > 0, cellMapRaw.isFinite else { return }
+        let cellMap = pow(2, log2(cellMapRaw).rounded())
+        let anchorX = (mapRect.minX / cellMap).rounded(.down) * cellMap
+        let anchorY = (mapRect.minY / cellMap).rounded(.down) * cellMap
+        let origin = point(for: MKMapPoint(x: anchorX, y: anchorY))
+        let cell = cellMap * scale
+        guard cell > 0.01 else { return }
+
+        ctx.saveGState()
+        ctx.addPath(path)
+        ctx.clip()
+        ctx.interpolationQuality = .none    // keep the tone hard-edged, not blurred
+        ctx.draw(image, in: CGRect(x: origin.x, y: origin.y, width: cell, height: cell),
+                 byTiling: true)
+        ctx.restoreGState()
+    }
+
+    // The device's tones are dots for water and diagonal stripes for parks, and
+    // that CHARACTER is what has to survive here — it's how the two read apart
+    // at a glance. Their exact ink coverage cannot: on a 235 ppi panel the
+    // water's 75% dots integrate into a dark grey, but a phone screentone big
+    // enough to still look dotted is coarse enough that 75% is simply black, and
+    // the bay swallows the map. So the patterns are kept and the coverage is
+    // lightened, preserving the device's ordering — water darker than parkland.
+    private static let dotTone = makeTone(2) { x, y in (x & 1) == (y & 1) }        // 50% dots
+    private static let hatchTone = makeTone(4) { x, y in ((x - y) & 3) < 1 }       // 25% stripes
+
+    /// A tiny opaque-black-on-clear bitmap, tiled by `screentone`.
+    private static func makeTone(_ size: Int, _ on: (Int, Int) -> Bool) -> CGImage? {
+        var px = [UInt8](repeating: 0, count: size * size * 4)   // RGBA, premultiplied
+        for y in 0..<size {
+            for x in 0..<size where on(x, y) {
+                let i = (y * size + x) * 4
+                px[i] = 0; px[i + 1] = 0; px[i + 2] = 0; px[i + 3] = 255
+            }
+        }
+        guard let provider = CGDataProvider(data: Data(px) as CFData) else { return nil }
+        return CGImage(width: size, height: size, bitsPerComponent: 8, bitsPerPixel: 32,
+                       bytesPerRow: size * 4, space: CGColorSpaceCreateDeviceRGB(),
+                       bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+                       provider: provider, decode: nil, shouldInterpolate: false,
+                       intent: .defaultIntent)
+    }
+}

--- a/companion-ios/Sources/EInkTileStore.swift
+++ b/companion-ios/Sources/EInkTileStore.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Combine
+import MapKit
+
+/// Holds decoded map geometry for the areas this phone has downloaded, so the
+/// map can draw them in the device's own e-ink style.
+///
+/// Two separate facts, deliberately kept apart:
+///   * `ids` — every area we hold tile DATA for. This is what "downloaded"
+///     means on the map, and it comes from `TileCache` (the same blobs that get
+///     streamed to the device).
+///   * `BLEManager.deviceTileIds` — what the DEVICE has. The intersection is
+///     what earns a green check.
+///
+/// Decoding happens off the main actor; the renderer is never allowed to touch
+/// the disk, so only tiles already decoded get an overlay. A tile appears the
+/// moment its decode lands.
+@MainActor
+final class EInkTileStore: ObservableObject {
+    static let shared = EInkTileStore()
+
+    /// Bumps whenever the drawable set changes, so views re-diff their overlays.
+    @Published private(set) var version = 0
+
+    /// Areas we hold data for on disk.
+    private(set) var ids: Set<String> = []
+
+    private var loaded: [String: EBM.Tile] = [:]
+    private var loading: Set<String> = []
+    private var recency: [String] = []          // LRU, most recent last
+    private var heldPoints = 0
+
+    /// Roughly 20 MB of geometry (a point is two doubles in a CGPath, plus
+    /// overhead). Well past a screenful of res-6 hexes; the LRU only bites when
+    /// panning across a large downloaded region.
+    private let pointBudget = 1_200_000
+
+    /// Re-read which areas exist on disk. Cheap (one directory listing).
+    func refresh() {
+        Task {
+            let disk = await TileCache.shared.cachedIds()
+            guard disk != ids else { return }
+            ids = disk
+            // Drop geometry for areas that vanished (cache cleared).
+            for gone in loaded.keys where !disk.contains(gone) { evict(gone) }
+            version += 1
+        }
+    }
+
+    /// Decoded geometry, or nil if it hasn't been decoded yet.
+    func tile(for id: String) -> EBM.Tile? { loaded[id] }
+
+    /// What the map should draw for `region`, split into areas we can render in
+    /// the device's style and ones we can only outline.
+    ///
+    /// `synced` is the device's own tile list, so the two states the user asked
+    /// about — downloaded, and downloaded *and* on the device — are decided in
+    /// one place. Anything the device has but this phone has no data for still
+    /// gets an outline: coverage the user knows about must not vanish just
+    /// because the preview can't be drawn.
+    func visibleContent(in region: MKCoordinateRegion, synced: Set<String>)
+        -> (areas: [EInkArea], outlines: [OutlineHex]) {
+        let all = ids.union(synced)
+        guard !all.isEmpty, region.span.latitudeDelta > 0 else { return ([], []) }
+
+        // Pad by a hex so an area half off-screen still draws to the edge.
+        let padLat = region.span.latitudeDelta / 2 + 0.06
+        let padLon = region.span.longitudeDelta / 2 + 0.06
+        let s = region.center.latitude - padLat, n = region.center.latitude + padLat
+        let w = region.center.longitude - padLon, e = region.center.longitude + padLon
+
+        var near: [(tile: MapTile, distance: Double)] = []
+        for id in all {
+            guard let t = geometry(id) else { continue }
+            guard t.north >= s, t.south <= n, t.east >= w, t.west <= e else { continue }
+            let dLat = t.center.latitude - region.center.latitude
+            let dLon = t.center.longitude - region.center.longitude
+            near.append((t, dLat * dLat + dLon * dLon))
+        }
+        // Zoomed out far enough to see hundreds of areas, the ink is sub-pixel
+        // anyway. Draw the nearest in full and outline the rest rather than
+        // silently dropping them.
+        near.sort { $0.distance < $1.distance }
+        let drawable = near.prefix(previewLimit).map(\.tile)
+        let rest = near.dropFirst(previewLimit).map(\.tile)
+
+        ensureLoaded(drawable.filter { ids.contains($0.id) }.map(\.id))
+
+        var areas: [EInkArea] = []
+        var outlines: [OutlineHex] = []
+        for t in drawable {
+            if let geo = loaded[t.id] {
+                areas.append(EInkArea(id: t.id, hexagon: t.hexagon, center: t.center,
+                                      synced: synced.contains(t.id), tile: geo))
+            } else {
+                outlines.append(OutlineHex(id: t.id, hexagon: t.hexagon, center: t.center,
+                                           synced: synced.contains(t.id)))
+            }
+        }
+        for t in rest {
+            outlines.append(OutlineHex(id: t.id, hexagon: t.hexagon, center: t.center,
+                                       synced: synced.contains(t.id)))
+        }
+        return (areas, outlines)
+    }
+
+    private let previewLimit = 80
+
+    /// H3 id -> hexagon, memoised. Every id is a fixed cell on the globe, so
+    /// this never needs invalidating.
+    private var geometryCache: [String: MapTile] = [:]
+    private func geometry(_ id: String) -> MapTile? {
+        if let t = geometryCache[id] { return t }
+        let cell = h3_from_id(id)
+        guard cell != 0 else { return nil }
+        let t = H3Tiles.tile(from: cell)
+        geometryCache[id] = t
+        return t
+    }
+
+    /// Ask for these areas to be available to draw. Already-loaded ids are just
+    /// marked recently used; the rest are decoded in the background.
+    func ensureLoaded(_ wanted: [String]) {
+        for id in wanted {
+            touch(id)
+            guard loaded[id] == nil, !loading.contains(id), ids.contains(id) else { continue }
+            loading.insert(id)
+            Task.detached(priority: .utility) {
+                let blob = await TileCache.shared.displayData(for: id)
+                let tile = blob.flatMap { EBM.decode($0) }
+                await MainActor.run { self.finishLoad(id, tile) }
+            }
+        }
+    }
+
+    /// Called after a download so freshly built areas draw without a restart.
+    func noteDownloaded(_ newIds: [String]) {
+        guard !newIds.isEmpty else { return }
+        ids.formUnion(newIds)
+        // Re-decode rather than trusting a stale in-memory copy: a rebuilt area
+        // can legitimately differ from the one we already drew.
+        for id in newIds { evict(id) }
+        version += 1
+    }
+
+    private func finishLoad(_ id: String, _ tile: EBM.Tile?) {
+        loading.remove(id)
+        guard let tile else {
+            // Undecodable (truncated write, format drift): forget it so we
+            // don't retry every pan, and so it draws as plain Apple Maps.
+            ids.remove(id)
+            version += 1
+            return
+        }
+        loaded[id] = tile
+        heldPoints += tile.pointCount
+        touch(id)
+        trim()
+        version += 1
+    }
+
+    private func touch(_ id: String) {
+        if let i = recency.firstIndex(of: id) { recency.remove(at: i) }
+        recency.append(id)
+    }
+
+    private func evict(_ id: String) {
+        if let t = loaded.removeValue(forKey: id) { heldPoints -= t.pointCount }
+        recency.removeAll { $0 == id }
+    }
+
+    /// Drop least-recently-wanted geometry until back inside the budget. Never
+    /// drops the most recent entries, which are what's on screen right now.
+    private func trim() {
+        var i = 0
+        while heldPoints > pointBudget, i < recency.count, recency.count > 4 {
+            let victim = recency[i]
+            if loaded[victim] != nil { evict(victim) } else { i += 1 }
+        }
+    }
+}

--- a/companion-ios/Sources/MapsView.swift
+++ b/companion-ios/Sources/MapsView.swift
@@ -15,14 +15,20 @@ struct MapsView: View {
 
     // Res-6 H3 tiles are ~5.6 km across; start wide enough to show at least
     // 3–4 of them across the screen (~0.25° ≈ 22 km) so a whole area is easy to
-    // box in one drag. `.userLocation` would snap to MapKit's default
+    // box in one drag. Following the user would snap to MapKit's default
     // street-level zoom (far too tight for tile selection), so we center on the
     // user ourselves once a fix arrives (see `locator`), keeping this fixed
     // span. Falls back to a fixed region until then.
-    @State private var cam: MapCameraPosition = .region(
-        MKCoordinateRegion(center: .init(latitude: 37.7764, longitude: -122.4346),
-                           span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25)))
+    @State private var camera: MapCameraCommand? =
+        MapCameraCommand(target: .region(MKCoordinateRegion(
+            center: .init(latitude: 37.7764, longitude: -122.4346),
+            span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25))))
     @StateObject private var locator = MapLocator()
+    @StateObject private var projection = MapProjection()
+    @ObservedObject private var store = EInkTileStore.shared
+    @State private var visibleRegion: MKCoordinateRegion?
+    @State private var einkAreas: [EInkArea] = []
+    @State private var outlineHexes: [OutlineHex] = []
     @State private var didCenter = false
     @State private var dragStart: CGPoint?
     @State private var dragEnd: CGPoint?
@@ -42,13 +48,18 @@ struct MapsView: View {
     @State private var downloadTotal = 0            // hexes targeted this run
     @State private var downloadTask: Task<Void, Never>?
 
-    // Tiles the device already has, as drawable rectangles.
-    private var deviceTiles: [MapTile] {
-        ble.deviceTileIds.compactMap { id in
-            let cell = h3_from_id(id)
-            return cell == 0 ? nil : H3Tiles.tile(from: cell)
+    // Hexes in the drawn box that aren't on the device yet, in whichever state
+    // the download has reached. Areas already downloaded are NOT in here — they
+    // draw as e-ink underneath, which says "you have this" far better than a
+    // selection tint would.
+    private var selectionHexes: [SelectionHex] {
+        tiles.filter { !ble.deviceTileIds.contains($0.id) }.map { t in
+            SelectionHex(id: t.id, hexagon: t.hexagon,
+                         kind: converted.contains(t.id) ? .done
+                             : excluded.contains(t.id) ? .excluded : .pending)
         }
     }
+
     // Tiles that will actually be sent: not already on the device and not
     // tapped-out by the user.
     private var newTiles: [MapTile] {
@@ -66,73 +77,71 @@ struct MapsView: View {
 
     var body: some View {
         NavigationStack {
-            MapReader { proxy in
-                ZStack(alignment: .top) {
-                    HexMap(cam: $cam, deviceTiles: deviceTiles,
-                           selection: tiles.filter { !ble.deviceTileIds.contains($0.id) },
-                           converted: converted, excluded: excluded)
-                    .mapControls { MapUserLocationButton() }
-                    .ignoresSafeArea(edges: .top)
+            ZStack(alignment: .top) {
+                EInkMapView(
+                    areas: einkAreas,
+                    outlines: outlineHexes,
+                    selection: selectionHexes,
+                    camera: camera,
+                    showsUserLocation: ble.locationPermission.isGranted,
+                    showsTrackingButton: true,
+                    projection: projection,
                     // Tap a hex (once an area is drawn) to skip/keep it.
-                    .simultaneousGesture(SpatialTapGesture().onEnded { e in
-                        guard box != nil, !drawMode,
-                              let c = proxy.convert(e.location, from: .local) else { return }
+                    onTap: { c in
+                        guard box != nil, !drawMode else { return }
                         toggleHex(at: c)
-                    })
+                    },
                     // Long-press any hex to read its id. Deliberately NOT gated
                     // on an area being drawn — inspecting a hex already on the
                     // device is the more useful case of the two.
-                    .simultaneousGesture(
-                        LongPressGesture(minimumDuration: 0.5)
-                            .sequenced(before: SpatialTapGesture())
-                            .onEnded { value in
-                                guard !drawMode,
-                                      case .second(_, let tap?) = value,
-                                      let c = proxy.convert(tap.location, from: .local),
-                                      let id = H3Tiles.id(at: c) else { return }
-                                inspected = (id, ble.deviceTileIds.contains(id))
-                                UIImpactFeedbackGenerator(style: .medium)
-                                    .impactOccurred()
-                            })
+                    onLongPress: { c in
+                        guard !drawMode, let id = H3Tiles.id(at: c) else { return }
+                        inspected = (id, ble.deviceTileIds.contains(id))
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    },
+                    onRegionChange: { r in
+                        visibleRegion = r
+                        refreshEInk()
+                    })
+                .ignoresSafeArea(edges: .top)
 
-                    // In draw mode a transparent layer captures the drag so the
-                    // map doesn't pan while you draw a box.
-                    if drawMode {
-                        Rectangle().fill(Color.black.opacity(0.001))
-                            .contentShape(Rectangle())
-                            .gesture(DragGesture(minimumDistance: 4)
-                                .onChanged { g in
-                                    if dragStart == nil { dragStart = g.startLocation }
-                                    dragEnd = g.location
+                // In draw mode a transparent layer captures the drag so the
+                // map doesn't pan while you draw a box.
+                if drawMode {
+                    Rectangle().fill(Color.black.opacity(0.001))
+                        .contentShape(Rectangle())
+                        .gesture(DragGesture(minimumDistance: 4)
+                            .onChanged { g in
+                                if dragStart == nil { dragStart = g.startLocation }
+                                dragEnd = g.location
+                            }
+                            .onEnded { _ in
+                                if let a = dragStart, let b = dragEnd,
+                                   let c1 = projection.coordinate(at: a),
+                                   let c2 = projection.coordinate(at: b) {
+                                    let bx = (min(c1.latitude, c2.latitude), min(c1.longitude, c2.longitude),
+                                              max(c1.latitude, c2.latitude), max(c1.longitude, c2.longitude))
+                                    box = bx
+                                    tiles = H3Tiles.coveringTiles(south: bx.0, west: bx.1, north: bx.2, east: bx.3)
+                                    excluded = []
+                                    converted = []
+                                    status = nil
                                 }
-                                .onEnded { _ in
-                                    if let a = dragStart, let b = dragEnd,
-                                       let c1 = proxy.convert(a, from: .local),
-                                       let c2 = proxy.convert(b, from: .local) {
-                                        let bx = (min(c1.latitude, c2.latitude), min(c1.longitude, c2.longitude),
-                                                  max(c1.latitude, c2.latitude), max(c1.longitude, c2.longitude))
-                                        box = bx
-                                        tiles = H3Tiles.coveringTiles(south: bx.0, west: bx.1, north: bx.2, east: bx.3)
-                                        excluded = []
-                                        converted = []
-                                        status = nil
-                                    }
-                                    dragStart = nil; dragEnd = nil
-                                    drawMode = false
-                                })
-                            .ignoresSafeArea(edges: .top)
-                    }
-
-                    if let a = dragStart, let b = dragEnd {
-                        Rectangle().fill(Palette.accent.opacity(0.18))
-                            .overlay(Rectangle().stroke(Palette.accent, lineWidth: 2))
-                            .frame(width: abs(b.x - a.x), height: abs(b.y - a.y))
-                            .position(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
-                            .allowsHitTesting(false)
-                    }
-
-                    header
+                                dragStart = nil; dragEnd = nil
+                                drawMode = false
+                            })
+                        .ignoresSafeArea(edges: .top)
                 }
+
+                if let a = dragStart, let b = dragEnd {
+                    Rectangle().fill(Palette.accent.opacity(0.18))
+                        .overlay(Rectangle().stroke(Palette.accent, lineWidth: 2))
+                        .frame(width: abs(b.x - a.x), height: abs(b.y - a.y))
+                        .position(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
+                        .allowsHitTesting(false)
+                }
+
+                header
             }
             .navigationBarHidden(true)
             .sheet(item: Binding(
@@ -142,17 +151,32 @@ struct MapsView: View {
                 TileInspectorSheet(info: info)
             }
             .safeAreaInset(edge: .bottom) { bottomBar }
-            .onAppear { ble.refreshDeviceMaps(); ble.refreshDeviceTiles(); locator.start() }
+            .onAppear {
+                ble.refreshDeviceMaps(); ble.refreshDeviceTiles(); locator.start()
+                store.refresh()
+            }
+            // Redraw when a tile finishes decoding, or when the device's own
+            // tile list arrives and flips areas to "synced".
+            .onChange(of: store.version) { refreshEInk() }
+            .onChange(of: ble.deviceTileIds) { refreshEInk() }
             // Center on the user's first fix, once, at our fixed tile-friendly
             // span. Only before any interaction so it never yanks the map away
             // from a box the user is drawing.
             .onReceive(locator.$coordinate) { coord in
                 guard !didCenter, box == nil, !drawMode, let coord else { return }
                 didCenter = true
-                cam = .region(MKCoordinateRegion(center: coord,
-                    span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25)))
+                camera = MapCameraCommand(target: .region(MKCoordinateRegion(center: coord,
+                    span: MKCoordinateSpan(latitudeDelta: 0.25, longitudeDelta: 0.25))))
             }
         }
+    }
+
+    /// Ask the store what to draw for the region now on screen.
+    private func refreshEInk() {
+        guard let r = visibleRegion else { return }
+        let content = store.visibleContent(in: r, synced: ble.deviceTileIds)
+        einkAreas = content.areas
+        outlineHexes = content.outlines
     }
 
     private var header: some View {
@@ -261,7 +285,7 @@ struct MapsView: View {
         card {
             VStack(alignment: .leading, spacing: 3) {
                 Text(drawMode ? "Drag a box across the area you want."
-                              : "Tap “Select area”, then drag a box. Blue = already on the device.")
+                              : "Tap “Select area”, then drag a box. Areas drawn like the device’s screen are downloaded; a green check means the device has them too.")
                     .font(BarlowFont.text(14)).foregroundStyle(drawMode ? Palette.accent : Palette.muted)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if !ble.deviceTileIds.isEmpty {
@@ -326,6 +350,7 @@ struct MapsView: View {
                     converted.formUnion(cached.map(\.id))
                     anyBuilt = true
                     ble.enqueueTiles(cached)
+                    store.noteDownloaded(cached.map(\.id))
                 }
                 // ONE coastline fetch for the whole selection, padded well past
                 // it. Sea fill needs the COAST, and an ocean-only selection does
@@ -412,6 +437,9 @@ struct MapsView: View {
                     // Cache BEFORE sending: if the link drops mid-transfer the
                     // expensive work survives and the retry is instant.
                     await TileCache.shared.store(withElev)
+                    // Draw the new areas in the device's style straight away —
+                    // the download IS what "downloaded" means on this map.
+                    store.noteDownloaded(withElev.map(\.id))
                     ble.enqueueTiles(withElev)             // send in parallel with the next fetch
                 }
                 building = false
@@ -471,61 +499,6 @@ struct MapsView: View {
     }
 
     nonisolated func locationManager(_ m: CLLocationManager, didFailWithError error: Error) {}
-}
-
-
-/// The hex overlay map, pulled out of MapsView so that view's frequently
-/// changing state cannot invalidate it.
-///
-/// The fetch progress callback updates `status` many times a second, and while
-/// the Map lived in MapsView's body every one of those re-evaluated the body and
-/// rebuilt the Map and every MapPolygon — the map visibly flashed and stuttered
-/// for the whole download. Here its inputs are only the things that actually
-/// change what is drawn, and Equatable lets SwiftUI skip the rebuild when none
-/// of them moved.
-private struct HexMap: View, Equatable {
-    @Binding var cam: MapCameraPosition
-    let deviceTiles: [MapTile]
-    let selection: [MapTile]
-    let converted: Set<String>
-    let excluded: Set<String>
-
-    static func == (a: HexMap, b: HexMap) -> Bool {
-        a.deviceTiles.map(\.id) == b.deviceTiles.map(\.id) &&
-        a.selection.map(\.id) == b.selection.map(\.id) &&
-        a.converted == b.converted && a.excluded == b.excluded
-    }
-
-    var body: some View {
-        Map(position: $cam) {
-            UserAnnotation()
-            // Hexes already on the device — green highlight + a green check in
-            // the middle. Drawn once here (not repeated in the selection loop).
-            ForEach(deviceTiles) { t in
-                MapPolygon(coordinates: t.hexagon)
-                    .foregroundStyle(Palette.good.opacity(0.25))
-                    .stroke(Palette.good, lineWidth: 1.5)
-                Annotation("", coordinate: t.center) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 15))
-                        .foregroundStyle(Palette.good)
-                }
-            }
-            // Selection hexes NOT yet on the device. converted this run → green;
-            // tapped out → faint; pending → accent.
-            ForEach(selection) { t in
-                let done = converted.contains(t.id)
-                let off = excluded.contains(t.id)
-                MapPolygon(coordinates: t.hexagon)
-                    .foregroundStyle(done ? Palette.good.opacity(0.22)
-                                     : off ? Palette.muted.opacity(0.08)
-                                           : Palette.accent.opacity(0.16))
-                    .stroke(done ? Palette.good
-                            : off ? Palette.muted.opacity(0.55) : Palette.accent,
-                            lineWidth: 1.5)
-            }
-        }
-    }
 }
 
 

--- a/companion-ios/Sources/OnboardingView.swift
+++ b/companion-ios/Sources/OnboardingView.swift
@@ -152,7 +152,8 @@ struct OnboardingView: View {
 
     private var locationStep: some View {
         page(
-            art: AnyView(iconBadge("location.fill", tint: tint(ble.locationPermission))),
+            art: AnyView(SketchIcon(glyph: .location, tint: tint(ble.locationPermission),
+                                    active: step == 2)),
             title: "Share your location",
             body: "Used to show your position on the map, warm-start the device's GPS so it locks on fast, and act as a backup fix when the device can't see the sky. Only while you're using the app.",
             note: AnyView(statusChip(for: ble.locationPermission,
@@ -164,7 +165,8 @@ struct OnboardingView: View {
 
     private var bluetoothStep: some View {
         page(
-            art: AnyView(iconBadge("dot.radiowaves.left.and.right", tint: tint(ble.bluetoothPermission))),
+            art: AnyView(SketchIcon(glyph: .waves, tint: tint(ble.bluetoothPermission),
+                                    active: step == 3)),
             title: "Connect over Bluetooth",
             body: "Everything travels to and from your OpenTrailPaper over Bluetooth — routes, offline maps, settings and recorded rides. No account, no cloud. Next, we'll link the app to your device.",
             note: AnyView(bluetoothNote)
@@ -221,7 +223,8 @@ struct OnboardingView: View {
     private var connectStep: some View {
         VStack(spacing: 0) {
             Spacer()
-            iconBadge(connectSymbol, tint: connectTint)
+            SketchIcon(glyph: ble.state == .connected ? .check : .waves,
+                       tint: connectTint, active: step == 4)
                 .padding(.bottom, 36)
             Text("Pair with your device")
                 .font(TypeScale.screenTitle)
@@ -243,9 +246,6 @@ struct OnboardingView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private var connectSymbol: String {
-        ble.state == .connected ? "checkmark.circle.fill" : "antenna.radiowaves.left.and.right"
-    }
     private var connectTint: Color {
         ble.state == .connected ? Palette.good : Palette.accent
     }
@@ -281,7 +281,7 @@ struct OnboardingView: View {
 
     private var ready: some View {
         page(
-            art: AnyView(iconBadge("checkmark", tint: Palette.good)),
+            art: AnyView(SketchIcon(glyph: .check, tint: Palette.good, active: step == lastStep)),
             title: "You're all set",
             body: "Your device connects on its own whenever it's on and nearby — you'll see it on the Ride tab. Plan a route or build a map any time, and it syncs over. Anything you skipped is listed under Permissions in Settings."
         )
@@ -332,16 +332,6 @@ struct OnboardingView: View {
         }
     }
 
-    private func iconBadge(_ symbol: String, tint: Color) -> some View {
-        ZStack {
-            Circle()
-                .fill(tint.opacity(0.12))
-                .frame(width: 132, height: 132)
-            Image(systemName: symbol)
-                .font(.system(size: 56, weight: .semibold))
-                .foregroundStyle(tint)
-        }
-    }
 
     // MARK: button logic
 

--- a/companion-ios/Sources/OnboardingView.swift
+++ b/companion-ios/Sources/OnboardingView.swift
@@ -4,12 +4,18 @@ import SwiftUI
 // the two system permission prompts (location, Bluetooth) on their own
 // explaining screens — so the OS dialog arrives with context rather than cold
 // at launch. Shown once; gated by BLEManager.onboardedKey.
+//
+// Every screen that explains a permission must be able to ACT on it, which is
+// what the permission steps below are built around: if it hasn't been asked, the
+// button raises the system prompt; if it was refused, the button opens Settings
+// (the only place that can be undone); either way there is always a way past the
+// screen without granting anything. A screen that describes a permission and
+// then can't do anything about it is the failure mode to avoid.
 struct OnboardingView: View {
     @EnvironmentObject var ble: BLEManager
     var onFinish: () -> Void
 
     @State private var step = OnboardingView.initialStep
-    @State private var askedThisStep = false
 
     private let lastStep = 5
 
@@ -50,7 +56,6 @@ struct OnboardingView: View {
         .onChange(of: ble.bluetoothReady) { _, ready in
             if step == 3, ready { advance() }
         }
-        .onChange(of: step) { _, _ in askedThisStep = false }
     }
 
     // MARK: chrome
@@ -83,15 +88,14 @@ struct OnboardingView: View {
 
     private var footer: some View {
         VStack(spacing: 12) {
-            PrimaryButton(title: primaryTitle, action: primaryAction)
-            // Permission steps: an out on the same screen as the ask.
-            if step == 2 || step == 3 {
-                Button(askedThisStep ? "Continue" : "Not now") {
-                    advance()
-                }
-                .font(TypeScale.bodyStrong)
-                .foregroundStyle(Palette.muted)
-                .opacity(askedThisStep ? 0 : 1)   // once asked, primary says Continue
+            PrimaryButton(title: stepAction.title, action: primaryAction)
+            // Permission steps always keep an out on the same screen as the ask,
+            // so declining never traps anyone. Hidden only when the primary
+            // button IS "Continue" — two identical buttons help nobody.
+            if let state = permissionState, stepAction.kind != .next {
+                Button(state == .notDetermined ? "Not now" : "Continue") { advance() }
+                    .font(TypeScale.bodyStrong)
+                    .foregroundStyle(Palette.muted)
             }
         }
         .padding(.horizontal, 24)
@@ -148,18 +152,68 @@ struct OnboardingView: View {
 
     private var locationStep: some View {
         page(
-            art: AnyView(iconBadge("location.fill", tint: Palette.accent)),
+            art: AnyView(iconBadge("location.fill", tint: tint(ble.locationPermission))),
             title: "Share your location",
-            body: "Used to show your position on the map, warm-start the device's GPS so it locks on fast, and act as a backup fix when the device can't see the sky. Only while you're using the app."
+            body: "Used to show your position on the map, warm-start the device's GPS so it locks on fast, and act as a backup fix when the device can't see the sky. Only while you're using the app.",
+            note: AnyView(statusChip(for: ble.locationPermission,
+                                     granted: "Location allowed",
+                                     denied: "Location is off for this app. Open Settings to allow it — the map still works without it.",
+                                     unavailable: "Location is restricted on this iPhone."))
         )
     }
 
     private var bluetoothStep: some View {
         page(
-            art: AnyView(iconBadge("dot.radiowaves.left.and.right", tint: Palette.accent)),
+            art: AnyView(iconBadge("dot.radiowaves.left.and.right", tint: tint(ble.bluetoothPermission))),
             title: "Connect over Bluetooth",
-            body: "Everything travels to and from your OpenTrailPaper over Bluetooth — routes, offline maps, settings and recorded rides. No account, no cloud. Next, we'll link the app to your device."
+            body: "Everything travels to and from your OpenTrailPaper over Bluetooth — routes, offline maps, settings and recorded rides. No account, no cloud. Next, we'll link the app to your device.",
+            note: AnyView(bluetoothNote)
         )
+    }
+
+    // Bluetooth has a fourth state the others don't: allowed, but the radio is
+    // switched off. That is not a refused permission and must not be reported as
+    // one — no button of ours can fix it, only Control Centre.
+    @ViewBuilder private var bluetoothNote: some View {
+        if ble.bluetoothPermission.isGranted && !ble.bluetoothPoweredOn {
+            chip("Bluetooth is switched off — turn it on in Control Centre.",
+                 symbol: "exclamationmark.circle.fill", tint: Palette.accent)
+        } else {
+            statusChip(for: ble.bluetoothPermission,
+                       granted: "Bluetooth allowed",
+                       denied: "Bluetooth is off for this app. Open Settings to allow it — without it the app can't reach your device at all.",
+                       unavailable: "Bluetooth is restricted on this iPhone.")
+        }
+    }
+
+    @ViewBuilder private func statusChip(for state: PermissionState, granted: String,
+                                         denied: String, unavailable: String) -> some View {
+        switch state {
+        case .granted:      chip(granted, symbol: "checkmark.circle.fill", tint: Palette.good)
+        case .denied:       chip(denied, symbol: "exclamationmark.circle.fill", tint: Palette.accent)
+        case .unavailable:  chip(unavailable, symbol: "lock.circle.fill", tint: Palette.muted)
+        case .notDetermined: EmptyView()
+        }
+    }
+
+    private func chip(_ text: String, symbol: String, tint: Color) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: symbol).foregroundStyle(tint)
+            Text(text)
+                .font(BarlowFont.text(13))
+                .foregroundStyle(Palette.muted)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+        .background(Palette.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .strokeBorder(Palette.hairline, lineWidth: 1))
+    }
+
+    private func tint(_ state: PermissionState) -> Color {
+        state.isGranted ? Palette.good : Palette.accent
     }
 
     // Reassures the user the app pairs with the head unit, and — because the
@@ -229,13 +283,14 @@ struct OnboardingView: View {
         page(
             art: AnyView(iconBadge("checkmark", tint: Palette.good)),
             title: "You're all set",
-            body: "Your device connects on its own whenever it's on and nearby — you'll see it on the Ride tab. Plan a route or build a map any time, and it syncs over. You can change permissions later in Settings."
+            body: "Your device connects on its own whenever it's on and nearby — you'll see it on the Ride tab. Plan a route or build a map any time, and it syncs over. Anything you skipped is listed under Permissions in Settings."
         )
     }
 
     // MARK: pieces
 
-    private func page(art: AnyView, title: String, body: String) -> some View {
+    private func page(art: AnyView, title: String, body: String,
+                      note: AnyView? = nil) -> some View {
         VStack(spacing: 0) {
             Spacer()
             art
@@ -251,6 +306,7 @@ struct OnboardingView: View {
                 .multilineTextAlignment(.center)
                 .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)
+            if let note { note.padding(.top, 22) }
             Spacer()
             Spacer()
         }
@@ -289,27 +345,48 @@ struct OnboardingView: View {
 
     // MARK: button logic
 
-    private var primaryTitle: String {
+    /// The permission this step is about, if any.
+    private var permissionState: PermissionState? {
         switch step {
-        case 2: return askedThisStep ? "Continue" : "Allow location access"
-        case 3: return askedThisStep ? "Continue" : "Enable Bluetooth"
-        case lastStep: return "Start riding"
-        default: return "Continue"
+        case 2: return ble.locationPermission
+        case 3: return ble.bluetoothPermission
+        default: return nil
+        }
+    }
+
+    private struct StepAction {
+        enum Kind { case ask, openSettings, next, finish }
+        let title: String
+        let kind: Kind
+    }
+
+    /// What the primary button says and does. The permission steps are driven
+    /// entirely by the current state, so the button can never be an ask that
+    /// raises no prompt (iOS only prompts once) or a dead end after a refusal.
+    private var stepAction: StepAction {
+        if step == lastStep { return .init(title: "Start riding", kind: .finish) }
+        guard let state = permissionState else { return .init(title: "Continue", kind: .next) }
+        switch state {
+        case .notDetermined:
+            return .init(title: step == 2 ? "Allow location access" : "Enable Bluetooth",
+                         kind: .ask)
+        case .denied:
+            return .init(title: "Open Settings", kind: .openSettings)
+        case .granted, .unavailable:
+            return .init(title: "Continue", kind: .next)
         }
     }
 
     private func primaryAction() {
-        switch step {
-        case 2:
-            if askedThisStep { advance() }
-            else { ble.requestLocationPermission(); askedThisStep = true }
-        case 3:
-            if askedThisStep { advance() }
-            else { ble.enableBluetooth(); askedThisStep = true }
-        case lastStep:
-            onFinish()
-        default:
+        switch stepAction.kind {
+        case .ask:
+            if step == 2 { ble.requestLocationPermission() } else { ble.enableBluetooth() }
+        case .openSettings:
+            openAppSettings()
+        case .next:
             advance()
+        case .finish:
+            onFinish()
         }
     }
 

--- a/companion-ios/Sources/RouteView.swift
+++ b/companion-ios/Sources/RouteView.swift
@@ -7,22 +7,32 @@ import CoreLocation
 struct RouteView: View {
     @EnvironmentObject var ble: BLEManager
     @StateObject private var model = RouteModel()
+    @ObservedObject private var store = EInkTileStore.shared
     @State private var showSaved = false
+    @State private var visibleRegion: MKCoordinateRegion?
+    @State private var einkAreas: [EInkArea] = []
+    @State private var outlineHexes: [OutlineHex] = []
 
     var body: some View {
         NavigationStack {
             ZStack(alignment: .bottom) {
-                Map(position: $model.camera) {
-                    UserAnnotation()
-                    if let dest = model.destination {
-                        Marker(model.destinationName, coordinate: dest)
-                            .tint(Palette.accent)
-                    }
-                    if let route = model.route {
-                        MapPolyline(route.polyline)
-                            .stroke(Palette.accent, lineWidth: 5)
-                    }
-                }
+                // Same map as the Maps screen: the areas already downloaded are
+                // drawn as the head unit will draw them, so you can see at a
+                // glance whether a route you're planning is inside the coverage
+                // the device actually carries.
+                EInkMapView(
+                    areas: einkAreas,
+                    outlines: outlineHexes,
+                    route: model.route?.polyline,
+                    destination: model.destination.map {
+                        MapDestination(name: model.destinationName, coordinate: $0)
+                    },
+                    camera: model.camera,
+                    showsUserLocation: ble.locationPermission.isGranted,
+                    onRegionChange: { r in
+                        visibleRegion = r
+                        refreshEInk()
+                    })
                 .ignoresSafeArea(edges: .top)
 
                 VStack(spacing: 12) {
@@ -75,11 +85,22 @@ struct RouteView: View {
             .onAppear {
                 if ProcessInfo.processInfo.arguments.contains("-demo-route") { model.demoRoute() }
                 else { model.requestLocation() }
+                store.refresh()
             }
             .onChange(of: model.destinationName) {
                 ble.routeSent = false; ble.routeReceived = false
             }
+            .onChange(of: store.version) { refreshEInk() }
+            .onChange(of: ble.deviceTileIds) { refreshEInk() }
         }
+    }
+
+    /// Ask the store what to draw for the region now on screen.
+    private func refreshEInk() {
+        guard let r = visibleRegion else { return }
+        let content = store.visibleContent(in: r, synced: ble.deviceTileIds)
+        einkAreas = content.areas
+        outlineHexes = content.outlines
     }
 
     // "Route" title pill, floated top-left below the status bar.
@@ -165,8 +186,11 @@ final class RouteModel: NSObject, ObservableObject {
     @Published var destinationName = ""
     @Published var route: MKRoute?
     @Published var routeMode = ""   // "Cycling" or "Walking"
-    @Published var camera: MapCameraPosition = .userLocation(
-        fallback: .region(MKCoordinateRegion(
+    // Starts on a fixed region and switches to following the user as soon as a
+    // fix exists (see requestLocation/recenter) — the map has no fallback mode
+    // of its own, so the camera is always something we chose.
+    @Published var camera: MapCameraCommand? = MapCameraCommand(
+        target: .region(MKCoordinateRegion(
             center: CLLocationCoordinate2D(latitude: 37.7764, longitude: -122.4346),
             span: MKCoordinateSpan(latitudeDelta: 0.08, longitudeDelta: 0.08))))
 
@@ -182,6 +206,13 @@ final class RouteModel: NSObject, ObservableObject {
 
     func requestLocation() {
         locManager.requestWhenInUseAuthorization()
+        // Frame the user as soon as we have them, instead of sitting on the
+        // fallback region until the first tap of "recenter".
+        if let loc = locManager.location {
+            camera = MapCameraCommand(target: .region(MKCoordinateRegion(
+                center: loc.coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.08, longitudeDelta: 0.08))))
+        }
     }
 
     // Recenter/follow the user (replaces the default map location button, which
@@ -189,10 +220,10 @@ final class RouteModel: NSObject, ObservableObject {
     func recenter() {
         locManager.requestWhenInUseAuthorization()
         if let loc = locManager.location {
-            camera = .region(MKCoordinateRegion(center: loc.coordinate,
-                span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)))
+            camera = MapCameraCommand(target: .region(MKCoordinateRegion(center: loc.coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05))))
         } else {
-            camera = .userLocation(fallback: .automatic)
+            camera = MapCameraCommand(target: .followUser)
         }
     }
 
@@ -276,7 +307,7 @@ final class RouteModel: NSObject, ObservableObject {
         // to edge, so the route ran into the screen borders and under the
         // search field and the route summary — hard to read, and impossible to
         // see what it passes near. 25% on each axis gives it room to breathe.
-        camera = .rect(r.polyline.boundingMapRect.paddedForDisplay())
+        camera = MapCameraCommand(target: .rect(r.polyline.boundingMapRect.paddedForDisplay()))
     }
 }
 

--- a/companion-ios/Sources/SettingsView.swift
+++ b/companion-ios/Sources/SettingsView.swift
@@ -116,6 +116,7 @@ struct SettingsView: View {
 
                     if ble.state == .connected { diagnosticsCard }
 
+                    permissionsCard
                     tutorialCard
 
                     Text(ble.state == .connected
@@ -162,6 +163,98 @@ struct SettingsView: View {
         let n = ble.deviceTileIds.count
         if n == 0 { return "Download map areas to your device" }
         return "\(n) area\(n == 1 ? "" : "s") on device"
+    }
+
+    /// Permissions, and how to fix the ones that are missing.
+    ///
+    /// Once a permission has been refused the app can never prompt for it again
+    /// — iOS only ever asks once — so without a route to Settings a "no" tapped
+    /// during onboarding would be permanent and unexplained. Granted ones are
+    /// listed too, so this reads as the whole picture rather than only a list of
+    /// complaints.
+    @ViewBuilder private var permissionsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Permissions").trackedLabel()
+                permissionRow(
+                    symbol: "dot.radiowaves.left.and.right",
+                    name: "Bluetooth",
+                    state: ble.bluetoothPermission,
+                    granted: ble.bluetoothPermission.isGranted && !ble.bluetoothPoweredOn
+                        ? "Allowed, but Bluetooth is switched off — turn it on in Control Centre."
+                        : "Allowed. This is how the app talks to your OpenTrailPaper.",
+                    missing: "Without it the app can't reach your device at all — no routes, maps, settings or ride downloads.",
+                    ask: { ble.enableBluetooth() })
+                Divider().overlay(Palette.hairline)
+                permissionRow(
+                    symbol: "location.fill",
+                    name: "Location",
+                    state: ble.locationPermission,
+                    granted: "Allowed while you're using the app.",
+                    missing: "The app still works: you lose your position on the map, the GPS warm-start that helps the device lock on faster, and the backup fix when it can't see the sky.",
+                    ask: { ble.requestLocationPermission() })
+
+                if needsPermissionFix {
+                    PrimaryButton(title: "Open Settings", systemImage: "arrow.up.forward.app",
+                                  enabled: true) { openAppSettings() }
+                    Text("Opens this app's page in Settings. Changes apply as soon as you come back.")
+                        .font(.system(size: 11)).foregroundStyle(Palette.muted)
+                }
+            }
+        }
+    }
+
+    /// True only when Settings can actually change something — a restricted
+    /// permission or a switched-off radio is not fixable there, and offering the
+    /// button anyway would send the user somewhere that can't help.
+    private var needsPermissionFix: Bool {
+        ble.bluetoothPermission.fixableInSettings || ble.locationPermission.fixableInSettings
+    }
+
+    private func permissionRow(symbol: String, name: String, state: PermissionState,
+                               granted: String, missing: String,
+                               ask: @escaping () -> Void) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(state.isGranted ? Palette.good : Palette.accent)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(name).font(BarlowFont.text(15, .semibold)).foregroundStyle(Palette.ink)
+                    Text(statusLabel(state))
+                        .font(.system(size: 10, weight: .bold))
+                        .padding(.horizontal, 7).padding(.vertical, 3)
+                        .background(state.isGranted ? Palette.good : Palette.accent)
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                }
+                Text(state.isGranted ? granted : missing)
+                    .font(.system(size: 12)).foregroundStyle(Palette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+                // Never asked (skipped during the tutorial): iOS will still show
+                // the real prompt, so ask here rather than sending the user to
+                // Settings for something they were never offered.
+                if state == .notDetermined {
+                    Button(action: ask) {
+                        Text("Allow \(name.lowercased())")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Palette.accent)
+                    }
+                    .padding(.top, 2)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func statusLabel(_ state: PermissionState) -> String {
+        switch state {
+        case .granted:       return "ALLOWED"
+        case .denied:        return "NOT ALLOWED"
+        case .notDetermined: return "NOT ASKED"
+        case .unavailable:   return "RESTRICTED"
+        }
     }
 
     @ViewBuilder private var tutorialCard: some View {

--- a/companion-ios/Sources/SketchIcon.swift
+++ b/companion-ios/Sources/SketchIcon.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+// Tutorial icon art, drawn rather than placed: a single pen lays the outline
+// down live, the panel's screentone develops behind it, and the whole badge
+// flashes once as it settles — which is exactly the sequence the head unit goes
+// through on every full refresh. It makes the first screens of the app feel like
+// the device they're introducing.
+//
+// Drawn in a Canvas off a clock rather than with SwiftUI animation modifiers
+// because the pen head has to sit at the END of the line being drawn, and that
+// point only exists per-frame: `body` is not re-evaluated on animation frames,
+// so an interpolated `progress` would never reach it.
+
+/// What to draw. Each case is a set of strokes in a 100×100 space, listed in
+/// pen order — the badge ring first, then the glyph.
+enum SketchGlyph: Equatable {
+    case location, waves, check
+
+    func strokes(in side: CGFloat) -> Path {
+        let k = side / 100
+        func pt(_ x: CGFloat, _ y: CGFloat) -> CGPoint { CGPoint(x: x * k, y: y * k) }
+
+        var path = Path()
+        // The ring, clockwise from the top. First, so the badge draws itself
+        // before whatever goes inside it.
+        arc(&path, center: pt(50, 50), radius: 46 * k, from: -90, to: 270)
+
+        switch self {
+        case .location:
+            // The location arrow, one closed outline.
+            path.move(to: pt(75, 26))
+            path.addLine(to: pt(26, 48))
+            path.addLine(to: pt(47, 55))
+            path.addLine(to: pt(54, 75))
+            path.addLine(to: pt(75, 26))
+
+        case .waves:
+            // A transmitter: the dot, then each pair of waves spreading outward.
+            path.addEllipse(in: CGRect(x: 44 * k, y: 44 * k, width: 12 * k, height: 12 * k))
+            for r in [20.0, 32.0] as [CGFloat] {
+                arc(&path, center: pt(50, 50), radius: r * k, from: 140, to: 220)
+                arc(&path, center: pt(50, 50), radius: r * k, from: -40, to: 40)
+            }
+
+        case .check:
+            path.move(to: pt(30, 52))
+            path.addLine(to: pt(44, 67))
+            path.addLine(to: pt(71, 33))
+        }
+        return path
+    }
+
+    /// `addArc` joins to the current point, which would trail a stray line in
+    /// from wherever the pen was. Always start the arc's own subpath.
+    private func arc(_ path: inout Path, center: CGPoint, radius: CGFloat,
+                     from a: Double, to b: Double) {
+        let start = CGPoint(x: center.x + radius * cos(a * .pi / 180),
+                            y: center.y + radius * sin(a * .pi / 180))
+        path.move(to: start)
+        path.addArc(center: center, radius: radius,
+                    startAngle: .degrees(a), endAngle: .degrees(b), clockwise: false)
+    }
+}
+
+struct SketchIcon: View {
+    let glyph: SketchGlyph
+    var tint: Color = Palette.accent
+    var side: CGFloat = 132
+    /// True while this is the page on screen. Flipping it replays the drawing,
+    /// so swiping back and forth re-draws instead of showing a stale result.
+    var active: Bool = true
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var runStart: Date?
+    @State private var runToken = 0
+
+    private let drawTime = 1.15
+    private let flashTime = 0.24
+    private let developTime = 0.5
+    private var total: Double { drawTime + flashTime + developTime }
+
+    var body: some View {
+        Group {
+            if let runStart, !reduceMotion {
+                TimelineView(.animation) { timeline in
+                    Canvas { ctx, size in
+                        render(&ctx, size: size,
+                               elapsed: timeline.date.timeIntervalSince(runStart))
+                    }
+                }
+            } else {
+                // Settled state — also what Reduce Motion gets, with no drawing.
+                Canvas { ctx, size in render(&ctx, size: size, elapsed: total) }
+            }
+        }
+        .frame(width: side, height: side)
+        .accessibilityHidden(true)
+        .onAppear { if active { replay() } }
+        .onChange(of: active) { _, on in if on { replay() } }
+        // The connect page swaps its glyph the moment the device shows up;
+        // drawing the new one is a better "it worked" than a swap would be.
+        .onChange(of: glyph) { _, _ in if active { replay() } }
+    }
+
+    private func replay() {
+        guard !reduceMotion else { return }
+        runToken += 1
+        let token = runToken
+        runStart = Date()
+        // Stop the timeline once it's done — otherwise it keeps ticking at 60 Hz
+        // behind a finished drawing for as long as the tutorial is open.
+        Task {
+            try? await Task.sleep(for: .seconds(total + 0.15))
+            if runToken == token { runStart = nil }
+        }
+    }
+
+    private func render(_ ctx: inout GraphicsContext, size: CGSize, elapsed: Double) {
+        let s = min(size.width, size.height)
+        guard s > 0 else { return }
+        let k = s / 100
+
+        let pen = clamp(elapsed / drawTime)
+        let after = elapsed - drawTime
+        // One up-and-back pulse, like the panel's settle flash.
+        let flash = (after >= 0 && after < flashTime)
+            ? sin(.pi * after / flashTime) : 0
+        let develop = clamp((after - flashTime) / developTime)
+
+        let disc = Path(ellipseIn: CGRect(x: 2 * k, y: 2 * k,
+                                          width: s - 4 * k, height: s - 4 * k))
+        ctx.fill(disc, with: .color(Palette.surface))
+
+        // The screentone the map uses, in miniature: a dot screen rather than a
+        // flat tint, developing after the ink is down.
+        if develop > 0 {
+            var dots = Path()
+            let pitch = 5 * k, r = 1.15 * k
+            var y = pitch
+            while y < s {
+                var x = pitch
+                while x < s {
+                    dots.addEllipse(in: CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2))
+                    x += pitch
+                }
+                y += pitch
+            }
+            var layer = ctx
+            layer.clip(to: disc)
+            layer.opacity = develop
+            layer.fill(dots, with: .color(tint.opacity(0.5)))
+        }
+
+        let full = glyph.strokes(in: s)
+        let drawn = full.trimmedPath(from: 0, to: pen)
+        let style = StrokeStyle(lineWidth: 3.4 * k, lineCap: .round, lineJoin: .round)
+        ctx.stroke(drawn, with: .color(tint), style: style)
+
+        // The pen itself, riding the end of the line.
+        if pen > 0, pen < 1, let head = drawn.currentPoint {
+            let r = 2.6 * k
+            ctx.fill(Path(ellipseIn: CGRect(x: head.x - r, y: head.y - r,
+                                            width: r * 2, height: r * 2)),
+                     with: .color(tint))
+        }
+
+        // The settle flash: the badge inverts for an instant and clears.
+        if flash > 0 {
+            var layer = ctx
+            layer.opacity = flash * 0.9
+            layer.fill(disc, with: .color(Palette.ink))
+            layer.stroke(full, with: .color(Palette.paper), style: style)
+        }
+    }
+
+    private func clamp(_ v: Double) -> CGFloat { CGFloat(min(max(v, 0), 1)) }
+}

--- a/companion-ios/Sources/TileCache.swift
+++ b/companion-ios/Sources/TileCache.swift
@@ -13,13 +13,18 @@ import Foundation
 /// mapgen.js / build_map.py / MapBuilder.swift by design), so caching them by id
 /// is safe and needs no invalidation beyond age.
 ///
-/// Stored in Caches: this is reconstructible from the network, so the system is
-/// free to evict it under disk pressure, and it must not count against the
-/// user's iCloud backup.
+/// Lives in Application Support, NOT Caches. It started in Caches on the theory
+/// that it is reconstructible from the network — true, but it is no longer only
+/// a build cache: these blobs are what the map draws downloaded areas from
+/// (`EInkTileStore`), so an eviction would silently blank out areas the user
+/// downloaded, with an Overpass round-trip to get them back. Excluded from
+/// backup, so it still doesn't ride along in iCloud.
 actor TileCache {
     static let shared = TileCache()
 
     /// Tiles older than this are re-fetched, so OSM edits eventually land.
+    /// Applies to REUSE only — `displayData` ignores it, since drawing a
+    /// slightly stale area beats drawing nothing.
     private let maxAge: TimeInterval = 60 * 60 * 24 * 90   // 90 days
     /// Rough ceiling before the oldest entries are dropped.
     private let maxBytes: Int = 256 * 1024 * 1024
@@ -27,16 +32,21 @@ actor TileCache {
     private let dir: URL
 
     init() {
-        let base = FileManager.default.urls(for: .cachesDirectory,
-                                            in: .userDomainMask)[0]
+        let fm = FileManager.default
+        let base = (try? fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                appropriateFor: nil, create: true))
+            ?? fm.urls(for: .cachesDirectory, in: .userDomainMask)[0]
         // Versioned. Bump when a builder change alters what a tile SHOULD
         // contain, so stale blobs cannot mask the fix. v2: tiles built before
         // the padded-coastline fetch have no sea fill — an ocean-only hex was
         // cached blank (elevation alone made it non-empty), and reusing it would
         // look exactly like the bug still being there.
         dir = base.appendingPathComponent("TileCache-v2", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir,
-                                                 withIntermediateDirectories: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        var res = URLResourceValues()
+        res.isExcludedFromBackup = true
+        var d = dir
+        try? d.setResourceValues(res)
     }
 
     private func url(_ id: String) -> URL {
@@ -55,6 +65,23 @@ actor TileCache {
               let d = try? Data(contentsOf: u), !d.isEmpty
         else { return nil }
         return d
+    }
+
+    /// Blob for `id` with no age check, for DRAWING the area on the map.
+    /// `data(for:)` expires tiles so a rebuild picks up OSM edits; expiring what
+    /// the map draws would instead make downloaded areas quietly disappear.
+    func displayData(for id: String) -> Data? {
+        let d = try? Data(contentsOf: url(id))
+        return (d?.isEmpty == false) ? d : nil
+    }
+
+    /// Every H3 id this phone holds tile data for — the set of areas the map can
+    /// draw in the device's own style.
+    func cachedIds() -> Set<String> {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil) else { return [] }
+        return Set(files.filter { $0.pathExtension == "ebm" }
+                        .map { $0.deletingPathExtension().lastPathComponent })
     }
 
     func store(_ data: Data, for id: String) {


### PR DESCRIPTION
Two requested changes to the companion app.

## 1. The map

Areas this phone has **downloaded** are drawn the way the head unit draws them — black ink on paper, roads by class, water as a dot screen, parks as a diagonal hatch. Areas the device **also has** get a green check. Everywhere else is plain Apple Maps, so the edge of your offline coverage is visible at a glance. The **Route screen uses the same map**.

| Overview | Street level |
|---|---|
| Downloaded hexes as e-ink, Apple Maps beyond them, route on top | Road hierarchy, dashed paths, park hatch |

### Where the geometry comes from

The app already builds `.ebm` tiles and streams them to the device. A new `EBMDecoder.swift` reads them back. It deliberately mirrors the **firmware's** projection (`src/map_tiles.cpp`) rather than the encoder's: the device derives its scale factor from the grid header (`gridLat0 + tileDeg * gridNy / 2`), not from the bbox the encoder used, and reproducing what the *device* computes is what makes this an honest preview.

Verified by round-tripping real `MapBuilder` output — roads, water rings and park rings decode back to within metres of where they went in, and truncated/garbage blobs return `nil` rather than trapping. Also decoded the 7 real San Francisco tiles used for the screenshots: all six road classes plus water and parks, all landing on their H3 cell.

### Why UIKit

Only `MKOverlayRenderer` can draw a patterned fill locked to the map, and only MapKit's own overlay compositing keeps it pinned frame-for-frame while panning — a SwiftUI `Canvas` layered over a `Map` redraws a frame late and visibly swims. `EInkMapView` is one `UIViewRepresentable` shared by both screens; MapsView keeps its drag-a-box selection, hex tap-to-skip and long-press inspector.

### One deliberate deviation

The screentones keep the device's **character** (dots for water, diagonal stripes for parks — that's how the two read apart) but not its exact ink coverage. On a 235 ppi panel the water's 75% dots integrate into a dark grey; a phone screentone coarse enough to still look dotted is coarse enough that 75% is simply black and the bay swallows the map. Coverage is lightened, keeping the device's ordering — water darker than parkland. First attempt is in the history if you want to see the black-bay version.

### Cache durability

`TileCache` moves from Caches to Application Support (excluded from backup). It is no longer only a build cache — it is what the map draws downloaded areas from, so an eviction would silently blank out areas the user downloaded. Age expiry still applies to *reuse*; drawing ignores it, since a slightly stale area beats no area.

Areas the device has but this phone has no data for (cache cleared, another phone sent them) still get an outline and a check rather than vanishing.

## 2. Permissions

**The rule now enforced:** a screen that explains a permission can always act on it. Not asked → the button raises the system prompt. Refused → the button opens Settings, the only place that can undo it. Either way there is a way past the screen.

Previously the onboarding buttons no-oped once a permission had been answered — `requestWhenInUseAuthorization()` does nothing after a refusal, and iOS never prompts twice — so anyone who tapped "Don't Allow" was stuck on a screen asking for something it could no longer request.

**Settings gains a Permissions section**: both permissions with their state and what breaks without each, an inline ask for anything never requested, and a link to the app's Settings page for anything refused. The link only appears when Settings can actually change it — a restricted permission (parental controls / MDM) or a switched-off Bluetooth radio cannot be fixed there, and `bluetoothPoweredOn` is tracked separately so a switched-off radio is never reported as a refused permission.

`PermissionState` is four cases, not a Bool, because not-asked / refused / restricted each need a different answer. State is re-read on foreground, since returning from Settings is exactly the path our own buttons send people down.

**Also:** the map no longer asks for location just by appearing. Both `showsUserLocation` and touching the user-tracking mode make MapKit request authorization, so merely opening a tab raised a prompt with no explanation attached. The ask now belongs to the tutorial, the recenter button and Settings.

## Testing

- `xcodebuild` clean for the iOS app; `pio run` clean for both firmware envs (untouched).
- Decoder round-trip harness against real `MapBuilder` output — all assertions pass.
- Ran in a simulator seeded with 7 real SF tiles built through the actual pipeline (Overpass → `encodeTiles` → water/parks/coastline), and with a seeded device tile list to exercise the synced/not-synced split. Verified: overview and street zoom, route drawn above the paper, green check over both paper and screentone, onboarding location step in both not-asked and refused states, and the Settings permissions card.
- Two rendering bugs found and fixed this way: the route was being painted over by the e-ink overlay (overlays at the same level draw in insertion order — the route is now re-added last), and the green check rendered black (`withTintColor` on an SF Symbol; now drawn explicitly, with a white ring so it holds up over the dark water tone).

## Not done

Not run on a physical device, and the download path itself (which needs a connected head unit) was exercised only through the seeding harness, not end-to-end in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7j9FFejmEKqjeVaFnxqZV