### PR TITLE
Flash without touching BOOT or RESET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ compile_commands.json
 tools/maps/sf_overpass.json
 *_overpass.json
 tools/maps/__pycache__/
+tools/__pycache__/
 
 # Xcode user-specific state (the generated .xcodeproj itself is kept)
 **/xcuserdata/

--- a/README.md
+++ b/README.md
@@ -356,25 +356,68 @@ pio run -t upload                       # flash over USB
 pio device monitor -b 115200            # serial log
 ```
 
-The board runs in USB-OTG mode, so esptool's auto-reset can't enter the
-bootloader. Three ways in:
+`pio run -t upload` needs no button presses: `tools/pio_upload.py` reboots the
+running firmware into download mode first and resets it back into the app
+afterwards. Close any serial monitor before uploading — the hook needs the
+console port to send the `bootloader` command.
 
-- **From the running firmware** (easiest): send `bootloader` on the serial
-  console. It calls `usb_persist_restart(RESTART_BOOTLOADER)`, so the port
-  reappears as `…usbmodem2101` with no button press. Flash with
-  `--after no_reset`, then tap **RESET** to run — esptool's own reset drives
-  GPIO0 low on that bridge and would land straight back in download mode.
-- **By hand**, when the firmware isn't running: hold **BOOT**, tap **RESET**,
-  release **BOOT**, upload, tap **RESET**.
+The same logic is available standalone, for flashing a prebuilt image without a
+PlatformIO build:
+
+```sh
+tools/flash.py --firmware firmware.bin  # enter download mode, write, reset
+tools/flash.py enter                    # only reboot into download mode
+tools/flash.py finish                   # only reset a board that's stuck in it
+```
+
+<details>
+<summary>Why this needs its own tooling</summary>
+
+The board runs its USB in OTG mode, so while the app is running there is no
+bridge whose DTR/RTS reach GPIO0/EN — esptool's auto-reset can't get *in*.
+`usb_persist_restart(RESTART_BOOTLOADER)`, behind the firmware's `bootloader`
+console command, solves that half: on the S3 it calls `usb_switch_to_cdc_jtag()`,
+so the board reappears as the USB-Serial-JTAG device (`…usbmodem2101`, product
+`USB JTAG/serial debug unit`) — a different port from the app's, and one whose
+DTR/RTS *are* wired to GPIO0/EN.
+
+Getting back *out* used to need the RESET button, for two separate reasons:
+
+- `usb_persist_restart()` sets `RTC_CNTL_FORCE_DOWNLOAD_BOOT`, and nothing in the
+  Arduino core clears it. It sits in the RTC domain, which a soft reset doesn't
+  touch, so the ROM diverts to the loader again on every subsequent reset. Only
+  pulling CHIP_EN low — the physical button — resets that domain.
+- esptool's `--after hard_reset` pulses RTS but leaves DTR asserted (its
+  `_setRTS()` re-asserts DTR as a Windows workaround, and `--before no_reset`
+  never clears it). With DTR driving GPIO0, its reset releases EN with GPIO0
+  still low: download mode, again.
+
+`tools/flash.py` clears the bit over the download-mode connection and then drives
+the reset itself with DTR deasserted. `src/main.cpp` also clears a stale bit at
+boot, so a set bit can't quietly send some later OTA reboot into download mode.
+</details>
+
+Two fallbacks remain:
+
+- **By hand**, if the firmware is too broken to accept the `bootloader` command:
+  hold **BOOT**, tap **RESET**, release **BOOT**, then `tools/flash.py` (it
+  detects the board is already in download mode and skips straight to flashing).
 - **No USB at all**: copy `firmware.bin` to the SD card root and reboot, or push
   OTA from the app.
 
-Note that the app's OTG console port only re-enumerates on a *physical* reset,
-so after any software restart the port stays away until you tap **RESET**.
+Note that the app's OTG console port only re-enumerates on a *physical* reset, so
+after a plain software restart (`reboot`, an OTA, a crash) the port stays away
+until you tap **RESET**. This is not fixable from the firmware: the Arduino core
+compiles its USB-persist support out (`usb_persist_enabled` is hard-coded false in
+`esp32-hal-tinyusb.c`), so `RESTART_PERSIST` is a no-op. Going out through
+download mode, as the flasher does, is the way to get a software-triggered reset
+that brings the port back.
 
 No toolchain? Flash a prebuilt `firmware.bin` (from CI artifacts or a release)
 straight from the [project site](https://raemondbw.github.io/OpenTrailPaper/#flash)
-over Web Serial in Chrome/Edge — same manual download-mode step as above.
+over Web Serial in Chrome/Edge. You still need to enter download mode by hand
+there (BOOT + RESET, or send `bootloader` from a serial console first), but it
+resets into the new firmware on its own when the flash finishes.
 
 ### iOS companion
 

--- a/docs/flash.js
+++ b/docs/flash.js
@@ -135,6 +135,41 @@ async function cleanup() {
   if (statusEl.className.indexOf("err") === -1) setStatus("Not connected.");
 }
 
+// --- leaving download mode ---------------------------------------------------
+// soc/rtc_cntl_reg.h: DR_REG_RTCCNTL_BASE (0x60008000) + 0x12C, bit 0.
+const RTC_CNTL_OPTION1_REG = 0x6000812c;
+const RTC_CNTL_FORCE_DOWNLOAD_BOOT = 0x1;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Reset the board so it runs the app instead of returning to download mode.
+// Two things stand in the way, and both are handled here:
+//
+//  1. Whatever put the board into download mode set FORCE_DOWNLOAD_BOOT. That
+//     bit lives in the RTC domain, which a reset does not clear, so the ROM
+//     would divert to the loader again. We clear it over the connection that
+//     just did the flashing, while the loader is still listening.
+//
+//  2. On the USB-Serial-JTAG bridge, DTR drives GPIO0 and RTS drives EN — and
+//     Transport.setRTS() re-asserts the last DTR state on every call (a
+//     Windows driver workaround). Deassert DTR *first*, or every RTS pulse
+//     also pulls GPIO0 low and boots the loader.
+async function bootIntoApp() {
+  await esploader.writeReg(
+    RTC_CNTL_OPTION1_REG,
+    0x0,
+    RTC_CNTL_FORCE_DOWNLOAD_BOOT, // mask: leave the rest of the register alone
+  );
+  log("Cleared the force-download-boot bit.");
+
+  await transport.setDTR(false); // GPIO0 high — boot from flash
+  await transport.setRTS(false); // idle
+  await sleep(100);
+  await transport.setRTS(true); // EN low: chip in reset
+  await sleep(100);
+  await transport.setRTS(false); // EN high: boots, sampling GPIO0 high
+}
+
 // --- flash ------------------------------------------------------------------
 flashBtn.addEventListener("click", async () => {
   if (!esploader) return;
@@ -191,15 +226,40 @@ flashBtn.addEventListener("click", async () => {
     });
 
     bar.style.width = "100%";
-    setStatus("Done! Tap RESET on the board to run the new firmware.", "ok");
-    log("\n✔ Flash complete. Tap RESET to boot.");
-    try { await esploader.after(); } catch (_) { /* OTG can't auto-reset; that's fine */ }
+    log("\n✔ Flash complete.");
+
+    // Boot the new firmware without a RESET tap. esptool's own after() can't:
+    // it pulses RTS while leaving DTR asserted, and on this board's
+    // USB-Serial-JTAG bridge DTR drives GPIO0 — so its reset lands right back
+    // in download mode. See bootIntoApp() for the sequence that works.
+    let resetErr = null;
+    try {
+      await bootIntoApp();
+      log("Reset sent — the board should be running the new firmware now.");
+    } catch (e) {
+      console.error(e);
+      resetErr = e;
+      log("Couldn't reset automatically (" + (e?.message || e) + "). Tap RESET to boot.");
+    }
+
+    // The board re-enumerates as a different USB device on the way out of
+    // download mode, so this port is dead either way — drop it and reset the UI
+    // rather than leaving a Disconnect button pointing at nothing.
+    await cleanup();
+    setStatus(
+      resetErr
+        ? "Flashed OK, but the reset failed — tap RESET on the board."
+        : "Done! The board is booting the new firmware.",
+      "ok",
+    );
   } catch (err) {
     console.error(err);
     log("Error: " + (err?.message || err));
     setStatus("Flash failed — see the log above.", "err");
   } finally {
-    flashBtn.disabled = false;
+    // Only offer Flash again if we still hold a connection: on the success path
+    // cleanup() has already dropped it, and the board is off running the app.
+    flashBtn.disabled = esploader === null;
     connectBtn.disabled = false;
   }
 });

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,6 +103,13 @@ upload_speed = 921600
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 boards_dir = vendor/T5S3-4.7-e-paper-PRO/boards
+; Hands-free upload: the hooks reboot the running firmware into the ROM loader
+; before flashing and reset it back into the app afterwards, so `pio run -t
+; upload` needs no BOOT/RESET presses. Both resets have to be ours, hence the
+; no_reset pair -- esptool's own are wrong for this board (see tools/flash.py).
+extra_scripts = post:tools/pio_upload.py
+board_upload.before_reset = no_reset
+board_upload.after_reset = no_reset
 lib_extra_dirs =
     vendor/T5S3-4.7-e-paper-PRO/lib
 ; epdiy supplies the TYPES our renderers and font data use, but none of its

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -350,16 +350,22 @@ void setup() {
     esp_reset_reason_t rr = esp_reset_reason();
     diag::log("boot firmware %s (reset: %s [%d])", FIRMWARE_VERSION,
               resetReasonStr(rr), (int)rr);
-    // Is the force-download-boot bit still set?
+    // Clear the force-download-boot bit if it survived into this boot.
     //
-    // The `bootloader` console command (usb_persist_restart) sets it and NOTHING
-    // in the Arduino core ever clears it — whether it survives depends on the
-    // ROM, which we can't read from the host. If this logs 1 on a normal app
-    // boot, the bit is sticky and the command strands the device in download
-    // mode until a real power cycle; if it logs 0, the command is safe to use
-    // for hands-free flashing and the physical BOOT/RST dance is unnecessary.
-    diag::log("force-download-boot bit: %d",
-              (int)((REG_READ(RTC_CNTL_OPTION1_REG) & RTC_CNTL_FORCE_DOWNLOAD_BOOT) != 0));
+    // The `bootloader` console command (usb_persist_restart) sets it and nothing
+    // in the Arduino core ever clears it. It lives in the RTC domain, which a
+    // soft reset does not touch, so a set bit means the *next* esp_restart() —
+    // an OTA reboot, a crash, a `restart` — would land in download mode instead
+    // of the app, with no obvious cause. Only a physical RESET clears the domain.
+    //
+    // The host-side flasher clears it too (tools/flash.py), which is what makes
+    // hands-free flashing work; this is the belt-and-braces for every other way
+    // the bit could still be set by the time we get here. Logged when found set,
+    // since on a healthy boot it should always read 0.
+    if (REG_READ(RTC_CNTL_OPTION1_REG) & RTC_CNTL_FORCE_DOWNLOAD_BOOT) {
+        REG_CLR_BIT(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+        diag::log("cleared a stale force-download-boot bit");
+    }
     if (rr == ESP_RST_DEEPSLEEP) {
         esp_sleep_wakeup_cause_t wc = esp_sleep_get_wakeup_cause();
         diag::log("woke by: %s [%d]", wakeCauseStr(wc), (int)wc);

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1322,11 +1322,15 @@ void applySdUpdate() {
 }
 
 // Reboot into the ROM serial bootloader (download mode) for hands-free
-// reflashing. usb_persist_restart keeps the USB-CDC enumerated across the reset
-// (same port, no re-enumeration) — unlike a raw FORCE_DOWNLOAD_BOOT + restart,
-// which tears the USB down and leaves no port for the host to connect to.
+// reflashing. On the S3, usb_persist_restart(RESTART_BOOTLOADER) calls
+// usb_switch_to_cdc_jtag() before restarting, so the board comes back on the
+// USB-Serial-JTAG peripheral rather than TinyUSB: a *different* USB device on a
+// different port (…usbmodem2101, product "USB JTAG/serial debug unit"). That is
+// the point — unlike our OTG port, that bridge has DTR/RTS wired to GPIO0/EN,
+// so the host can reset us back into the app afterwards with no button press.
+// tools/flash.py drives both halves; `pio run -t upload` goes through it.
 static void rebootToBootloader() {
-    Serial.println("[cmd] entering download mode (USB persists) — flash now");
+    Serial.println("[cmd] entering download mode — flash now");
     Serial.flush();
     delay(100);
     usb_persist_restart(RESTART_BOOTLOADER);

--- a/tools/flash.py
+++ b/tools/flash.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Hands-free USB flashing for the T5S3 bike computer.
+
+The board runs its USB in OTG (TinyUSB) mode, so esptool's auto-reset can't
+reach it: while the app is running there is no UART bridge whose DTR/RTS lines
+are wired to GPIO0/EN. Getting firmware onto it has therefore cost two button
+presses -- one to enter download mode, one to leave it. This removes both.
+
+Entering is the easy half and already existed: the firmware's `bootloader`
+console command (rebootToBootloader() in src/ui_dashboard.cpp) reboots into the
+ROM loader, which comes back as the USB-Serial-JTAG device -- a *different*
+serial port from the app's OTG one, with "JTAG" in its USB product string.
+
+*Leaving* download mode is what needed the RESET tap, for two independent
+reasons, both of which this script handles:
+
+  1. usb_persist_restart(RESTART_BOOTLOADER) sets RTC_CNTL_FORCE_DOWNLOAD_BOOT
+     (esp32-hal-tinyusb.c) and nothing in the Arduino core ever clears it. The
+     bit lives in the RTC domain, which a soft reset does not touch, so every
+     later reset walks straight back into download mode. Only pulling CHIP_EN
+     low -- the physical RESET button -- resets that domain. So we clear the bit
+     ourselves, over the download-mode connection, before resetting.
+
+  2. esptool's own `--after hard_reset` is wrong for this bridge. HardReset
+     pulses RTS only, and its _setRTS() helper re-asserts the port's current DTR
+     as a Windows workaround. On USB-Serial-JTAG, DTR drives GPIO0 -- and
+     pyserial asserts DTR on open, while `--before no_reset` (which we must use,
+     the board being in download mode already) never runs the JTAG sequence that
+     would clear it. The reset thus releases EN with GPIO0 still low, which is
+     download mode again. So we drive the reset ourselves with DTR explicitly
+     deasserted.
+
+Usage:
+    tools/flash.py                      # enter download mode, flash, reset
+    tools/flash.py --firmware fw.bin    # ... a specific image
+    tools/flash.py enter                # only reboot into download mode
+    tools/flash.py finish               # only clear the bit and reset
+
+This is also the engine behind `pio run -t upload`; see tools/pio_upload.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+try:
+    import serial
+    import serial.tools.list_ports as list_ports
+except ImportError:  # pragma: no cover - pyserial ships with PlatformIO
+    sys.exit("pyserial is required: pip install pyserial")
+
+
+# --- chip constants ---------------------------------------------------------
+# soc/rtc_cntl_reg.h: DR_REG_RTCCNTL_BASE (0x60008000) + 0x12C, bit 0.
+RTC_CNTL_OPTION1_REG = 0x6000812C
+RTC_CNTL_FORCE_DOWNLOAD_BOOT = 0x1
+
+ESPRESSIF_VID = 0x303A
+
+# How long the ROM loader takes to enumerate after the `bootloader` command, and
+# how long the app's TinyUSB CDC takes to come back after the reset. Both are
+# generous: a slow SD mount at boot can push the app port out past 5 s.
+DOWNLOAD_PORT_TIMEOUT = 20.0
+# Generous, because the first boot after a flash is the slowest one there is: a
+# board recovering from a crash loop repairs the ride file it was cut off in the
+# middle of before the console ever comes up, which has been measured past 25 s.
+# Overshooting only delays a warning on a board that never comes back;
+# undershooting cries wolf on a perfectly good flash.
+APP_PORT_TIMEOUT = 60.0
+
+
+def _log(msg: str) -> None:
+    print(f"[flash] {msg}", flush=True)
+
+
+# --- port discovery ---------------------------------------------------------
+# Both the app's TinyUSB CDC and the ROM's USB-Serial-JTAG enumerate as
+# 303a:1001, so the PID cannot tell them apart. The product string can: the ROM
+# device reports "USB JTAG/serial debug unit", the app reports the board name
+# from the Arduino USB descriptors ("LilyGo T5-ePaper-S3").
+def esp_ports():
+    return [p for p in list_ports.comports() if p.vid == ESPRESSIF_VID]
+
+
+def is_rom_port(p) -> bool:
+    return "jtag" in (p.product or "").lower()
+
+
+def find_rom_port():
+    for p in esp_ports():
+        if is_rom_port(p):
+            return p.device
+    return None
+
+
+def find_app_port():
+    for p in esp_ports():
+        if not is_rom_port(p):
+            return p.device
+    return None
+
+
+def _wait_for(predicate, timeout: float, what: str):
+    """Poll the port list until `predicate` returns a device path."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        found = predicate()
+        if found:
+            # macOS creates the /dev node a moment before the CDC endpoints are
+            # actually usable; opening too eagerly gets ENXIO.
+            time.sleep(0.4)
+            return found
+        time.sleep(0.2)
+    raise SystemExit(f"[flash] timed out after {timeout:.0f}s waiting for {what}")
+
+
+# --- download mode ----------------------------------------------------------
+def enter_download_mode() -> str:
+    """Get the board into the ROM loader and return its serial port."""
+    existing = find_rom_port()
+    if existing:
+        _log(f"already in download mode on {existing}")
+        return existing
+
+    _log("asking the firmware to reboot into download mode")
+
+    # Keep trying for the whole window rather than sampling once. Two things make
+    # a single attempt unreliable, and both are worst on a board that is
+    # crash-looping — precisely when you most need to reflash it:
+    #   - the port enumerates a second or two into boot, before the console task
+    #     is necessarily reading it, so an early write is simply dropped;
+    #   - between resets the port is not there at all, so a one-shot lookup can
+    #     conclude "no board" about a board that is plugged in and fine.
+    # Re-sending costs nothing: the command is idempotent, and once the ROM
+    # loader is up the app port is gone and we stop.
+    deadline = time.monotonic() + DOWNLOAD_PORT_TIMEOUT
+    last_err = None
+    while time.monotonic() < deadline:
+        rom = find_rom_port()
+        if rom:
+            time.sleep(0.4)   # let the CDC endpoints settle before esptool opens it
+            _log(f"download mode up on {rom}")
+            return rom
+        app = find_app_port()
+        if app:
+            try:
+                # The console runs at 115200 but this is a native CDC port, so the
+                # baud rate is decorative. The leading newline flushes any
+                # half-typed line.
+                with serial.Serial(app, 115200, timeout=1) as s:
+                    s.write(b"\nbootloader\n")
+                    s.flush()
+            except (serial.SerialException, OSError) as e:
+                # Expected while the board is mid-reset; only worth reporting if
+                # we never get in at all.
+                last_err = e
+        time.sleep(0.5)
+
+    hint = f" (last error: {last_err})" if last_err else ""
+    raise SystemExit(
+        f"[flash] the firmware never entered download mode{hint}.\n"
+        "        Close any serial monitor, or do it by hand: hold BOOT, tap\n"
+        "        RESET, release BOOT, then re-run."
+    )
+
+
+# --- esptool plumbing -------------------------------------------------------
+def _esptool(args: list[str]) -> None:
+    """Run esptool in-process, preferring PlatformIO's pinned copy."""
+    try:
+        import esptool  # noqa: F401
+    except ImportError:
+        pio_esptool = os.path.expanduser("~/.platformio/packages/tool-esptoolpy")
+        if not os.path.isdir(pio_esptool):
+            raise SystemExit("[flash] esptool not importable: pip install esptool")
+        sys.path.insert(0, pio_esptool)
+        import esptool  # noqa: F811
+
+    esptool.main(args)
+
+
+def clear_force_download_boot(port: str) -> None:
+    """Clear the sticky bit that would send the next reset back to download mode.
+
+    Runs over the still-open download-mode connection. `--before no_reset`
+    because the board is already in the ROM loader and must not be bounced;
+    `--after no_reset` because we do the reset ourselves, correctly, below.
+    """
+    _log("clearing RTC_CNTL_FORCE_DOWNLOAD_BOOT")
+    _esptool([
+        "--chip", "esp32s3",
+        "--port", port,
+        "--before", "no_reset",
+        "--after", "no_reset",
+        "write_mem",
+        hex(RTC_CNTL_OPTION1_REG),
+        "0x0",
+        hex(RTC_CNTL_FORCE_DOWNLOAD_BOOT),   # mask: touch only bit 0
+    ])
+
+
+def reset_into_app(port: str) -> None:
+    """Reset the chip with GPIO0 held high, so it boots the app.
+
+    On the USB-Serial-JTAG bridge DTR drives GPIO0 and RTS drives EN. pyserial
+    asserts both on open, so the states are set *before* open() rather than
+    after -- otherwise the chip would take a stray EN-low/GPIO0-low glitch (i.e.
+    a bounce into download mode) on the way through.
+    """
+    _log("resetting into the application")
+    s = serial.Serial()
+    s.port = port
+    s.baudrate = 115200
+    s.dtr = False    # GPIO0 high -- boot from flash, not the ROM loader
+    s.rts = False
+    s.open()
+    try:
+        s.rts = True     # EN low: chip in reset
+        time.sleep(0.1)
+        s.rts = False    # EN high: boots, sampling GPIO0 high
+    finally:
+        s.close()
+
+
+def wait_for_app(timeout: float = APP_PORT_TIMEOUT) -> str | None:
+    """Wait for the app's OTG console port to come back after the reset."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        # Ignore a ROM port lingering in the list: on macOS the old node can
+        # take a beat to disappear after the device re-enumerates.
+        app = find_app_port()
+        if app:
+            _log(f"application is up on {app}")
+            return app
+        time.sleep(0.2)
+    _log(f"warning: the app console port did not reappear within {timeout:.0f}s")
+    return None
+
+
+def finish(port: str) -> None:
+    """The whole after-flash half: clear the bit, reset, confirm the app is up."""
+    clear_force_download_boot(port)
+    reset_into_app(port)
+    wait_for_app()
+
+
+# --- flashing ---------------------------------------------------------------
+def default_firmware() -> str:
+    """The shipping env's build output (see default_envs in platformio.ini)."""
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(root, ".pio", "build", "t5s3-painter", "firmware.bin")
+
+
+def write_firmware(port: str, firmware: str, address: int, baud: int) -> None:
+    if not os.path.isfile(firmware):
+        raise SystemExit(f"[flash] no such firmware image: {firmware}\n"
+                         "        Build it first with `pio run`.")
+    size = os.path.getsize(firmware)
+    _log(f"writing {firmware} ({size} bytes) to {hex(address)}")
+    _esptool([
+        "--chip", "esp32s3",
+        "--port", port,
+        "--baud", str(baud),
+        "--before", "no_reset",
+        "--after", "no_reset",
+        # Underscored spellings: esptool renamed these to hyphens in v5, but the
+        # pinned PlatformIO copy is v4.5.1, where only these parse.
+        "write_flash", "-z",
+        "--flash_mode", "keep",
+        "--flash_freq", "keep",
+        "--flash_size", "keep",
+        hex(address), firmware,
+    ])
+
+
+# --- CLI --------------------------------------------------------------------
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Flash the T5S3 bike computer without touching BOOT or RESET.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("command", nargs="?", default="flash",
+                    choices=["flash", "enter", "finish"],
+                    help="flash (default): enter download mode, write, reset. "
+                         "enter: only reboot into download mode. "
+                         "finish: only clear the bit and reset into the app.")
+    ap.add_argument("--firmware", default=None,
+                    help="image to write (default: .pio/build/t5s3-painter/firmware.bin)")
+    ap.add_argument("--address", type=lambda x: int(x, 0), default=0x10000,
+                    help="flash offset for the image (default: 0x10000, the app partition)")
+    ap.add_argument("--baud", type=int, default=921600, help="upload baud rate")
+    ap.add_argument("--port", default=None,
+                    help="override port autodetection (the download-mode port)")
+    args = ap.parse_args(argv)
+
+    if args.command == "finish":
+        port = args.port or find_rom_port()
+        if not port:
+            raise SystemExit("[flash] no board in download mode to finish.")
+        finish(port)
+        return 0
+
+    port = args.port or enter_download_mode()
+    if args.command == "enter":
+        return 0
+
+    write_firmware(port, args.firmware or default_firmware(), args.address, args.baud)
+    finish(port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pio_upload.py
+++ b/tools/pio_upload.py
@@ -1,0 +1,51 @@
+"""PlatformIO hooks that make `pio run -t upload` hands-free.
+
+PlatformIO still does the flashing -- it knows the image list, offsets and flash
+settings, and we do not want to reimplement that here. This script only wraps
+the two ends that the board's USB-OTG mode breaks:
+
+  before upload  reboot the running firmware into the ROM loader (if it isn't
+                 there already) and point UPLOAD_PORT at the download-mode port,
+                 which is a *different* device from the app's console port.
+
+  after upload   clear RTC_CNTL_FORCE_DOWNLOAD_BOOT and reset with GPIO0 high,
+                 so the board boots the image we just wrote instead of sitting
+                 in download mode waiting for a RESET tap.
+
+The `--before no_reset --after no_reset` that this depends on is not set here:
+it comes from board_upload.before_reset / board_upload.after_reset in
+platformio.ini, so the flags stay visible next to the rest of the upload config.
+
+The reasoning behind each step is in tools/flash.py, which does the real work.
+"""
+
+import os
+import sys
+
+Import("env")  # noqa: F821 - injected by SCons
+
+# SCons exec()s this file without setting __file__, so locate our sibling module
+# through the project root instead.
+sys.path.insert(0, os.path.join(env["PROJECT_DIR"], "tools"))  # noqa: F821
+import flash  # noqa: E402
+
+
+def before_upload(source, target, env):
+    port = flash.enter_download_mode()
+    env.Replace(UPLOAD_PORT=port)
+
+
+def after_upload(source, target, env):
+    # Re-detect rather than reusing the port from before_upload: esptool has
+    # closed it by now, and on a re-enumeration the node could differ.
+    port = env.subst("$UPLOAD_PORT")
+    if not os.path.exists(port):
+        port = flash.find_rom_port()
+    if not port:
+        print("[flash] board left download mode on its own; nothing to reset")
+        return
+    flash.finish(port)
+
+
+env.AddPreAction("upload", before_upload)    # noqa: F821
+env.AddPostAction("upload", after_upload)    # noqa: F821


### PR DESCRIPTION
Flashing the board cost two button presses. Entering download mode was already solved — the `bootloader` console command reboots into the ROM loader — but leaving it always needed a physical **RESET** tap. This removes that, so `pio run -t upload` is hands-free.

## Why the RESET tap was needed

Two independent causes, both confirmed in source rather than inferred:

1. **A sticky bit.** `usb_persist_restart(RESTART_BOOTLOADER)` does `REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT)` (`esp32-hal-tinyusb.c`), and nothing in the Arduino core ever clears it. It lives in the RTC domain, which a soft reset does not touch, so the ROM diverts to the loader again on every subsequent reset. Only pulling CHIP_EN low — the button — resets that domain.

2. **esptool's `--after hard_reset` is wrong for this bridge.** `HardReset` pulses RTS but leaves DTR asserted: its `_setRTS()` re-asserts DTR as a Windows driver workaround, and `--before no_reset` (which we must use, the board already being in download mode) never clears it. On USB-Serial-JTAG, DTR drives GPIO0 — so the reset releases EN with GPIO0 still low, landing straight back in download mode.

This also settles the question `src/main.cpp` was instrumented for: on the S3, `usb_persist_restart()` calls `usb_switch_to_cdc_jtag()` before restarting, so download mode is a **different USB device** from the app's OTG port. That is what makes a host-driven reset possible at all — unlike the OTG port, that bridge has DTR/RTS wired to GPIO0/EN. The old comment on `rebootToBootloader()` claimed the port persisted across the reboot; it does not.

## What's here

- **`tools/flash.py`** — the engine. Enters download mode via the console command, flashes, clears the bit with esptool `write_mem`, then resets with DTR explicitly deasserted. Usable standalone (`flash` / `enter` / `finish`) for prebuilt images.
- **`tools/pio_upload.py` + `platformio.ini`** — wraps the two ends of PlatformIO's own upload, so it keeps owning the image list and offsets. `board_upload.before_reset`/`after_reset` hand us both resets.
- **`docs/flash.js`** — same fix in the browser (`writeReg` + a DTR-safe `setSignals` sequence), so the web flasher no longer ends on "Tap RESET".
- **`src/main.cpp`** — clears a stale bit at boot, so a set bit cannot quietly send some later OTA reboot into download mode.

## Testing

On hardware: `pio run -t upload` twice end to end with **no button presses**, plus the standalone `tools/flash.py --firmware` path against an arbitrary image. Fresh boot confirmed each time via the uptime counter, not just port reappearance.

Three bugs surfaced only under live use and are fixed here — none would appear when flashing a healthy board:

- esptool 4.5.1 wants `--flash_mode`/`--flash_freq`/`--flash_size`; the hyphenated spellings are v5-only
- a one-shot port lookup reported "no board found" for a board that was merely mid-reset
- a single `bootloader` send could land before the console starts reading

## Known limitation

Firmware too wedged to service its console still needs BOOT+RESET. That is inherent to OTG mode — there is no hardware line into the chip while the app owns USB — and it is now reported clearly instead of hanging.

Not addressed: making the OTG console port survive a plain software restart. The Arduino core compiles its USB-persist support out (`usb_persist_enabled` is hard-coded false), so `RESTART_PERSIST` is a no-op; documented in the README rather than shipped as dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TsgJa1Hg1kUsfA5L1NtDw