### PR TITLE
Turn the vector fonts on for device builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -124,6 +124,9 @@ lib_deps =
     https://github.com/tonywestonuk/EPD_Painter.git
 build_unflags = -std=gnu++11
 build_flags =
+    ; Vector fonts (Anton values / Arimo labels) instead of the bitmap
+    ; Impact/Arial tables — same faces at the same heights, ~950 KB less flash.
+    -DVFONT
     -std=gnu++17
     -I vendor/T5S3-4.7-e-paper-PRO/lib/epdiy/src
     -DBOARD_HAS_PSRAM


### PR DESCRIPTION
-DVFONT in the t5s3-painter env: Anton values / Arimo labels rasterised on device (see #63) instead of the bitmap Impact/Arial tables, which the linker now drops — ~950 KB less flash. Same faces at the same ladder heights.