### PR TITLE
Site: link the App Store listing from the companion-app section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,10 @@
     <p class="kicker">02 — The companion app</p>
     <h2>The phone does the typing. The bike does the riding.</h2>
     <p class="sub">A free iOS app handles everything that&rsquo;s fiddly on a touch e-paper screen — planning routes, building offline maps, and reviewing rides — then streams it all to the head unit over Bluetooth.</p>
+    <div class="cta-row app-cta">
+      <a class="btn accent" href="https://apps.apple.com/us/app/opentrailpaper/id6793646642">Download on the App Store →</a>
+      <span class="app-cta-note">Free · iPhone · iOS 17 or later</span>
+    </div>
     <div class="app-gallery">
       <figure class="app-shot">
         <div class="iphone">

--- a/docs/style.css
+++ b/docs/style.css
@@ -332,6 +332,15 @@ section .sub { color: var(--ink-soft); font-size: 1.06rem; margin: 0 0 40px; max
 }
 
 /* --- companion app gallery --- */
+/* The section's .sub already carries the 40px gap above the button, so the row
+   only owns the space down to the screenshots. */
+.app-cta { margin: 0 0 40px; }
+.app-cta-note { color: var(--ink-soft); font-size: 0.9rem; }
+/* Below 860px .cta-row stacks and centres its button, so the note follows it. */
+@media (max-width: 860px) {
+  .app-cta { margin-bottom: 24px; }
+  .app-cta-note { text-align: center; }
+}
 .app-gallery { display: grid; grid-template-columns: repeat(3, 1fr); gap: 40px; }
 @media (max-width: 720px) {
   .app-gallery {


### PR DESCRIPTION
Section 02 has described a free iOS app since the site went up, with no way to go get it — the page sells the app and then leaves the reader to search for it.

**https://apps.apple.com/us/app/opentrailpaper/id6793646642** (verified live: 200, "OpenTrailPaper App - App Store")

## Placement

Under the section's copy, not in the hero. The hero's claim is that the head unit needs no phone at all, and an app download sitting beside "no phone required" would undercut the pitch. Section 02 is where the reader has just been told what the app does.

Beside the button, the terms you want before tapping: **Free · iPhone · iOS 17 or later** — iOS 17 is the deployment target in `companion-ios/project.yml`.

## Styling

Reuses the existing `.btn.accent` and `.cta-row`, so it inherits the site's button treatment and the below-860px stacking the hero's buttons already use. The only new CSS is spacing down to the screenshot gallery and centring the note on narrow screens.

Checked rendered at 1400px, 760px and 390px — button and note read correctly at each, nothing clipped or overlapping.

Plain text button rather than Apple's badge art, deliberately: the badge is rounded and dark, which would sit oddly among this site's square 2px-border uppercase buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoqKkeLvXmSTVKh6q6aX1J