### PR TITLE
Wait for the boot screen's paint before anything else drives the panel

### DIFF
--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1004,6 +1004,25 @@ void bootRepaint() {
     if (!fb) return;
     ui_render_boot_screen(FIRMWARE_VERSION, bootLines, bootState, bootCount, fb);
     epdc_paint();
+    // WAIT for the rows to finish clocking out. epdc_paint() is asynchronous on
+    // the EPD_Painter backend — it hands the frame to the driver's paint task
+    // and returns mid-drive — so leaving one in flight means the NEXT paint is
+    // issued into a panel that is still being driven, and the driver wedges:
+    // the glass keeps whatever was on it and never updates again.
+    //
+    // This bit when the "Maps" step moved the last boot repaint from main.cpp
+    // (where ~3 s of SD scan plus the whole BLE init happened to follow it, so
+    // the paint always landed first) to the end of ui_dashboard::begin(), a few
+    // hundred ms before the UI task's first frame. The panel then froze on the
+    // boot screen for the rest of the session while the firmware ran on
+    // perfectly happily behind it — console answering, GPS logging, 140 s uptime.
+    //
+    // Same rule shutdownDevice() already follows for the farewell screen. It
+    // belongs here rather than at the handover because EVERY boot repaint is a
+    // full-screen paint, and any of them can be the last one before something
+    // else drives the panel. Bounded at 6 s inside epdc_paint_wait(), so this
+    // cannot turn a slow panel into a hung boot.
+    epdc_paint_wait();
     if (shadowFb) memcpy(shadowFb, fb, fbSize);   // keep the delta engine honest
 }
 


### PR DESCRIPTION
The device booted to a **frozen boot screen** — the glass stopped at the "Maps"
step and never advanced for the rest of the session.

## It was not a boot hang

With the panel visibly stuck, the device was:

```
[gpsdbg t=140s] SRCH type=1 sats=0/12 ... chars=64016
UI task (console) responding: True
[sd] mounted=yes cardType=SDHC size=30436MB
[07:53:54] map: 107 tiles indexed
```

140 s of uptime, GPS logging once a second, SD mounted, and the serial console
answering. So `map_store::begin()` had returned in its usual ~3 s, `setup()`
had completed, every task was running, and the UI task was calling `refresh()`
once a second. **Only the display was dead.**

## Cause

`epdc_paint()` is asynchronous on the EPD_Painter backend — it hands the frame
to the driver's paint task and returns while the rows are still being clocked
out. `bootRepaint()` never waited for that.

It didn't matter while the last boot repaint was `bootStatus("Display")` in
`main.cpp`: ~3 s of SD scanning plus the entire BLE init followed it, so the
paint always landed with room to spare. Adding the "Maps" step moved the last
repaint to the **end of `ui_dashboard::begin()`**, a few hundred ms ahead of the
UI task's first frame. The second paint is then issued into a panel still being
driven, the driver wedges, and the glass keeps whatever was on it.

`shutdownDevice()` already documents this exact rule for the farewell screen:

> MUST come before deep sleep. On the EPD_Painter backend `epdc_paint()` only
> hands the frame to the driver's paint task and returns while the rows are
> still being clocked out.

I added a new `epdc_paint()` caller and didn't carry that across.

## Fix

`epdc_paint_wait()` inside `bootRepaint()` — not at the handover, because every
boot repaint is a full-screen paint and any of them can be the last one before
something else drives the panel. Bounded at 6 s internally, so it cannot turn a
slow panel into a hung boot. Costs ~50 ms per boot step (the measured refresh
time), so a few hundred ms of boot.

## Testing

- Builds; flashed to the device.
- **NOT confirmed on glass.** The panel has not been observed to recover.

Two earlier calls in this area were wrong for want of exactly that check, and
both cost debugging cycles:

- A flash reported as "booted normally" on the strength of the USB port
  reappearing — which proves only that the app ran, not that the panel drew.
  That claim let the freeze survive three further flashes.
- A bisect binary described as "known-good" that still contained the "Maps"
  step, so it could never have cleared the real culprit. The flash that came
  back *still stuck* was the result that actually pointed here.

Worth confirming on the panel before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwYZjHmfM1HsbvSAjJrw4U