### PR TITLE
Remember several paired sensors per kind

### DIFF
--- a/src/ble_sensors.cpp
+++ b/src/ble_sensors.cpp
@@ -308,8 +308,7 @@ class ScanCallbacks : public NimBLEScanCallbacks {
             // this kind. With nothing paired we never auto-adopt a device
             // (that used to grab strangers' sensors). Pairing happens on
             // the Sensors screen.
-            const char* saved = settings::sensorAddr(k);
-            if (!saved[0] || strcasecmp(saved, addr.c_str()) != 0) continue;
+            if (!settings::sensorPaired(k, addr.c_str())) continue;
             sensor.addr = dev->getAddress();
             sensor.found = true;
             std::string advName = dev->getName();
@@ -469,7 +468,7 @@ void task(void*) {
         // exist. Only paired kinds gate scanning; once they're up, scanning stops.
         bool allConnected = true;
         for (int k = 0; k < KIND_COUNT; ++k) {
-            bool paired = settings::sensorAddr(k)[0] != 0;
+            bool paired = settings::sensorAddrCount(k) > 0;
             if (paired && !sensors[k].connected) allConnected = false;
         }
 
@@ -658,7 +657,7 @@ int getCandidates(Candidate* out, int maxOut) {
                            candidates[i].addr) == 0) {
                 out[i].connected = true;
             }
-            if (strcasecmp(settings::sensorAddr(k), candidates[i].addr) == 0) {
+            if (settings::sensorPaired(k, candidates[i].addr)) {
                 out[i].paired = true;
             }
         }
@@ -674,9 +673,11 @@ int getCandidates(Candidate* out, int maxOut) {
     // persistent row for every paired kind whose address isn't already listed,
     // marking its live connection state. This keeps paired sensors visible
     // (connected or not) whether or not they're currently advertising.
-    for (int k = 0; k < KIND_COUNT && n < maxOut; ++k) {
-        const char* paddr = settings::sensorAddr(k);
-        if (!paddr || !paddr[0]) continue;
+    for (int k = 0; k < KIND_COUNT; ++k) {
+      for (int pi = 0; pi < settings::sensorAddrCount(k) && n < maxOut; ++pi) {
+        char paddr[18];
+        snprintf(paddr, sizeof(paddr), "%s", settings::sensorAddrAt(k, pi));
+        if (!paddr[0]) continue;
         bool already = false;
         for (int i = 0; i < n; ++i) {
             if (strcasecmp(out[i].addr, paddr) == 0) { already = true; break; }
@@ -685,24 +686,25 @@ int getCandidates(Candidate* out, int maxOut) {
         Candidate& c = out[n++];
         memset(&c, 0, sizeof(c));
         snprintf(c.addr, sizeof(c.addr), "%s", paddr);
-        // Live make (this session) > remembered name (NVS, survives reboot /
-        // shows before reconnect) > advertised name > generic kind label.
-        const char* nm = sensors[k].make[0]        ? sensors[k].make
-                       : settings::sensorName(k)[0] ? settings::sensorName(k)
-                       : sensors[k].advName[0]      ? sensors[k].advName
-                                                    : sensors[k].name;
+        const bool live = sensors[k].connected &&
+            strcasecmp(sensors[k].addr.toString().c_str(), paddr) == 0;
+        // Live make (this session) > remembered name (NVS — kept for the most
+        // recent pairing only) > advertised name > generic kind label.
+        const char* nm = live && sensors[k].make[0]      ? sensors[k].make
+                       : pi == 0 && settings::sensorName(k)[0]
+                                                        ? settings::sensorName(k)
+                       : live && sensors[k].advName[0]  ? sensors[k].advName
+                                                        : sensors[k].name;
         snprintf(c.name, sizeof(c.name), "%s", nm);
         c.kindsMask = (uint8_t)(1 << k);
         c.paired = true;
-        c.connected = sensors[k].connected &&
-                      strcasecmp(sensors[k].addr.toString().c_str(), paddr) == 0;
+        c.connected = live;
         c.rssi = 0;
         // Fold in any other kinds paired to the same address (e.g. power+cadence).
         for (int k2 = k + 1; k2 < KIND_COUNT; ++k2) {
-            if (strcasecmp(settings::sensorAddr(k2), paddr) == 0) {
-                c.kindsMask |= (uint8_t)(1 << k2);
-            }
+            if (settings::sensorPaired(k2, paddr)) c.kindsMask |= (uint8_t)(1 << k2);
         }
+      }
     }
     return n;
 }
@@ -722,10 +724,13 @@ void pairCandidate(const char* addr) {
 
     for (int k = 0; k < KIND_COUNT; ++k) {
         if (!(mask & (1 << k))) continue;
-        settings::setSensorAddr(k, addr);
+        // ADDS to the kind's paired set (most recent first) — pairing a
+        // trainer's simulated strap must not forget the real one, or the
+        // real one never comes back on the road.
+        settings::addSensorAddr(k, addr);
         // Remember the advertised name now; upgraded to the DIS make on connect.
         if (advName[0]) settings::setSensorName(k, advName);
-        // drop a different currently-connected device for this kind
+        // Switch to the newly paired device now if a different one is up.
         if (sensors[k].connected &&
             strcasecmp(sensors[k].addr.toString().c_str(), addr) != 0) {
             sensors[k].client->disconnect();
@@ -737,7 +742,7 @@ void pairCandidate(const char* addr) {
 
 void forgetAll() {
     for (int k = 0; k < KIND_COUNT; ++k) {
-        settings::setSensorAddr(k, "");
+        settings::clearSensorAddrs(k);
         if (sensors[k].connected) sensors[k].client->disconnect();
         sensors[k].found = false;
     }
@@ -747,8 +752,8 @@ void forgetAll() {
 void forget(const char* addr) {
     if (!addr || !addr[0]) return;
     for (int k = 0; k < KIND_COUNT; ++k) {
-        if (strcasecmp(settings::sensorAddr(k), addr) != 0) continue;
-        settings::setSensorAddr(k, "");
+        if (!settings::sensorPaired(k, addr)) continue;
+        settings::removeSensorAddr(k, addr);
         if (sensors[k].connected &&
             strcasecmp(sensors[k].addr.toString().c_str(), addr) == 0) {
             sensors[k].client->disconnect();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include <string.h>
 
 #include <Arduino.h>
 #include <Preferences.h>
@@ -24,7 +25,11 @@ bool showOff = false;
 // ride timer auto-pauses. 0 disables auto-pause entirely.
 int autoPause = 10;
 bool wkPauseStep = false;
-char addrs[3][18] = {"", "", ""};
+// Per kind, a ';'-separated list of paired addresses, most recent first (max
+// SENSOR_MAX_PAIRED). Stored under the same NVS key as the old single address,
+// which parses as a one-entry list — no migration.
+char addrs[3][settings::SENSOR_MAX_PAIRED * 18 + 4] = {"", "", ""};
+char addrScratch[3][18];   // sensorAddr()/sensorAddrAt() return into these
 char names[3][32] = {"", "", ""};   // remembered vendor/model per paired kind
 double lastLat = 0, lastLon = 0;
 bool rtcSynced = false;  // has GPS ever written UTC to the coin-cell RTC?
@@ -141,14 +146,89 @@ void setShowOffline(bool on) {
     prefs.putBool("showoff", showOff);
 }
 
-const char* sensorAddr(int kind) {
-    return (kind >= 0 && kind < 3) ? addrs[kind] : "";
+// Split addrs[kind] into up to SENSOR_MAX_PAIRED entries of `out`.
+static int splitAddrs(int kind, char out[][18]) {
+    int n = 0;
+    const char* p = addrs[kind];
+    while (*p && n < SENSOR_MAX_PAIRED) {
+        const char* e = strchr(p, ';');
+        size_t len = e ? (size_t)(e - p) : strlen(p);
+        if (len > 0 && len < 18) {
+            memcpy(out[n], p, len);
+            out[n][len] = 0;
+            ++n;
+        }
+        if (!e) break;
+        p = e + 1;
+    }
+    return n;
 }
 
-void setSensorAddr(int kind, const char* addr) {
-    if (kind < 0 || kind >= 3) return;
-    snprintf(addrs[kind], sizeof(addrs[kind]), "%s", addr ? addr : "");
+static void joinAddrs(int kind, char in[][18], int n) {
+    addrs[kind][0] = 0;
+    size_t used = 0;
+    for (int i = 0; i < n; ++i) {
+        used += snprintf(addrs[kind] + used, sizeof(addrs[kind]) - used, "%s%s",
+                         i ? ";" : "", in[i]);
+    }
     prefs.putString(KEYS[kind], addrs[kind]);
+}
+
+int sensorAddrCount(int kind) {
+    if (kind < 0 || kind >= 3) return 0;
+    char list[SENSOR_MAX_PAIRED][18];
+    return splitAddrs(kind, list);
+}
+
+const char* sensorAddrAt(int kind, int i) {
+    if (kind < 0 || kind >= 3) return "";
+    char list[SENSOR_MAX_PAIRED][18];
+    int n = splitAddrs(kind, list);
+    if (i < 0 || i >= n) return "";
+    snprintf(addrScratch[kind], sizeof(addrScratch[kind]), "%s", list[i]);
+    return addrScratch[kind];
+}
+
+const char* sensorAddr(int kind) { return sensorAddrAt(kind, 0); }
+
+bool sensorPaired(int kind, const char* addr) {
+    if (kind < 0 || kind >= 3 || !addr || !addr[0]) return false;
+    char list[SENSOR_MAX_PAIRED][18];
+    int n = splitAddrs(kind, list);
+    for (int i = 0; i < n; ++i)
+        if (strcasecmp(list[i], addr) == 0) return true;
+    return false;
+}
+
+void addSensorAddr(int kind, const char* addr) {
+    if (kind < 0 || kind >= 3 || !addr || !addr[0] || strlen(addr) >= 18) return;
+    char list[SENSOR_MAX_PAIRED][18];
+    int n = splitAddrs(kind, list);
+    // Move-to-front: the newest pairing is the first the scanner reports and
+    // the one the console/app calls "the" paired sensor.
+    char next[SENSOR_MAX_PAIRED][18];
+    int m = 0;
+    snprintf(next[m++], 18, "%s", addr);
+    for (int i = 0; i < n && m < SENSOR_MAX_PAIRED; ++i)
+        if (strcasecmp(list[i], addr) != 0) snprintf(next[m++], 18, "%s", list[i]);
+    joinAddrs(kind, next, m);
+}
+
+void removeSensorAddr(int kind, const char* addr) {
+    if (kind < 0 || kind >= 3 || !addr) return;
+    char list[SENSOR_MAX_PAIRED][18];
+    int n = splitAddrs(kind, list);
+    char next[SENSOR_MAX_PAIRED][18];
+    int m = 0;
+    for (int i = 0; i < n; ++i)
+        if (strcasecmp(list[i], addr) != 0) snprintf(next[m++], 18, "%s", list[i]);
+    joinAddrs(kind, next, m);
+}
+
+void clearSensorAddrs(int kind) {
+    if (kind < 0 || kind >= 3) return;
+    addrs[kind][0] = 0;
+    prefs.putString(KEYS[kind], "");
 }
 
 const char* sensorName(int kind) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -42,9 +42,19 @@ void setUsbDrive(bool on);
 bool showOffline();
 void setShowOffline(bool on);
 
-// kind: 0 HR, 1 Power, 2 Cadence (matches ble_sensors). "" = none saved.
+// kind: 0 HR, 1 Power, 2 Cadence (matches ble_sensors). Several sensors can be
+// paired per kind (a strap and a trainer's simulated strap, two bikes' power
+// meters): pairing ADDS, most recent first, up to SENSOR_MAX_PAIRED. The
+// scanner connects to whichever paired one is advertising. sensorAddr() is
+// the most recent — "" when none is saved.
+constexpr int SENSOR_MAX_PAIRED = 4;
 const char* sensorAddr(int kind);
-void setSensorAddr(int kind, const char* addr);
+int sensorAddrCount(int kind);
+const char* sensorAddrAt(int kind, int i);        // "" past the end
+bool sensorPaired(int kind, const char* addr);
+void addSensorAddr(int kind, const char* addr);  // dedupes; moves to front
+void removeSensorAddr(int kind, const char* addr);
+void clearSensorAddrs(int kind);
 
 // Remembered display name (vendor/model) per paired kind, so a paired sensor
 // shows its identity even before it reconnects and across reboots.

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1620,10 +1620,15 @@ static void printSensorReport() {
         Serial.printf("  %-8s %-17s %-13s %s\n", l.kind,
                       l.pairedAddr[0] ? l.pairedAddr : "(not paired)",
                       l.connected ? "CONNECTED" : "not connected", l.name);
+        // Further pairings of the same kind (a trainer's simulated strap, a
+        // second bike's meter) — the scanner takes whichever advertises.
+        for (int i = 1; i < settings::sensorAddrCount(k); ++i)
+            Serial.printf("  %-8s %-17s also paired\n", "",
+                          settings::sensorAddrAt(k, i));
         // A live link to an address we never saved cannot happen through the
         // scan path — if it ever prints, that IS the bug, so say so loudly
         // rather than folding it into the line above.
-        if (l.connected && strcasecmp(l.liveAddr, l.pairedAddr) != 0)
+        if (l.connected && !settings::sensorPaired(k, l.liveAddr))
             Serial.printf("  %-8s ** live link is %s, NOT the saved address **\n",
                           "", l.liveAddr);
     }


### PR DESCRIPTION
## Summary
- Pairing stored one address per sensor kind, so pairing the sensor-sim's HR strap / power meter silently unpaired the real Magene and Assioma; the scanner only connects to saved addresses, so they never came back on the road.
- Each kind now keeps up to four paired addresses (most recent first) under the same NVS keys — an old single address parses as a one-entry list, no migration.
- Pair adds (move-to-front), forget removes one address, the scanner connects to whichever paired sensor is advertising; console `sensors` lists all pairings.

## Test plan
- [ ] Pair real HR + power, then pair the simulator; `sensors` shows both as paired for each kind
- [ ] Power the sim off: real sensors reconnect on the next hunt without re-pairing
- [ ] `forget <sim mac>` removes only the sim; `forget all` clears everything
- [ ] Devices with existing single pairings boot with them intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoqKkeLvXmSTVKh6q6aX1J