### PR TITLE
iOS: queue ride and log transfers instead of racing them on one buffer

### DIFF
--- a/companion-ios/Sources/BLEManager.swift
+++ b/companion-ios/Sources/BLEManager.swift
@@ -210,6 +210,36 @@ final class BLEManager: NSObject, ObservableObject {
     private var dlNextSeq: UInt16 = 0
     @Published private(set) var downloadingLog = false
 
+    // Ride and log transfers share ONE device-side streamer and one receive
+    // buffer here, so exactly one may be in flight. Asking for a second file
+    // mid-transfer used to reset the buffer under the running stream: the tail
+    // of file A landed in the buffer and was then written out under file B's
+    // name, so B was saved corrupt (and cached, so it never re-downloaded) and
+    // A was never saved at all. Requests are queued and run strictly serially.
+    private enum Transfer: Equatable {
+        case ride(String)
+        case log(String)        // "" = today's rolling diag.log
+
+        var isLog: Bool { if case .log = self { return true }; return false }
+        var displayName: String {
+            switch self {
+            case .ride(let n): return n
+            case .log(let n):  return n.isEmpty ? "diag" : n
+            }
+        }
+    }
+    private var dlQueue: [Transfer] = []
+    private var dlActive: Transfer? = nil
+    /// List commands share the device's one request slot with transfers, so they
+    /// wait for the queue to drain rather than clobbering it.
+    private var listRefreshPending = false
+    private var logListPending = false
+    private var dlWatchdog: Task<Void, Never>?
+    private var dlLastActivity = Date()
+    /// Names waiting their turn, so a row can show "Queued" instead of looking
+    /// like the tap did nothing.
+    @Published private(set) var queuedDownloads: [String] = []
+
     // OTA transfer state
     private var otaData = Data()
     private var otaOffset = 0
@@ -430,6 +460,12 @@ final class BLEManager: NSObject, ObservableObject {
 
     func refreshRides() {
         guard let c = ridesChar, let p = peripheral else { return }
+        // The device holds ONE pending request: a list command written while a
+        // transfer is in flight is overwritten by (or overwrites) the next
+        // queued download, and whichever loses is silently dropped — leaving the
+        // list spinning forever or the download waiting on its watchdog. Wait
+        // for the line instead.
+        guard dlActive == nil, dlQueue.isEmpty else { listRefreshPending = true; return }
         rides = []
         loadingRides = true
         p.writeValue(Data([0x01]), for: c, type: .withResponse)
@@ -437,6 +473,10 @@ final class BLEManager: NSObject, ObservableObject {
 
     func deleteRide(_ name: String) {
         rides.removeAll { $0.name == name }
+        // Drop it from the download queue too, so a deleted ride doesn't get
+        // fetched (and re-cached) moments later.
+        dlQueue.removeAll { $0 == .ride(name) }
+        publishQueue()
         try? FileManager.default.removeItem(at: BLEManager.cachedURL(for: name))
         // Offline: just drop the local cache. Connected: also delete on device.
         guard let c = ridesChar, let p = peripheral else { return }
@@ -446,21 +486,16 @@ final class BLEManager: NSObject, ObservableObject {
 
     // Pull /diag.log off the device (reuses the reliable ride-transfer path).
     func downloadLog() {
-        guard let c = ridesChar, let p = peripheral else {
+        guard ridesChar != nil, peripheral != nil else {
             lastMessage = "Not connected"; return
         }
-        dlBuffer = Data()
-        dlExpected = 0
-        downloadingLog = true
-        downloadingName = "diag"
-        downloadProgress = 0
-        logFileURL = nil
-        p.writeValue(Data([0x05]), for: c, type: .withResponse)
+        enqueueTransfer(.log(""))
     }
 
     // List the per-day log files on the device (reply parsed via 0x30/0x31).
     func requestLogList() {
         guard let c = ridesChar, let p = peripheral else { return }
+        guard dlActive == nil, dlQueue.isEmpty else { logListPending = true; return }
         logsBuilding = []
         loadingLogs = true
         p.writeValue(Data([0x06]), for: c, type: .withResponse)
@@ -468,15 +503,8 @@ final class BLEManager: NSObject, ObservableObject {
 
     // Download one specific day's log file.
     func downloadLogFile(_ name: String) {
-        guard let c = ridesChar, let p = peripheral else { lastMessage = "Not connected"; return }
-        dlBuffer = Data()
-        dlExpected = 0
-        downloadingLog = true
-        downloadingName = name
-        downloadProgress = 0
-        logFileURL = nil
-        var cmd = Data([0x07]); cmd.append(Data(name.utf8))
-        p.writeValue(cmd, for: c, type: .withResponse)
+        guard ridesChar != nil, peripheral != nil else { lastMessage = "Not connected"; return }
+        enqueueTransfer(.log(name))
     }
 
     // MARK: firmware / OTA
@@ -895,16 +923,109 @@ final class BLEManager: NSObject, ObservableObject {
     }
 
     func downloadRide(_ name: String) {
-        guard let c = ridesChar, let p = peripheral else { return }
+        guard ridesChar != nil, peripheral != nil else { return }
+        enqueueTransfer(.ride(name))
+    }
+
+    // MARK: serialized transfer queue
+
+    private func enqueueTransfer(_ t: Transfer) {
+        // Tapping the same file twice queues it once.
+        guard dlActive != t, !dlQueue.contains(t) else { return }
+        dlQueue.append(t)
+        startNextTransfer()
+    }
+
+    /// Sends the next queued request, but only when the line is free — the
+    /// device streams one file at a time and we hold one receive buffer.
+    private func startNextTransfer() {
+        publishQueue()
+        guard dlActive == nil else { return }
+        guard !dlQueue.isEmpty else { runDeferredListRequests(); return }
+        guard let c = ridesChar, let p = peripheral else {
+            dlQueue = []          // link gone; nothing can be fetched
+            publishQueue()
+            return
+        }
+        let t = dlQueue.removeFirst()
+        dlActive = t
         dlBuffer = Data()
         dlExpected = 0
-        dlName = name
-        downloadingName = name
+        dlNextSeq = 0
         downloadProgress = 0
-        downloadedFileURL = nil
-        var cmd = Data([0x02])
-        cmd.append(Data(name.utf8))
-        p.writeValue(cmd, for: c, type: .withResponse)
+        downloadingLog = t.isLog
+        downloadingName = t.displayName
+        switch t {
+        case .ride(let name):
+            dlName = name
+            downloadedFileURL = nil
+            var cmd = Data([0x02])
+            cmd.append(Data(name.utf8))
+            p.writeValue(cmd, for: c, type: .withResponse)
+        case .log(let name):
+            dlName = name
+            logFileURL = nil
+            if name.isEmpty {
+                p.writeValue(Data([0x05]), for: c, type: .withResponse)
+            } else {
+                var cmd = Data([0x07])
+                cmd.append(Data(name.utf8))
+                p.writeValue(cmd, for: c, type: .withResponse)
+            }
+        }
+        publishQueue()
+        armDownloadWatchdog()
+    }
+
+    /// The active transfer ended (either way) — release the line and run the
+    /// next request. Always the single exit point, so the queue can't jam.
+    private func endActiveTransfer() {
+        dlWatchdog?.cancel()
+        dlWatchdog = nil
+        dlActive = nil
+        downloadingName = nil
+        downloadingLog = false
+        dlBuffer = Data()          // don't hold a ride's bytes after it's saved
+        dlExpected = 0
+        startNextTransfer()
+    }
+
+    /// Abandon everything queued (device busy, disconnected) with one message
+    /// rather than one failure toast per queued file.
+    private func cancelAllTransfers(_ message: String?) {
+        dlQueue = []
+        if let message { lastMessage = message }
+        endActiveTransfer()
+    }
+
+    private func publishQueue() {
+        let names = dlQueue.map(\.displayName)
+        if names != queuedDownloads { queuedDownloads = names }
+    }
+
+    /// Run whatever asked for the line while it was busy. Called once the queue
+    /// is empty, so these never race a transfer for the device's request slot.
+    private func runDeferredListRequests() {
+        if listRefreshPending { listRefreshPending = false; refreshRides() }
+        if logListPending { logListPending = false; requestLogList() }
+    }
+
+    /// A device that stops mid-stream (or never answers) must not strand the
+    /// queue behind a transfer that will never finish.
+    private func armDownloadWatchdog() {
+        dlWatchdog?.cancel()
+        dlLastActivity = Date()
+        dlWatchdog = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !Task.isCancelled, let self, self.dlActive != nil else { return }
+                if Date().timeIntervalSince(self.dlLastActivity) > 20 {
+                    self.lastMessage = "\(self.dlActive?.displayName ?? "Transfer") timed out — try again"
+                    self.endActiveTransfer()
+                    return
+                }
+            }
+        }
     }
 
     private func handleRidesNotify(_ d: Data) {
@@ -926,11 +1047,17 @@ final class BLEManager: NSObject, ObservableObject {
             loadingLogs = false
             deviceLogs = logsBuilding.sorted { $0.name > $1.name }   // newest day first
         case 0x10:  // download start: [u32 total]
+            // Ignore a stream we didn't ask for: after a timeout or a dropped
+            // link the device can still be pushing an abandoned file, and those
+            // bytes must not land in the next transfer's buffer.
+            guard dlActive != nil, d.count > 4 else { return }
+            dlLastActivity = Date()
             dlExpected = Int(d[1]) | (Int(d[2]) << 8) | (Int(d[3]) << 16) | (Int(d[4]) << 24)
             dlBuffer = Data(capacity: dlExpected)
             dlNextSeq = 0
         case 0x11:  // chunk: [u16 seq][payload]
-            guard d.count > 3 else { return }
+            guard dlActive != nil, dlExpected > 0, d.count > 3 else { return }
+            dlLastActivity = Date()
             let seq = UInt16(d[1]) | (UInt16(d[2]) << 8)
             // Strict in-order: only append the chunk we're expecting next.
             // Anything else (a duplicate from a resend, or a chunk that arrived
@@ -938,11 +1065,16 @@ final class BLEManager: NSObject, ObservableObject {
             if seq == dlNextSeq {
                 dlBuffer.append(d[3...])
                 dlNextSeq = seq &+ 1
-                if dlExpected > 0 {
-                    downloadProgress = min(1, Double(dlBuffer.count) / Double(dlExpected))
-                }
+                downloadProgress = min(1, Double(dlBuffer.count) / Double(dlExpected))
             }
         case 0x14:  // window end — tell the device the next seq we need
+            // Only ack a stream we're actually collecting — one we asked for AND
+            // whose [0x10] header we saw. Acking anything else would answer an
+            // abandoned transfer with our seq 0 and make the device resend that
+            // whole file. Staying quiet lets its 5s ack timeout drop the stale
+            // stream and pick up our request instead.
+            guard dlActive != nil, dlExpected > 0 else { return }
+            dlLastActivity = Date()
             var ack = Data([0x04])
             ack.append(UInt8(dlNextSeq & 0xFF))
             ack.append(UInt8(dlNextSeq >> 8))
@@ -950,16 +1082,18 @@ final class BLEManager: NSObject, ObservableObject {
                 p.writeValue(ack, for: c, type: .withResponse)
             }
         case 0x12:  // done
+            guard dlActive != nil else { return }
             finishDownload()
         case 0x13: break  // delete ack (already removed locally)
         case 0x1F:  // error (e.g. recording in progress)
             // Only surface a toast if the user was actively downloading; the
             // routine list-refresh fails silently mid-ride (the Rides tab shows
             // an "in progress" banner + the already-synced rides instead).
-            let wasDownloading = downloadingName != nil
-            downloadingName = nil
             loadingRides = false
-            if wasDownloading { lastMessage = "Device busy — stop the ride first" }
+            guard dlActive != nil else { return }
+            // A recording device refuses every file, so drop the whole queue
+            // rather than failing each one in turn with its own toast.
+            cancelAllTransfers("Device busy — stop the ride first")
         default: break
         }
     }
@@ -1010,23 +1144,30 @@ final class BLEManager: NSObject, ObservableObject {
     }
 
     private func finishDownload() {
-        // A short transfer means packets were lost — surface it instead of
-        // handing a truncated file to the parser.
-        if dlExpected > 0 && dlBuffer.count != dlExpected {
-            lastMessage = "Transfer incomplete (\(dlBuffer.count)/\(dlExpected) bytes) — try again"
-            downloadingName = nil
-            downloadingLog = false
+        // A short transfer means packets were lost, and a zero-length one means
+        // no [0x10] header ever arrived. Either way the bytes in hand aren't the
+        // file — never write them out, least of all under the requested name.
+        if dlExpected == 0 || dlBuffer.count != dlExpected {
+            lastMessage = dlExpected == 0
+                ? "Transfer failed — try again"
+                : "Transfer incomplete (\(dlBuffer.count)/\(dlExpected) bytes) — try again"
+            endActiveTransfer()
             return
         }
-        if downloadingLog {                    // diagnostics log, not a ride
-            downloadingLog = false
-            var fname = (downloadingName ?? "diag").replacingOccurrences(of: "/", with: "_")
-            downloadingName = nil
+        // Take the payload and the name BEFORE releasing the line — starting the
+        // next queued transfer clears both.
+        let payload = dlBuffer
+        let wasLog = downloadingLog
+        let name = wasLog ? (downloadingName ?? "diag") : dlName
+        endActiveTransfer()
+
+        if wasLog {                            // diagnostics log, not a ride
+            var fname = name.replacingOccurrences(of: "/", with: "_")
             if !fname.hasSuffix(".log") { fname += ".log" }
             let url = FileManager.default.temporaryDirectory
                 .appendingPathComponent("bikegps-\(fname)")
             do {
-                try dlBuffer.write(to: url)
+                try payload.write(to: url)
                 logFileURL = url
             } catch {
                 lastMessage = "Log save failed: \(error.localizedDescription)"
@@ -1034,15 +1175,14 @@ final class BLEManager: NSObject, ObservableObject {
             return
         }
         // Persist to the cache so it's available offline and never re-fetched.
-        let url = BLEManager.cachedURL(for: dlName)
+        let url = BLEManager.cachedURL(for: name)
         do {
-            try dlBuffer.write(to: url)
+            try payload.write(to: url)
             downloadedFileURL = url
-            lastMessage = "\(dlName) ready"
+            lastMessage = "\(name) ready"
         } catch {
             lastMessage = "Save failed: \(error.localizedDescription)"
         }
-        downloadingName = nil
     }
 
     // MARK: route upload (chunked with a 1-byte opcode per packet)
@@ -1165,7 +1305,12 @@ extension BLEManager: CBCentralManagerDelegate {
             }
             status = DeviceStatus()
             sawStatusSinceConnect = false
-            rides = []; loadingRides = false; downloadingName = nil
+            rides = []; loadingRides = false
+            // Nothing queued can proceed without a link, and a half-received
+            // file must not be mistaken for a complete one on reconnect.
+            if dlActive != nil || !dlQueue.isEmpty {
+                cancelAllTransfers("Connection dropped mid-download — try again")
+            }
             deviceRoutes = []; loadingRoutes = false
             lastUploadProgress = nil; routeSent = false; routeReceived = false
             sensors = []; scanningSensors = false

--- a/companion-ios/Sources/RidesView.swift
+++ b/companion-ios/Sources/RidesView.swift
@@ -23,7 +23,8 @@ struct RidesView: View {
         return out.sorted { $0.name > $1.name }
     }
 
-    // Show a cached ride immediately; otherwise pull it over BLE.
+    // Show a cached ride immediately; otherwise pull it over BLE. Downloads are
+    // queued by BLEManager, so tapping a second ride mid-transfer is safe.
     private func open(_ ride: RideFile) {
         let url = BLEManager.cachedURL(for: ride.name)
         if let data = try? Data(contentsOf: url) {
@@ -35,6 +36,14 @@ struct RidesView: View {
         } else {
             ble.downloadRide(ride.name)
         }
+    }
+
+    // Throw away a cached file that won't parse and fetch it again — the way
+    // out for rides left corrupt on disk by an interrupted transfer.
+    private func redownload(_ name: String) {
+        try? FileManager.default.removeItem(at: BLEManager.cachedURL(for: name))
+        previews.forget(name)
+        ble.downloadRide(name)
     }
 
     // Big title + sync status + refresh (mockup 2c).
@@ -157,6 +166,7 @@ struct RidesView: View {
                                     cached: BLEManager.isCached(ride.name),
                                     preview: previews.preview(for: ride.name),
                                     downloading: ble.downloadingName == ride.name,
+                                    queued: ble.queuedDownloads.contains(ride.name),
                                     progress: ble.downloadProgress,
                                     onTap: { open(ride) },
                                     onDelete: {
@@ -203,10 +213,14 @@ struct RidesView: View {
             }
             .onChange(of: ble.downloadedFileURL) { _, url in
                 guard let url, let data = try? Data(contentsOf: url) else { return }
+                // A queued ride that lands while the rider is looking at an
+                // earlier one fills in its row rather than yanking the sheet
+                // out from under them.
+                let busy = detail != nil || failedURL != nil
                 if let preview = FITDecoder.decode(data) {
-                    detail = RideDetailData(url: url, preview: preview)
                     previews.store(preview, for: url.lastPathComponent)  // fill the row thumbnail
-                } else {
+                    if !busy { detail = RideDetailData(url: url, preview: preview) }
+                } else if !busy {
                     failedURL = url
                 }
             }
@@ -214,7 +228,9 @@ struct RidesView: View {
                 RideDetailView(fileURL: d.url, preview: d.preview)
             }
             .sheet(item: $failedURL) { url in
-                RideParseErrorView(url: url)
+                RideParseErrorView(url: url,
+                                   canRetry: ble.state == .connected,
+                                   onRetry: { redownload(url.lastPathComponent) })
             }
         }
     }
@@ -231,6 +247,7 @@ private struct RideRow: View {
     let cached: Bool
     let preview: RidePreview?
     let downloading: Bool
+    let queued: Bool
     let progress: Double
     let onTap: () -> Void
     let onDelete: () -> Void
@@ -286,6 +303,15 @@ private struct RideRow: View {
                     Text("Downloading…").font(.system(size: 12))
                         .foregroundStyle(Palette.muted)
                 }
+            } else if queued {
+                VStack(spacing: 8) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 30)).foregroundStyle(Palette.muted)
+                    Text("Queued — starts after the current download")
+                        .font(.system(size: 12)).foregroundStyle(Palette.muted)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                }
             } else {
                 VStack(spacing: 8) {
                     Image(systemName: cached ? "map" : "arrow.down.circle")
@@ -324,6 +350,10 @@ private struct RideRow: View {
     @ViewBuilder private var trailing: some View {
         if downloading {
             ProgressView(value: progress).frame(width: 54)
+        } else if queued {
+            Image(systemName: "clock")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Palette.muted)
         } else if cached {
             Image(systemName: "chevron.right")
                 .font(.system(size: 14, weight: .semibold))
@@ -360,6 +390,8 @@ private struct RideRow: View {
 // raw .fit so it can be inspected.
 private struct RideParseErrorView: View {
     let url: URL
+    let canRetry: Bool
+    let onRetry: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -369,17 +401,35 @@ private struct RideParseErrorView: View {
                 .foregroundStyle(Palette.accent)
             Text("Couldn't read this ride")
                 .font(TypeScale.title).foregroundStyle(Palette.ink)
-            Text("The full file downloaded but the app couldn't parse it. Share the raw .fit file so it can be analyzed.")
+            Text(canRetry
+                 ? "The app couldn't parse this file. Download it again from the device, or share the raw .fit so it can be analyzed."
+                 : "The full file downloaded but the app couldn't parse it. Share the raw .fit file so it can be analyzed.")
                 .font(TypeScale.body).foregroundStyle(Palette.muted)
                 .multilineTextAlignment(.center)
+            if canRetry {
+                Button {
+                    dismiss()
+                    onRetry()
+                } label: {
+                    Label("Download again", systemImage: "arrow.clockwise")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Palette.accent)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+            }
             ShareLink(item: url) {
                 Label("Share .fit file", systemImage: "square.and.arrow.up")
                     .font(.system(size: 17, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(Palette.accent)
-                    .foregroundStyle(.white)
+                    .background(canRetry ? Palette.surface : Palette.accent)
+                    .foregroundStyle(canRetry ? Palette.ink : .white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .overlay(RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(canRetry ? Palette.hairline : .clear, lineWidth: 1))
             }
             Button("Close") { dismiss() }
                 .foregroundStyle(Palette.muted)

--- a/companion-ios/Sources/SettingsView.swift
+++ b/companion-ios/Sources/SettingsView.swift
@@ -314,6 +314,20 @@ struct SettingsView: View {
                 Text("Diagnostics").trackedLabel()
                 Text("The device keeps a daily log (boot, GPS, BLE, OTA, errors). Grab today's, or pick a specific day.")
                     .font(.system(size: 12)).foregroundStyle(Palette.muted)
+                // Logs share the one transfer channel with rides, so a tap while
+                // something else is downloading waits its turn — say so, rather
+                // than looking like the button did nothing.
+                if !queuedLogs.isEmpty {
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "clock")
+                        Text(queuedLogs.count == 1
+                             ? "\(logDayLabel(queuedLogs[0])) queued — starts after the current download"
+                             : "\(queuedLogs.count) logs queued — they start after the current download")
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 0)
+                    }
+                    .font(.system(size: 12)).foregroundStyle(Palette.muted)
+                }
                 if ble.downloadingLog {
                     ProgressView(value: ble.downloadProgress) {
                         Text("Downloading \(logDayLabel(ble.downloadingName ?? "log"))…")
@@ -347,6 +361,11 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    // Queued entries that are logs (rides are ".fit", today's log is "diag").
+    private var queuedLogs: [String] {
+        ble.queuedDownloads.filter { $0 == "diag" || $0.hasSuffix(".log") }
     }
 
     // "20260716.log" -> "Jul 16, 2026"; "pending.log" -> "Before first GPS fix".


### PR DESCRIPTION
## The bug

Start downloading one ride, then tap another: the second ride is saved corrupt and the first is lost entirely.

The device streams one file at a time and only reads its pending-request slot *between* streams (`src/ble_server.cpp`), but `downloadRide` wrote its command and reset the shared receive state immediately, whatever was in flight:

1. `dlBuffer` was emptied while `dlNextSeq` stayed at ride A's position — so A's remaining chunks still passed the strict in-order check and accumulated in the buffer meant for B.
2. `dlExpected` went back to `0`, which made `finishDownload`'s truncation guard — `if dlExpected > 0 && dlBuffer.count != dlExpected` — skip entirely.
3. When A's stream ended, that tail was written to disk **under ride B's name** and announced as "B ready". Ride A was never saved at all.

`isCached()` then returns true for B, so tapping it again never re-downloads — the corrupt file is permanent until the ride is deleted.

## Verification

There is no test target, so I confirmed the mechanism by simulating the firmware's `streamFileWindowed` against the old and new phone-side state machines:

```
── BEFORE the fix
   wrote B.fit: the last 460 bytes of A.fit     ← corrupt save, announced as "B ready"
   wrote B.fit: the whole of B.fit
   on disk A.fit: NOT SAVED
── BEFORE the fix  (link drops before the second stream)
   on disk B.fit: CORRUPT — the last 460 bytes of A.fit
── AFTER the fix
   on disk A.fit: correct  ·  on disk B.fit: correct  ·  queue drained: true
```

Builds clean (`xcodebuild -destination 'generic/platform=iOS Simulator'`), no new warnings. **Not yet exercised against real hardware** — worth confirming on-device: start a ride download, tap a second immediately, check both decode.

## The fix

- **Serial queue.** Rides and logs share the one device-side streamer and the one receive buffer, so they queue: a request is only written when the line is free, and `endActiveTransfer()` is the single exit point that starts the next.
- **Stray packets can't reach the buffer.** `0x10`/`0x11`/`0x12`/`0x14` require an active transfer; chunks require a seen header. The `0x14` ack is withheld from a stream we aren't collecting — acking it with our seq 0 would make the device seek back and resend that entire file, where silence lets its own 5s ack timeout drop it and pick up our request.
- **Never write a partial file.** A missing `[0x10]` header (`dlExpected == 0`) is now a failure instead of a silent pass-through. That single condition is what turned a race into a corrupt file on disk.
- **List commands defer** while transfers are pending — they share the device's single request slot, so a mid-download refresh would clobber the next queued download (or be clobbered), leaving "Loading rides…" spinning forever or a download waiting on its watchdog.
- **20s stall watchdog**; a busy (recording) device or a dropped link cancels the whole queue with one message rather than one failure per file.

## UI

Queued rides say so; a ride that lands while you're reading an earlier one fills in its row instead of yanking the sheet away; and the parse-error sheet now offers **Download again** (deletes the cached file and re-queues) — the way out for rides already left corrupt by this bug.

## Note

The Android companion has the identical defect (`companion-android/…/ble/BleManager.kt` is a line-for-line port). Fixed separately on the `android-companion` branch, since that app isn't on `main` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoqKkeLvXmSTVKh6q6aX1J