### PR TITLE
Cut the panel rails before deep sleep

### DIFF
--- a/src/epd_compat.cpp
+++ b/src/epd_compat.cpp
@@ -701,6 +701,23 @@ void epdc_paint_wait() {
         Serial.println("[epdc] paint did not finish within 6 s; powering off anyway");
 }
 
+// The driver's idle timer re-arms to `_idle_timeout_s` on every paint, so
+// shortening it here means the farewell paint that follows arms one second rather
+// than five.
+void epdc_power_off_soon() {
+    if (g_painter) g_painter->setIdleTimeout(1);
+}
+
+void epdc_power_off_wait() {
+    if (!g_painter) return;
+    // A blind wait, deliberately: the driver exposes no rail-state getter, so
+    // there is nothing to poll. Its `panel_idle_off` task ticks at 1 Hz and powers
+    // off when the count armed above reaches zero, which is two ticks away worst
+    // case. That task runs at priority 1 and this is the UI task at 2, so the
+    // delay is what lets it be scheduled at all.
+    vTaskDelay(pdMS_TO_TICKS(2400));
+}
+
 void epdc_clear(int passes) {
     if (!g_painter) return;
     if (passes < 1) passes = 1;

--- a/src/epd_compat.h
+++ b/src/epd_compat.h
@@ -60,6 +60,32 @@ void epdc_paint();
 // No-op on the epdiy backend, whose epd_hl_update_screen() already blocks.
 void epdc_paint_wait();
 
+// Cut the panel's high-voltage rails (VPOS/VNEG/VGH/VGL/VCOM) before deep sleep.
+//
+// Without this the TPS65185 keeps generating rails for the whole sleep. The
+// EPD_Painter backend does drop them on its own — but on a 5-second idle timer
+// run by its own `panel_idle_off` task, and shutdownDevice() stops the CPU long
+// inside that window, so the timer never fires. The enables are latched in the
+// XL9555 expander, which sits on the always-on 3V3, so nothing else drops them
+// either. (The epdiy backend powered the rails down around every paint, which is
+// why this only became a problem with the EPD_Painter port.)
+//
+// Two calls because of how that timer works: it is armed at paint time, so the
+// countdown has to be shortened BEFORE the last paint, and waited for after it.
+//
+//   epdc_power_off_soon();   // then paint the farewell screen
+//   epdc_paint_wait();
+//   epdc_power_off_wait();
+//
+// powerOff() itself is private to the driver, and reproducing it here would mean
+// duplicating its TPS-register-then-expander sequencing — so this drives the
+// driver's own path instead of reimplementing it.
+//
+// Safe for the image: e-paper holds its last frame with no power at all, which is
+// the whole premise of the farewell screen.
+void epdc_power_off_soon();
+void epdc_power_off_wait();
+
 // Drive the whole panel to white. `passes` > 1 repeats it: e-paper keeps its
 // image through power-off, so the first boot after a different firmware needs
 // several passes to shift what is physically on the glass (one was not enough,

--- a/src/epd_compat_epdiy.cpp
+++ b/src/epd_compat_epdiy.cpp
@@ -65,6 +65,15 @@ void epdc_paint() {
 // must not sleep mid-drive (shutdownDevice) can be backend-agnostic.
 void epdc_paint_wait() {}
 
+// Already down — this backend powers the rails on and off around every paint
+// (above), which is why the deep-sleep drain the EPD_Painter port introduced was
+// never a problem here. Kept so the shutdown path can stay backend-agnostic.
+void epdc_power_off_soon() {}
+void epdc_power_off_wait() {
+    if (!g_ready) return;
+    epd_poweroff();   // belt and braces if a future paint path forgets
+}
+
 void epdc_clear(int passes) {
     if (!g_ready) return;
     if (passes < 1) passes = 1;

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -147,6 +147,11 @@ void shutdownDevice(uint8_t* fb, const char* reason) {
     }
     diag::flushToSD();
 
+    // Shorten the panel's idle power-off before painting, so the farewell frame
+    // arms a one-second countdown instead of the default five. The rails cannot be
+    // dropped directly — see epd_compat.h.
+    epdc_power_off_soon();
+
     // Leave a static farewell on the glass — e-paper keeps it for free.
     // Full-screen map backdrop (last known position) with a POWERED OFF plate.
     // Force the widest zoom so the farewell shows the broadest area overview
@@ -182,6 +187,15 @@ void shutdownDevice(uint8_t* fb, const char* reason) {
     // and left the farewell screen half-written. (The epdiy backend painted
     // inline, which is why this never used to be needed.)
     epdc_paint_wait();
+
+    // Then let the panel's rails come down. Without this the TPS65185 sits
+    // generating VPOS/VNEG/VGH/VGL for the entire sleep — the enables are latched
+    // in the expander, which is on the always-on 3V3, and the driver's own
+    // power-off timer never gets to run because we stop the CPU first. Armed
+    // before the paint above; see epd_compat.h. The image survives regardless:
+    // e-paper needs no power to hold a frame, which is the whole premise of the
+    // farewell screen.
+    epdc_power_off_wait();
 
     // Close the SD cleanly before the card loses its host. An interrupted SD
     // transaction leaves the card's controller refusing CMD0 on the next boot —


### PR DESCRIPTION
The device was deep-sleeping with the e-paper high-voltage rails still up. The
CPU genuinely reaches deep sleep — but the TPS65185 was left generating
VPOS/VNEG/VGH/VGL for the whole of it.

## Why it happened

EPD_Painter does drop the rails, on a five-second idle timer serviced by its own
`panel_idle_off` task. `shutdownDevice()` paints the farewell screen and stops
the CPU well inside that window, so the timer never fires — and the enables are
latched in the XL9555 expander, which sits on the always-on 3V3, so nothing else
was going to drop them either. `epdc_paint_wait()` even carried a comment saying
"powering off anyway"; nothing did.

This is a regression from the epdiy port rather than a new bug. That backend
powered the rails on and off around every paint, inline, so it never needed
saying — the same shape as the note already in `epdc_paint_wait()` about epdiy
painting inline where EPD_Painter is asynchronous.

## Why the fix looks like this

`EPD_Painter::powerOff()` is private, and `end()` tears down the paint task, DMA
and the LCD peripheral without touching power. Reproducing the power-down here
would mean duplicating the driver's TPS-register-then-expander sequencing, which
is exactly the kind of thing that rots silently.

So this drives the driver's own path instead: shorten the idle timeout *before*
the farewell paint, so that paint arms a one-second countdown rather than five,
then wait for it. The two-call shape (`epdc_power_off_soon()` /
`epdc_power_off_wait()`) exists because the timer is armed at paint time.

Costs ~2.4 s on a path that already takes seconds, with the finished farewell
screen on the glass throughout. The image is unaffected either way — e-paper
holds a frame with no power at all, which is the whole premise of that screen.

The epdiy backend gets no-op/belt-and-braces implementations so the shutdown path
stays backend-agnostic.

## Testing

- Builds and flashed to hardware; boots and sleeps normally.
- The wait is blind by necessity: the driver exposes no rail-state getter, so
  there is nothing to poll.

**Not measured.** I have not quantified the saving. The TPS65185 with rails up is
plausibly tens of milliamps, which on a 1500 mAh cell would be the difference
between days and weeks of standby — but that is inference, not a reading. The
diagnostics log samples state-of-charge every two minutes, so an overnight
before/after would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TsgJa1Hg1kUsfA5L1NtDw