### PR TITLE
App: stop re-zoning ride and log names — the device names them locall…

### DIFF
--- a/companion-ios/Sources/RidesView.swift
+++ b/companion-ios/Sources/RidesView.swift
@@ -123,14 +123,16 @@ struct RidesView: View {
         return h > 0 ? "\(h)h \(m % 60)m" : "\(m)m"
     }
 
-    // Filenames look like 20260712-150300.fit — the device names them in UTC
-    // (gmtime), so parse as UTC to get the correct absolute instant. Display
-    // then uses the phone's local time zone (Calendar.current / .formatted).
+    // Filenames look like 20260712-150300.fit — the device names them in the
+    // RIDER'S wall-clock time (its timezone setting), so the name already says
+    // what a human wants to read. Parse and display in the phone's own zone so
+    // no conversion happens and the shown time equals the name, verbatim.
+    // (Rides recorded before the local-naming firmware carry UTC names and
+    // will display those UTC digits as-is — a one-time historical quirk.)
     static func rideDate(_ name: String) -> Date? {
         let base = name.replacingOccurrences(of: ".fit", with: "")
         let f = DateFormatter()
         f.dateFormat = "yyyyMMdd-HHmmss"
-        f.timeZone = TimeZone(secondsFromGMT: 0)
         return f.date(from: base)
     }
 

--- a/companion-ios/Sources/SettingsView.swift
+++ b/companion-ios/Sources/SettingsView.swift
@@ -373,7 +373,11 @@ struct SettingsView: View {
         let base = name.replacingOccurrences(of: ".log", with: "")
         if base == "pending" || base == "diag" { return base == "diag" ? "Today" : "Before first GPS fix" }
         guard base.count == 8, let _ = Int(base) else { return name }
-        let f = DateFormatter(); f.dateFormat = "yyyyMMdd"; f.timeZone = TimeZone(secondsFromGMT: 0)
+        // The device names log files by the rider's LOCAL day now, so parse and
+        // format in one zone (the phone's) — the label must repeat the name's
+        // digits, not shift them. The old UTC parse re-interpreted the day and
+        // could label 20260819.log as "Aug 18".
+        let f = DateFormatter(); f.dateFormat = "yyyyMMdd"
         guard let d = f.date(from: base) else { return name }
         let out = DateFormatter(); out.dateFormat = "MMM d, yyyy"
         return out.string(from: d)


### PR DESCRIPTION
…y now

rideDate() parsed filenames as UTC and let display convert to the phone's zone, which was right when the device stamped names with gmtime. Now that names carry the rider's wall-clock time, that conversion double-shifted: parse and format in one zone instead, so the shown date/time repeats the name's digits verbatim. Same fix for the log-day label, which could call 20260819.log "Aug 18". The FIT preview header is untouched — timestamps inside the file are still true UTC and still display in the phone's zone. Rides recorded on older firmware keep UTC names and now display those digits as-is; one-time historical quirk, nothing migrated.


Claude-Session: https://claude.ai/code/session_01GfSJUqm5g8xefBmMNiJ3gK