### PR TITLE
Apple Find My beacon (OpenHaystack) on the head unit

### DIFF
--- a/src/ble_server.cpp
+++ b/src/ble_server.cpp
@@ -6,6 +6,7 @@
 #include <Update.h>
 #include <esp_heap_caps.h>
 #include <esp_ota_ops.h>
+#include <mbedtls/base64.h>
 
 #include "config.h"
 #include "ride_state.h"
@@ -832,6 +833,85 @@ namespace ble_server {
 void otaAbortIfDownloading();
 void mapAbortReceive();
 
+// --- Apple Find My beacon (OpenHaystack) ------------------------------------
+// The head unit broadcasts Apple's offline-finding advertisement for a public
+// key the rider generated in OpenHaystack; any iPhone that hears it relays an
+// encrypted location to Apple, and the OpenHaystack tools on the rider's Mac
+// decrypt it. The format is public (Heinrich et al., 2021) and this is the
+// same payload OpenHaystack's own ESP32 firmware sends:
+//   address  : random static, bytes = key[0]|0xC0, key[1..5]
+//   ADV data : 1E FF 4C 00 12 19 <status> key[6..27] (key[0]>>6) 00
+// The beacon needs its OWN address, and this NimBLE build has no extended
+// advertising (one advertiser), so it time-shares with the GATT advertising:
+// ~0.8 s of beacon every ~3 s. iPhones scan continuously and catch it within
+// seconds; the app's discovery survives the gaps (it scans by service UUID
+// until it sees us). While the phone is connected, GATT advertising is off
+// anyway and the beacon runs in its slot alone. Only while the device is ON —
+// deep-sleep power-off silences BLE entirely.
+namespace findmy {
+uint8_t key[28];
+bool keyValid = false;
+bool beaconing = false;
+uint32_t phaseUntilMs = 0;
+constexpr uint32_t BEACON_MS = 800, GAP_MS = 2200;
+
+// Re-read the settings (boot, and after the console changes the key).
+void refresh() {
+    keyValid = false;
+    const char* b64 = settings::findMyKey();
+    if (!b64[0]) return;
+    size_t olen = 0;
+    if (mbedtls_base64_decode(key, sizeof(key), &olen, (const uint8_t*)b64,
+                              strlen(b64)) == 0 && olen == 28)
+        keyValid = true;
+    else
+        diag::log("findmy: key is not 28 base64 bytes — beacon off");
+}
+
+bool active() { return keyValid && settings::findMyEnabled(); }
+}  // namespace findmy
+
+// (Re)start ordinary GATT advertising: public address, connectable, service
+// UUID + name in the scan response. Also what the beacon hands back to.
+void startGattAdvertising() {
+    NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
+    if (!adv) return;
+    if (adv->isAdvertising()) adv->stop();
+    adv->reset();
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+    adv->setConnectableMode(BLE_GAP_CONN_MODE_UND);
+    adv->addServiceUUID(SVC_UUID);
+    adv->setName("OpenTrailPaper");
+    adv->enableScanResponse(true);
+    adv->start();
+}
+
+bool startFindMyBeacon() {
+    NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
+    if (!adv) return false;
+    if (adv->isAdvertising()) adv->stop();
+    // NimBLE addresses are little-endian: val[5] is the first byte on air.
+    uint8_t val[6] = {findmy::key[5], findmy::key[4], findmy::key[3],
+                      findmy::key[2], findmy::key[1],
+                      (uint8_t)(findmy::key[0] | 0xC0)};
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM);
+    NimBLEDevice::setOwnAddr(NimBLEAddress(val, BLE_ADDR_RANDOM));
+    uint8_t mfg[29];
+    mfg[0] = 0x4C; mfg[1] = 0x00;         // Apple
+    mfg[2] = 0x12; mfg[3] = 0x19;         // offline finding, length
+    mfg[4] = 0x00;                        // status (battery full)
+    memcpy(mfg + 5, findmy::key + 6, 22);
+    mfg[27] = findmy::key[0] >> 6;
+    mfg[28] = 0x00;                       // hint
+    adv->reset();
+    NimBLEAdvertisementData data;
+    data.setManufacturerData(std::string((const char*)mfg, sizeof(mfg)));
+    adv->setAdvertisementData(data);
+    adv->enableScanResponse(false);
+    adv->setConnectableMode(BLE_GAP_CONN_MODE_NON);
+    return adv->start();
+}
+
 // Stale-bond loop detector. When the PHONE holds pairing keys we no longer
 // match, iOS auto-reconnects, fails encryption, and drops the link within
 // seconds — forever, and nothing device-side can delete the phone's keys.
@@ -1058,8 +1138,10 @@ class ServerCb : public NimBLEServerCallbacks {
             ble_sensors::setScanAlways(false);
         }
         // Advertising stops once a central connects; restart it so the phone
-        // can find and reconnect to the device after disconnecting.
-        NimBLEDevice::startAdvertising();
+        // can find and reconnect to the device after disconnecting. If the
+        // Find My beacon owns the advertiser this instant, its slot end
+        // restores GATT advertising instead.
+        if (!findmy::beaconing) startGattAdvertising();
     }
 };
 
@@ -1943,16 +2025,17 @@ void begin() {
 
     svc->start();
 
-    NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
-    adv->addServiceUUID(SVC_UUID);
-    adv->setName("OpenTrailPaper");
-    adv->enableScanResponse(true);
-    NimBLEDevice::startAdvertising();
+    startGattAdvertising();
+    findmy::refresh();
+    if (findmy::active()) diag::log("findmy: beacon on");
 
     Serial.println("[srv] GATT server advertising as OpenTrailPaper");
 }
 
 void pushSettingsToPhone() { settingsDirty = true; }
+
+void findMyRefresh() { findmy::refresh(); }
+bool findMyBeaconing() { return findmy::active(); }
 
 bool isPhoneConnected() { return phoneConnected; }
 bool linkRelaxed() { return linkIntervalLong; }
@@ -2163,6 +2246,30 @@ void task(void*) {
             serviceMeshRequests();
         }
 
+        // Find My beacon time-share (see namespace findmy). Held off during
+        // transfers: an OTA or map upload must keep the link's full attention.
+        if (findmy::active() && otaPhase == 0 && mapBufLen == 0 && !mapCommitPending) {
+            const uint32_t now = millis();
+            if (!findmy::beaconing && now >= findmy::phaseUntilMs) {
+                findmy::beaconing = startFindMyBeacon();
+                findmy::phaseUntilMs = now + (findmy::beaconing
+                                                  ? findmy::BEACON_MS
+                                                  : findmy::GAP_MS);
+            } else if (findmy::beaconing && now >= findmy::phaseUntilMs) {
+                findmy::beaconing = false;
+                NimBLEDevice::getAdvertising()->stop();
+                NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+                if (!phoneConnected) startGattAdvertising();
+                findmy::phaseUntilMs = now + findmy::GAP_MS;
+            }
+        } else if (findmy::beaconing) {
+            // Switched off (or a transfer began) mid-slot: hand back now.
+            findmy::beaconing = false;
+            NimBLEDevice::getAdvertising()->stop();
+            NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+            if (!phoneConnected) startGattAdvertising();
+        }
+
         vTaskDelay(pdMS_TO_TICKS(100));
         if (!statusChr || millis() - lastStatus < 1000) continue;
         lastStatus = millis();
@@ -2180,9 +2287,9 @@ void task(void*) {
 
         // Safety net: make sure we're discoverable whenever no phone is
         // connected, in case a disconnect ever slips past onDisconnect.
-        if (!phoneConnected) {
+        if (!phoneConnected && !findmy::beaconing) {
             NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
-            if (adv && !adv->isAdvertising()) NimBLEDevice::startAdvertising();
+            if (adv && !adv->isAdvertising()) startGattAdvertising();
         }
 
         RideState s = g_state.snapshot();

--- a/src/ble_server.h
+++ b/src/ble_server.h
@@ -19,6 +19,11 @@ void task(void* arg);
 // Mirror a device-side settings edit (FTP/tz/units/backlight) to the phone.
 void pushSettingsToPhone();
 
+// Apple Find My beacon (OpenHaystack): re-read the key/enable settings, and
+// whether a valid key is currently being broadcast.
+void findMyRefresh();
+bool findMyBeaconing();
+
 // True while a phone (the companion app) is connected — used to hold off
 // auto-sleep during transfers.
 bool isPhoneConnected();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -33,6 +33,8 @@ bool rtcSynced = false;  // has GPS ever written UTC to the coin-cell RTC?
 // happen because a firmware update landed — it is a choice, so the device waits to
 // be asked. The Mesh tab has the switch.
 bool meshOn = false;
+char fmKey[48] = "";
+bool fmOn = false;
 // "" = no explicit channel; mesh_service derives the name from the modem preset.
 char meshChan[16] = "";
 uint8_t meshKey = 1;
@@ -74,6 +76,8 @@ void begin() {
     lastLon = prefs.getDouble("lastlon", 0);
     rtcSynced = prefs.getBool("rtcok", false);
     meshOn = prefs.getBool("meshon", false);
+    prefs.getString("fmkey", fmKey, sizeof(fmKey));
+    fmOn = prefs.getBool("fmon", false);
     prefs.getString("meshchan", meshChan, sizeof(meshChan));   // "" = use the preset
     meshKey = (uint8_t)constrain(prefs.getUChar("meshkey", 1), 1, 10);
     meshPresetIdx = prefs.getUChar("meshpreset", MESH_PRESET_DEFAULT);
@@ -182,6 +186,17 @@ void setCompassOffsetDeg(float deg) {
     // when the learned offset has actually drifted a few degrees.
     compassOff = deg;
     prefs.putFloat("cmpoff", deg);
+}
+
+const char* findMyKey() { return fmKey; }
+void setFindMyKey(const char* b64) {
+    snprintf(fmKey, sizeof(fmKey), "%s", b64 ? b64 : "");
+    prefs.putString("fmkey", fmKey);
+}
+bool findMyEnabled() { return fmOn; }
+void setFindMyEnabled(bool on) {
+    fmOn = on;
+    prefs.putBool("fmon", on);
 }
 
 bool meshEnabled() { return meshOn; }

--- a/src/settings.h
+++ b/src/settings.h
@@ -51,6 +51,13 @@ void setSensorAddr(int kind, const char* addr);
 const char* sensorName(int kind);
 void setSensorName(int kind, const char* name);
 
+// Apple Find My (OpenHaystack-style) beacon: the 28-byte public key as
+// base64, and whether the head unit should broadcast it. "" = no key.
+const char* findMyKey();
+void setFindMyKey(const char* b64);
+bool findMyEnabled();
+void setFindMyEnabled(bool on);
+
 // Last known GPS position (map center across reboots). Returns false if
 // no position has ever been saved.
 bool lastPosition(double& lat, double& lon);

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1686,6 +1686,7 @@ static void printConsoleHelp() {
     Serial.println("  mesh <on|off>        power the LoRa radio");
     Serial.println("  autopause [sec|off]  ride timer pause after N s stopped (0/off disables)");
     Serial.println("  workout <list|load <f>|start|pause|resume|stop|skip|back|goto <n>|ftp [W]>");
+    Serial.println("  findmy [key <b64>|on|off]   Apple Find My beacon (OpenHaystack key)");
     Serial.println("  sleepexp [on|off]    re-arm the light-sleep-with-phone experiment (this boot)");
     Serial.println("  disconnect <kind>    drop the link (hr|power|cadence|all); stays paired");
     Serial.println("  forget <kind|mac>    unpair and drop (hr|power|cadence|all|aa:bb:..)");
@@ -2051,6 +2052,23 @@ static void runConsoleLine(char* line) {
                               (unsigned long)v.totalSec);
             }
         }
+    } else if (!strcasecmp(cmd, "findmy")) {
+        // findmy                  status
+        // findmy key <base64>     28-byte OpenHaystack public key
+        // findmy on|off           broadcast it (needs a key)
+        if (arg && !strcasecmp(arg, "key")) {
+            char* k = strtok(nullptr, " \t");
+            if (!k) { Serial.println("[findmy] key <base64 public key>"); return; }
+            settings::setFindMyKey(k);
+            ble_server::findMyRefresh();
+        } else if (arg && (!strcasecmp(arg, "on") || !strcasecmp(arg, "off"))) {
+            settings::setFindMyEnabled(!strcasecmp(arg, "on"));
+            ble_server::findMyRefresh();
+        }
+        Serial.printf("[findmy] key %s, %s -> beacon %s\n",
+                      settings::findMyKey()[0] ? "set" : "NOT set",
+                      settings::findMyEnabled() ? "enabled" : "disabled",
+                      ble_server::findMyBeaconing() ? "BROADCASTING" : "off");
     } else if (!strcasecmp(cmd, "reboot")) {
         Serial.println("[cmd] rebooting");
         Serial.flush(); delay(80); esp_restart();


### PR DESCRIPTION
## Summary
- Broadcast Apple's offline-finding (Find My network) advertisement for an OpenHaystack public key: passing iPhones relay the device's encrypted location to Apple; the rider decrypts it with the OpenHaystack tools on a Mac. Not the Find My *app* — Apple restricts that to MFi accessories.
- Payload + key-derived random static address match OpenHaystack's reference ESP32 firmware.
- One legacy advertiser, no ext-adv in this NimBLE build, so the beacon time-shares with GATT advertising (0.8 s beacon / 3 s cycle), paused during OTA/map transfers; watchdog + onDisconnect defer to the beacon slot.
- Settings: `fmkey` (base64 28-byte key) + `fmon`. Console: `findmy key <b64>`, `findmy on|off`, `findmy`.

## Setup
1. Generate a key in OpenHaystack (macOS) — copy the accessory's *public key* (base64, 28 bytes).
2. Console: `findmy key <base64>` then `findmy on`.
3. Location appears in OpenHaystack after an iPhone has been near the device.

## Test plan
- [ ] `findmy` reports BROADCASTING with a valid key; rejects a malformed key
- [ ] App still discovers/connects/reconnects with the beacon on (gaps ≤ 3 s)
- [ ] OTA and map upload run uninterrupted with the beacon enabled
- [ ] OpenHaystack shows a location within ~10 min near an iPhone
- [ ] Beacon survives light sleep; stops when the device powers off (expected)

## Follow-ups
- App: settings field to paste the key (console-only for now)
- Consider holding the device in light sleep instead of auto-off when Find My is on, so a parked bike keeps beaconing (battery trade-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoqKkeLvXmSTVKh6q6aX1J