### PR TITLE
Android: import GPX routes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,12 @@ jobs:
       # Wrapper + dependency caching, keyed on the lockable Gradle inputs.
       - uses: gradle/actions/setup-gradle@v4
 
+      # The format tests are the only thing standing between a wrong byte order
+      # and a route that transfers cleanly then draws the wrong line. Cheap
+      # enough (~10s) to gate every push.
+      - name: Unit tests
+        run: ./gradlew --no-daemon testDebugUnitTest
+
       # The runner image ships the Android SDK at $ANDROID_HOME, so there is
       # no local.properties step. Debug only: it proves the app compiles (the
       # same bar as the iOS job) and needs no signing — keystore.properties

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ companion-android/build/
 companion-android/app/build/
 companion-android/app/.cxx/
 companion-android/.gradle/
+# Kotlin compile-daemon scratch (sessions, error logs), recreated by every build.
+companion-android/.kotlin/
 companion-android/local.properties
 companion-android/.idea/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ released version into the GitHub release body (see .github/workflows/build.yml),
 and the app shows it under Settings → Firmware when an update is available —
 so write for the rider, newest version first, one `## vX.YY` heading each.
 
+## Unreleased
+
+- Android: import a `.gpx` route — pick one in the app or open it from Files,
+  Komoot or Strava. The route is previewed, sent to the head unit exactly as it
+  came, and can optionally be given turn cues derived from OSRM.
+- Android: route names and turn cues are now trimmed to the firmware's byte
+  budgets on codepoint boundaries, so a long non-ASCII street name can no longer
+  put a half character on the panel.
+
 ## v1.17
 
 - If the device resets or runs out of battery mid-ride, the next boot asks

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ remaining), framed **route**, **map-tile**, **log** and **OTA** transfers, and a
   optional track-up rotation. See [Map tiles](#map-tiles).
 - **Map-cached elevation** — altitude and climb come from a DEM grid baked into
   each map tile, not the GPS chip's noisy barometric/ellipsoidal altitude.
-- **GPX routes** — plan on the phone or drop `.gpx` in `/routes`; pick one under
+- **GPX routes** — plan on the phone, import a `.gpx` (Android: file picker or
+  opening one from another app) or drop `.gpx` in `/routes`; pick one under
   Navigate. Route draws on the map (ridden solid / ahead dashed) with
   km-remaining in the footer and optional turn banners.
 - **On-device settings** — units (mi/km), 12/24 h clock, FTP (power zone bar),

--- a/companion-android/README.md
+++ b/companion-android/README.md
@@ -2,19 +2,23 @@
 
 Jetpack Compose app that pairs with the OpenTrailPaper device over BLE to control
 settings, push routes (searched on the phone or imported from a `.gpx`) and
-build offline maps. Feature-for-feature with [`companion-ios`](../companion-ios),
-against the same firmware and the same `.ebm` tile format.
+build offline maps. Feature-for-feature with [`companion-ios`](../companion-ios)
+on device control and maps, against the same firmware and the same `.ebm` tile
+format.
 
 ## What it does
 
 - **Ride** — live device status over BLE: connection, speed, battery, heart rate,
   power, GPS lock, and active-route distance remaining. The dashboard card opens
   the layout editor.
-- **Route** — search a destination, build a cycling route, preview it, and send it
-  to the head unit. The route is exported as GPX and streamed over BLE; the device
-  saves it to `/routes` (and rides it even without an SD card). Turn cues go with
-  it. Hexagons appear over any part of the route neither the phone nor the device
-  has map coverage for.
+- **Route** — search a destination and build a cycling route, or import a `.gpx`
+  (file picker, or opened from another app); preview it and send it to the head
+  unit. The route is exported as GPX and streamed over BLE; the device saves it
+  to `/routes` (and rides it even without an SD card). A searched route comes
+  with turn cues built in; an imported route draws, tracks progress and reports
+  remaining distance without them, unless turn cues are added afterward (derived
+  from OSRM). Hexagons appear over any part of the route neither the phone nor
+  the device has map coverage for.
 - **Rides** — lists recorded `.fit` files, downloads them over BLE, decodes them
   (distance, moving time, power, normalized power, HR, DEM ascent) and shows the
   track on a map. Downloaded rides stay cached for offline viewing and can be

--- a/companion-android/README.md
+++ b/companion-android/README.md
@@ -1,9 +1,9 @@
 # OpenTrailPaper — Android Companion App
 
 Jetpack Compose app that pairs with the OpenTrailPaper device over BLE to control
-settings, push routes and build offline maps. Feature-for-feature with
-[`companion-ios`](../companion-ios), against the same firmware and the same
-`.ebm` tile format.
+settings, push routes (searched on the phone or imported from a `.gpx`) and
+build offline maps. Feature-for-feature with [`companion-ios`](../companion-ios),
+against the same firmware and the same `.ebm` tile format.
 
 ## What it does
 

--- a/companion-android/app/src/main/AndroidManifest.xml
+++ b/companion-android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:label="@string/app_name"
             android:theme="@style/Theme.OpenTrailPaper"
@@ -68,6 +69,38 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Opening a .gpx from Files, mail, Komoot or Strava.
+                 Deliberately narrow: GPX is served as gpx+xml, octet-stream,
+                 text/xml or nothing depending on the provider, and matching
+                 all of those outright would put this app in the chooser for
+                 every XML and every binary on the phone. The exact type is
+                 matched directly; the generic ones only with a .gpx path. What
+                 actually decides is the file's first bytes, in RouteImport. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:mimeType="application/gpx+xml" />
+                <data android:scheme="file" android:mimeType="application/gpx+xml" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:scheme="content"
+                    android:mimeType="application/octet-stream"
+                    android:pathPattern=".*\\.gpx" />
+                <data
+                    android:scheme="file"
+                    android:mimeType="application/octet-stream"
+                    android:pathPattern=".*\\.gpx" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/gpx+xml" />
             </intent-filter>
         </activity>
 

--- a/companion-android/app/src/main/AndroidManifest.xml
+++ b/companion-android/app/src/main/AndroidManifest.xml
@@ -72,12 +72,22 @@
             </intent-filter>
 
             <!-- Opening a .gpx from Files, mail, Komoot or Strava.
-                 Deliberately narrow: GPX is served as gpx+xml, octet-stream,
-                 text/xml or nothing depending on the provider, and matching
-                 all of those outright would put this app in the chooser for
-                 every XML and every binary on the phone. The exact type is
-                 matched directly; the generic ones only with a .gpx path. What
-                 actually decides is the file's first bytes, in RouteImport. -->
+
+                 GPX is served as gpx+xml, octet-stream, text/xml or nothing at
+                 all depending on the provider, so the exact type alone is not
+                 enough: on a real device 7 of 8 .gpx files came back as
+                 application/octet-stream, and only a Suunto export as
+                 application/gpx+xml. Hence the second filter.
+
+                 The pathPattern on it does NOT narrow anything. Android ignores
+                 path matching once an intent carries a MIME type, so that filter
+                 is in practice "any octet-stream file" and this app is offered
+                 for .bin and .jpg too — verified with `cmd package
+                 query-activities`. The pattern is kept only for the type-less
+                 case. What actually decides is the file's first bytes, in
+                 RouteImport, which rejects a non-GPX with a readable message.
+                 Dropping the filter would trade that chooser noise for losing
+                 open-with on almost every real .gpx. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/BleManager.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/BleManager.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
 import com.raemond.opentrailpaper.data.DashConfig
 import com.raemond.opentrailpaper.data.DashLayout
+import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.FirmwareRelease
 import com.raemond.opentrailpaper.data.Prefs
 import kotlinx.coroutines.CoroutineScope
@@ -1393,7 +1394,10 @@ class BleManager(private val app: Application) {
             p.u8(0x04)
             p.i32((m.lat * 1e7).roundToLong().toInt())
             p.i32((m.lon * 1e7).roundToLong().toInt())
-            val text = m.text.toByteArray(Charsets.UTF_8)
+            // Trimmed to the device's own maneuver buffer (routes.h
+            // MANEUVER_TEXT), on a codepoint boundary — the firmware's snprintf
+            // would otherwise cut a two-byte character in half.
+            val text = DeviceText.maneuverText(m.text).toByteArray(Charsets.UTF_8)
             p.raw(text.copyOf(min(text.size, maxLen - 8)))
             packets += p.bytes()
         }

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/DeviceText.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/DeviceText.kt
@@ -1,0 +1,71 @@
+package com.raemond.opentrailpaper.data
+
+import java.text.Normalizer
+import java.util.Locale
+
+/**
+ * Fitting strings into the firmware's fixed `char[]` buffers.
+ *
+ * Both budgets here are byte budgets, not character budgets, and that is the
+ * whole point. The device copies cue text with `snprintf` into a `char[48]`
+ * (routes.h MANEUVER_TEXT) and route names into a `char[32]` (MAX_NAME); both
+ * cut at a byte count with no idea that "Ł" takes two of them. Truncating on
+ * this side, on codepoint boundaries, is what stops a half-character reaching a
+ * panel that then draws a replacement glyph — or nothing.
+ */
+object DeviceText {
+
+    /** routes.h MANEUVER_TEXT is 48; one byte belongs to the NUL. */
+    const val MANEUVER_BUDGET = 47
+
+    /** routes.h MAX_NAME is 32, less the NUL, less ".gpx". */
+    private const val NAME_BUDGET = 31 - 4
+
+    /**
+     * A route filename the device can hold and an SD card can store.
+     *
+     * Accents are folded rather than stripped: `Char.isLetterOrDigit()` is
+     * Unicode-aware, so filtering alone would keep "ś" and quietly spend two of
+     * the 31 bytes on it — and leave a FAT filesystem holding a name it may not
+     * round-trip.
+     */
+    fun routeFileName(title: String?): String {
+        val folded = Normalizer.normalize(title ?: "", Normalizer.Form.NFD)
+            .replace(Regex("\\p{Mn}+"), "")
+            .lowercase(Locale.US)
+        val safe = buildString {
+            for (c in folded) {
+                if (c in 'a'..'z' || c in '0'..'9') append(c)
+                else if (isNotEmpty() && last() != '_') append('_')
+            }
+        }.trim('_')
+        val base = safe.take(NAME_BUDGET).trim('_').ifEmpty { "route" }
+        return "$base.gpx"
+    }
+
+    /** A turn cue trimmed to what the device's maneuver buffer will hold. */
+    fun maneuverText(text: String): String = fitUtf8(text, MANEUVER_BUDGET)
+
+    /**
+     * The longest prefix of [text] that encodes to at most [maxBytes] of UTF-8,
+     * cut at a space where one is close to the end so a road name is shortened
+     * rather than a word left in pieces.
+     */
+    fun fitUtf8(text: String, maxBytes: Int): String {
+        if (text.toByteArray(Charsets.UTF_8).size <= maxBytes) return text
+
+        var end = 0
+        var used = 0
+        while (end < text.length) {
+            val cp = text.codePointAt(end)
+            val width = String(Character.toChars(cp)).toByteArray(Charsets.UTF_8).size
+            if (used + width > maxBytes) break
+            used += width
+            end += Character.charCount(cp)
+        }
+        val cut = text.substring(0, end)
+        // Only honour a word boundary that isn't throwing most of the cue away.
+        val space = cut.lastIndexOf(' ')
+        return (if (space > cut.length / 2) cut.substring(0, space) else cut).trimEnd()
+    }
+}

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/GpxImporter.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/GpxImporter.kt
@@ -1,10 +1,13 @@
 package com.raemond.opentrailpaper.data
 
 import org.xml.sax.Attributes
+import org.xml.sax.InputSource
 import org.xml.sax.SAXNotRecognizedException
 import org.xml.sax.SAXNotSupportedException
 import org.xml.sax.helpers.DefaultHandler
 import java.io.InputStream
+import java.io.StringReader
+import javax.xml.XMLConstants
 import javax.xml.parsers.SAXParserFactory
 import kotlin.math.ceil
 
@@ -64,13 +67,22 @@ object GpxImporter {
         try {
             val factory = SAXParserFactory.newInstance().apply {
                 isNamespaceAware = false
-                // A GPX is data, not a document that gets to name external files.
-                // This is a Xerces feature name; Android's SAX (Expat-based) doesn't
-                // recognise it and throws SAXNotRecognizedException, so it must not
-                // share the outer try — that would report every real-device parse
-                // as NotGpx while the JVM tests (which use a Xerces parser) stayed
-                // green.
+                // A GPX is data, not a document that gets to name external
+                // files, nor to expand one entity into gigabytes of text.
+                // Neither may share the outer try: the second is a Xerces
+                // feature name, Android's SAX (Expat-based) doesn't recognise it
+                // and throws SAXNotRecognizedException, which would report every
+                // real-device parse as NotGpx while the JVM tests (which use a
+                // Xerces parser) stayed green. Secure processing is asked for
+                // first for that same reason — it is the standard name, and a
+                // throw on the Xerces one must not cost us a parser that would
+                // have honoured it.
+                //
+                // Which is why neither is the fence that actually holds against
+                // external entities: [Handler.resolveEntity] is, needing no
+                // feature support from either parser.
                 try {
+                    setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
                     setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
                 } catch (_: SAXNotRecognizedException) {
                 } catch (_: SAXNotSupportedException) {
@@ -79,8 +91,7 @@ object GpxImporter {
             factory.newSAXParser().parse(input, handler)
         } catch (_: Exception) {
             // A truncated file that already yielded a usable track is still a
-            // route; anything else is not GPX as far as the rider is concerned.
-            if (!handler.sawGpx) return ImportResult.NotGpx
+            // route; anything else the check below rejects as not GPX.
         }
         if (!handler.sawGpx) return ImportResult.NotGpx
 
@@ -133,6 +144,19 @@ object GpxImporter {
         private var text: StringBuilder? = null
 
         private fun parent() = stack.getOrNull(stack.size - 2)
+
+        /**
+         * Refuses every external entity, on whichever parser we were handed.
+         *
+         * The factory features above are advisory — one of them is a Xerces
+         * name the device's parser throws on — so the guarantee lives here
+         * instead, in plain SAX that both parsers honour: a file naming
+         * file:///etc/passwd gets an empty string back, not the file. This
+         * input arrives from any app on the phone through the VIEW/SEND
+         * filters, so it cannot rest on a feature the target platform ignores.
+         */
+        override fun resolveEntity(publicId: String?, systemId: String?): InputSource =
+            InputSource(StringReader(""))
 
         override fun startElement(uri: String?, l: String?, qName: String, a: Attributes?) {
             val name = qName.substringAfter(':').lowercase()

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/GpxImporter.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/GpxImporter.kt
@@ -1,0 +1,178 @@
+package com.raemond.opentrailpaper.data
+
+import org.xml.sax.Attributes
+import org.xml.sax.SAXNotRecognizedException
+import org.xml.sax.SAXNotSupportedException
+import org.xml.sax.helpers.DefaultHandler
+import java.io.InputStream
+import javax.xml.parsers.SAXParserFactory
+import kotlin.math.ceil
+
+/** A route read out of somebody else's .gpx: geometry, a name, what it was planned for. */
+data class ImportedRoute(
+    val name: String,
+    val points: List<LatLon>,
+    /** The raw `<type>`, e.g. "racebike" or "cycling"; null when the file omits it. */
+    val activityType: String?,
+) {
+    val distanceMeters: Double
+        get() = (1 until points.size).sumOf { points[it - 1].distanceTo(points[it]) }
+
+    /** Feeds the badge the summary card already draws. Blank when the file doesn't say. */
+    val mode: String
+        get() = when (activityType?.lowercase()) {
+            "racebike", "cycling", "bike", "mtb", "touringbicycle", "gravel_bike",
+            "mountainbike", "e_bike",
+            -> "Cycling"
+            else -> ""
+        }
+}
+
+sealed interface ImportResult {
+    data class Ok(val route: ImportedRoute) : ImportResult
+
+    /** Not XML, or XML that isn't GPX. The MIME type lied. */
+    data object NotGpx : ImportResult
+
+    /** GPX, but with nothing in it that describes a path. */
+    data object NoPoints : ImportResult
+}
+
+/**
+ * Reads a GPX route into plain coordinates.
+ *
+ * The counterpart to [GpxExporter], and deliberately not a pass-through: the
+ * firmware's scanner pairs any `lat="`/`lon="` it finds regardless of tag
+ * (routes.cpp:319), so a file whose waypoints precede its track would have them
+ * dragged into the polyline. Parsing here and re-emitting through [GpxExporter]
+ * is what keeps that from happening — and drops `<ele>`/`<time>` on the way,
+ * which is most of the file.
+ *
+ * SAX rather than [android.util.Xml] so this stays testable on the JVM, the same
+ * reason the Overpass decoder uses Gson.
+ */
+object GpxImporter {
+
+    /** The firmware's own cap (routes.cpp MAX_PTS). Decimating here saves BLE time. */
+    const val MAX_POINTS = 4096
+
+    /** Above this we stop collecting: a pathological file must not exhaust memory. */
+    private const val HARD_LIMIT = 200_000
+
+    fun parse(input: InputStream, fallbackName: String): ImportResult {
+        val handler = Handler()
+        try {
+            val factory = SAXParserFactory.newInstance().apply {
+                isNamespaceAware = false
+                // A GPX is data, not a document that gets to name external files.
+                // This is a Xerces feature name; Android's SAX (Expat-based) doesn't
+                // recognise it and throws SAXNotRecognizedException, so it must not
+                // share the outer try — that would report every real-device parse
+                // as NotGpx while the JVM tests (which use a Xerces parser) stayed
+                // green.
+                try {
+                    setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+                } catch (_: SAXNotRecognizedException) {
+                } catch (_: SAXNotSupportedException) {
+                }
+            }
+            factory.newSAXParser().parse(input, handler)
+        } catch (_: Exception) {
+            // A truncated file that already yielded a usable track is still a
+            // route; anything else is not GPX as far as the rider is concerned.
+            if (!handler.sawGpx) return ImportResult.NotGpx
+        }
+        if (!handler.sawGpx) return ImportResult.NotGpx
+
+        val points = handler.trackPoints.ifEmpty { handler.routePoints }
+        if (points.size < 2) return ImportResult.NoPoints
+
+        return ImportResult.Ok(
+            ImportedRoute(
+                name = (handler.trackName ?: handler.metadataName ?: fallbackName).trim()
+                    .ifEmpty { fallbackName },
+                points = decimate(points, MAX_POINTS),
+                activityType = handler.activityType?.trim()?.ifEmpty { null },
+            ),
+        )
+    }
+
+    /**
+     * Every stride-th point, last one always kept.
+     *
+     * The same shape as the firmware's own halving (routes.cpp GpxScanner), done
+     * here so a 10,000-point export doesn't spend minutes on the air only to be
+     * thinned on arrival.
+     */
+    internal fun decimate(points: List<LatLon>, cap: Int): List<LatLon> {
+        if (points.size <= cap) return points
+        val stride = ceil(points.size.toDouble() / cap).toInt()
+        val out = ArrayList<LatLon>(cap + 1)
+        for (i in points.indices step stride) out.add(points[i])
+        if (out.last() !== points.last()) out.add(points.last())
+        return out
+    }
+
+    /**
+     * Element names are matched against their parent, never on their own.
+     *
+     * `<name>` and `<type>` both appear inside `<author>` — Komoot writes
+     * `<type>text/html</type>` for its own link, Strava writes the athlete in
+     * `<metadata><author><name>`. Taking the first of either yields the author,
+     * not the route.
+     */
+    private class Handler : DefaultHandler() {
+        val trackPoints = ArrayList<LatLon>()
+        val routePoints = ArrayList<LatLon>()
+        var trackName: String? = null
+        var metadataName: String? = null
+        var activityType: String? = null
+        var sawGpx = false
+
+        private val stack = ArrayList<String>()
+        private var text: StringBuilder? = null
+
+        private fun parent() = stack.getOrNull(stack.size - 2)
+
+        override fun startElement(uri: String?, l: String?, qName: String, a: Attributes?) {
+            val name = qName.substringAfter(':').lowercase()
+            stack.add(name)
+            when (name) {
+                "gpx" -> sawGpx = true
+                "trkpt" -> point(a)?.let { if (trackPoints.size < HARD_LIMIT) trackPoints.add(it) }
+                "rtept" -> point(a)?.let { if (routePoints.size < HARD_LIMIT) routePoints.add(it) }
+                "name", "type" -> if (parent() in SCOPES) text = StringBuilder()
+            }
+        }
+
+        override fun characters(ch: CharArray, start: Int, length: Int) {
+            text?.append(ch, start, length)
+        }
+
+        override fun endElement(uri: String?, l: String?, qName: String) {
+            val name = qName.substringAfter(':').lowercase()
+            val value = text?.toString()
+            text = null
+            if (value != null) {
+                when (name to parent()) {
+                    "name" to "trk", "name" to "rte" -> if (trackName == null) trackName = value
+                    "name" to "metadata" -> if (metadataName == null) metadataName = value
+                    "type" to "trk", "type" to "rte" ->
+                        if (activityType == null) activityType = value
+                }
+            }
+            if (stack.isNotEmpty()) stack.removeAt(stack.size - 1)
+        }
+
+        private fun point(a: Attributes?): LatLon? {
+            val lat = a?.getValue("lat")?.toDoubleOrNull() ?: return null
+            val lon = a.getValue("lon")?.toDoubleOrNull() ?: return null
+            if (lat !in -90.0..90.0 || lon !in -180.0..180.0) return null
+            return LatLon(lat, lon)
+        }
+
+        private companion object {
+            val SCOPES = setOf("trk", "rte", "metadata")
+        }
+    }
+}

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
@@ -1,0 +1,82 @@
+package com.raemond.opentrailpaper.data
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * A route waiting to be previewed.
+ *
+ * An import can arrive before the screen that shows it exists — an
+ * ACTION_VIEW from Files lands in the Activity while the rider is on the Ride
+ * tab — so the result has to sit somewhere above both. An `object` rather than
+ * something hung off BleManager: a file import is not Bluetooth, and that class
+ * is past 2,000 lines already. Same idiom as [Prefs] and EInkTileStore.
+ */
+object RouteImport {
+
+    /** Anything past this isn't a route file, and we won't read it into memory. */
+    private const val MAX_BYTES = 32L * 1024 * 1024
+
+    var pending by mutableStateOf<ImportedRoute?>(null)
+        private set
+
+    var error by mutableStateOf<String?>(null)
+        private set
+
+    fun offer(route: ImportedRoute) {
+        error = null
+        pending = route
+    }
+
+    fun fail(message: String) {
+        pending = null
+        error = message
+    }
+
+    /** Taken by the Route screen once it has drawn it. */
+    fun consume(): ImportedRoute? = pending?.also { pending = null }
+
+    fun clearError() { error = null }
+
+    /**
+     * Read and parse a GPX the rider picked or opened.
+     *
+     * The file is recognised by its contents, never by the MIME type the
+     * provider claims — GPX arrives as `application/gpx+xml`,
+     * `application/octet-stream`, `text/xml` or nothing at all depending on
+     * where it came from.
+     */
+    suspend fun read(context: Context, uri: Uri) = withContext(Dispatchers.IO) {
+        val resolver = context.contentResolver
+        val display = runCatching {
+            resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+        }.getOrNull()
+        val fallback = display?.substringBeforeLast('.')?.takeIf { it.isNotBlank() } ?: "Imported route"
+
+        val size = runCatching {
+            resolver.openAssetFileDescriptor(uri, "r")?.use { it.length }
+        }.getOrNull()
+        if (size != null && size > MAX_BYTES) {
+            fail("That file is too big to be a route")
+            return@withContext
+        }
+
+        val result = runCatching {
+            resolver.openInputStream(uri)?.use { GpxImporter.parse(it, fallback) }
+        }.getOrNull()
+
+        when (result) {
+            is ImportResult.Ok -> offer(result.route)
+            ImportResult.NoPoints -> fail("That file has no route in it")
+            ImportResult.NotGpx -> fail("That file isn't a GPX route")
+            null -> fail("Couldn't open that file")
+        }
+    }
+}

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
@@ -49,15 +49,35 @@ object RouteImport {
     var error by mutableStateOf<String?>(null)
         private set
 
+    /**
+     * Bumped on every [offer], and what the Route screen keys on.
+     *
+     * [pending] cannot do that job: ImportedRoute is a data class, so
+     * re-importing the same file offers an equal value, the screen's effect
+     * never restarts, and [fresh] is left stuck true — which makes the next
+     * redraw look like an arrival and wrongly clears the "sent to device"
+     * confirmation.
+     */
+    var arrival by mutableStateOf(0)
+        private set
+
     fun offer(route: ImportedRoute) {
         error = null
         pending = route
         cues = null
         fresh = true
+        arrival++
     }
 
+    /**
+     * Report a file we could not read, without touching [pending].
+     *
+     * Clearing here would orphan a route the rider is looking at: the screen
+     * keeps drawing it, this object no longer owns it, and the next tab tap
+     * loses it with no explanation. A bad second file is not a reason to throw
+     * away a good first one.
+     */
     fun fail(message: String) {
-        clear()
         error = message
     }
 

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/data/RouteImport.kt
@@ -6,6 +6,7 @@ import android.provider.OpenableColumns
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.raemond.opentrailpaper.routing.Routing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -17,6 +18,11 @@ import kotlinx.coroutines.withContext
  * tab — so the result has to sit somewhere above both. An `object` rather than
  * something hung off BleManager: a file import is not Bluetooth, and that class
  * is past 2,000 lines already. Same idiom as [Prefs] and EInkTileStore.
+ *
+ * It owns the route until the rider clears it, rather than handing it to the
+ * first screen that draws it: a tab tap destroys everything the Route screen
+ * remembers, and a search can be retyped where an import cannot be re-derived.
+ * The cues fetched for it are parked here for the same reason.
  */
 object RouteImport {
 
@@ -26,21 +32,46 @@ object RouteImport {
     var pending by mutableStateOf<ImportedRoute?>(null)
         private set
 
+    /** Turn cues the rider already paid an OSRM request for, if they asked. */
+    var cues by mutableStateOf<Routing.CueSet?>(null)
+        private set
+
+    /**
+     * True until the Route screen has drawn [pending] once.
+     *
+     * Lets the screen tell an import arriving from one being redrawn after a
+     * tab round-trip: only an arrival invalidates what was last sent to the
+     * device.
+     */
+    var fresh by mutableStateOf(false)
+        private set
+
     var error by mutableStateOf<String?>(null)
         private set
 
     fun offer(route: ImportedRoute) {
         error = null
         pending = route
+        cues = null
+        fresh = true
     }
 
     fun fail(message: String) {
-        pending = null
+        clear()
         error = message
     }
 
-    /** Taken by the Route screen once it has drawn it. */
-    fun consume(): ImportedRoute? = pending?.also { pending = null }
+    /** The Route screen has drawn this import; anything after is a redraw. */
+    fun markDrawn() { fresh = false }
+
+    fun noteCues(set: Routing.CueSet) { cues = set }
+
+    /** The rider dismissed the route — the only way an import leaves. */
+    fun clear() {
+        pending = null
+        cues = null
+        fresh = false
+    }
 
     fun clearError() { error = null }
 

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/routing/Routing.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/routing/Routing.kt
@@ -3,6 +3,7 @@ package com.raemond.opentrailpaper.routing
 import com.raemond.opentrailpaper.BuildConfig
 import com.raemond.opentrailpaper.ble.Maneuver
 import com.raemond.opentrailpaper.data.BoundingBox
+import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.LatLon
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -140,6 +141,133 @@ object Routing {
             durationSeconds = route.optDouble("duration", 0.0),
             maneuvers = maneuvers,
             mode = mode,
+        )
+    }
+
+    // MARK: turn cues for an imported route
+
+    /** routes.h MAX_MANEUVERS — more than this and the device drops the rest. */
+    private const val MAX_MANEUVERS = 128
+
+    /** How many via points describe the track well enough to route through it. */
+    private const val VIA_COUNT = 50
+
+    /** Cues that survived, and whether anything had to be thrown away to fit. */
+    data class CueSet(val maneuvers: List<Maneuver>, val truncated: Boolean)
+
+    /** A cue plus the two facts triage needs when there are too many of them. */
+    internal data class Cue(
+        val maneuver: Maneuver,
+        /** "Continue onto X" — no turn in it, the first thing worth losing. */
+        val isFiller: Boolean,
+        /** A slight left/right, the next thing worth losing. */
+        val isSlight: Boolean,
+    )
+
+    /**
+     * Turn cues for a route the rider brought with them.
+     *
+     * The track is sampled to [VIA_COUNT] waypoints and routed through, then
+     * OSRM's geometry is **discarded** — only the maneuver coordinates are kept.
+     * The device projects those onto whatever route is loaded
+     * (routes.cpp mapManeuversToRoute), so the rider still rides their own file
+     * while getting named turns off the OSM network.
+     *
+     * Measured against four real Komoot/Strava exports, cues land a median 0–1 m
+     * from the original track and 36 m at worst — inside the 20 m tolerance the
+     * firmware's own past-the-turn rule already lives with.
+     *
+     * Null on any failure: no network, a refusal, a route OSRM can't follow. The
+     * caller keeps the route and sends it without cues.
+     */
+    suspend fun cues(track: List<LatLon>): CueSet? = withContext(Dispatchers.IO) {
+        if (track.size < 2) return@withContext null
+        val vias = sampleByDistance(track, VIA_COUNT)
+        if (vias.size < 2) return@withContext null
+
+        val path = vias.joinToString(";") { "${fmt(it.lon)},${fmt(it.lat)}" }
+        val url = "https://routing.openstreetmap.de/routed-bike/route/v1/driving/$path" +
+            "?overview=false&steps=true&alternatives=false"
+        val body = get(url) ?: return@withContext null
+
+        val root = JSONObject(body)
+        if (root.optString("code") != "Ok") return@withContext null
+        val route = root.optJSONArray("routes")?.optJSONObject(0) ?: return@withContext null
+
+        val collected = ArrayList<Cue>()
+        val legs = route.optJSONArray("legs")
+        for (l in 0 until (legs?.length() ?: 0)) {
+            val steps = legs!!.optJSONObject(l)?.optJSONArray("steps") ?: continue
+            for (s in 0 until steps.length()) {
+                val step = steps.optJSONObject(s) ?: continue
+                val man = step.optJSONObject("maneuver") ?: continue
+                val loc = man.optJSONArray("location") ?: continue
+                // instruction() already returns null for depart/arrive, which is
+                // what discards the two artifacts every via point produces.
+                val txt = instruction(man, step.optString("name")) ?: continue
+                collected.add(
+                    Cue(
+                        maneuver = Maneuver(loc.optDouble(1), loc.optDouble(0), txt),
+                        isFiller = txt.startsWith("Continue"),
+                        isSlight = man.optString("modifier").startsWith("slight"),
+                    ),
+                )
+            }
+        }
+        if (collected.isEmpty()) return@withContext null
+        triage(collected)
+    }
+
+    /**
+     * [n] points spaced evenly along the track *by distance*.
+     *
+     * By distance and not by index because GPX point density varies wildly
+     * within one file — Komoot writes a point per second, so a slow climb is
+     * dense and a fast descent sparse. Sampling by index would spend most of the
+     * via budget on whichever part the rider went slowest through.
+     *
+     * The sample count is clamped to the track length: a short track asked for
+     * more vias than it has points would otherwise emit mostly duplicates,
+     * wasting OSRM's waypoint budget on a degenerate request.
+     */
+    internal fun sampleByDistance(points: List<LatLon>, n: Int): List<LatLon> {
+        if (points.size <= 2 || n < 2) return points
+        val cum = DoubleArray(points.size)
+        for (i in 1 until points.size) {
+            cum[i] = cum[i - 1] + points[i - 1].distanceTo(points[i])
+        }
+        val total = cum.last()
+        if (total <= 0.0) return listOf(points.first(), points.last())
+
+        val count = minOf(n, points.size)
+        val out = ArrayList<LatLon>(count)
+        var j = 0
+        for (i in 0 until count) {
+            val target = if (count > 1) total * i / (count - 1) else 0.0
+            while (j < cum.size - 1 && cum[j + 1] < target) j++
+            out.add(points[j])
+        }
+        out[out.size - 1] = points.last()
+        return out
+    }
+
+    /**
+     * Fit the cues into the device's maneuver table, cheapest losses first.
+     *
+     * Filler goes before slight turns, and slight turns before real ones. Only
+     * when even the real turns overflow does this truncate — and then it says
+     * so, because silently losing the last third of a route's cues is worse than
+     * admitting the list was cut.
+     */
+    internal fun triage(cues: List<Cue>, cap: Int = MAX_MANEUVERS): CueSet {
+        var kept: List<Cue> = cues
+        if (kept.size > cap) kept = kept.filterNot { it.isFiller }
+        if (kept.size > cap) kept = kept.filterNot { it.isSlight }
+        val truncated = kept.size > cap
+        if (truncated) kept = kept.take(cap)
+        return CueSet(
+            maneuvers = kept.map { it.maneuver.copy(text = DeviceText.maneuverText(it.maneuver.text)) },
+            truncated = truncated,
         )
     }
 

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/routing/Routing.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/routing/Routing.kt
@@ -178,7 +178,9 @@ object Routing {
      * firmware's own past-the-turn rule already lives with.
      *
      * Null on any failure: no network, a refusal, a route OSRM can't follow. The
-     * caller keeps the route and sends it without cues.
+     * caller keeps the route and sends it without cues. An empty [CueSet] is not
+     * a failure and must not be reported as one: a canal path with no junctions
+     * yields nothing but depart/arrive steps, which [instruction] drops.
      */
     suspend fun cues(track: List<LatLon>): CueSet? = withContext(Dispatchers.IO) {
         if (track.size < 2) return@withContext null
@@ -214,7 +216,6 @@ object Routing {
                 )
             }
         }
-        if (collected.isEmpty()) return@withContext null
         triage(collected)
     }
 

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MainActivity.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MainActivity.kt
@@ -79,13 +79,19 @@ class MainActivity : ComponentActivity() {
 
     /** A .gpx opened from another app. Parsed off the main thread. */
     private fun handleImport(intent: Intent?) {
-        val uri = when (intent?.action) {
+        intent ?: return
+        val uri = when (intent.action) {
             Intent.ACTION_VIEW -> intent.data
             Intent.ACTION_SEND -> IntentCompat.getParcelableExtra(
                 intent, Intent.EXTRA_STREAM, Uri::class.java,
             )
             else -> null
         } ?: return
+        // Spent as it is read: getIntent() still holds the VIEW intent after a
+        // rotation or a process restart, and re-parsing the file would replace
+        // the preview the rider has since annotated with cues.
+        intent.data = null
+        intent.removeExtra(Intent.EXTRA_STREAM)
         lifecycleScope.launch { RouteImport.read(this@MainActivity, uri) }
     }
 

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MainActivity.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MainActivity.kt
@@ -12,9 +12,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
+import androidx.core.content.IntentCompat
+import androidx.lifecycle.lifecycleScope
 import com.raemond.opentrailpaper.OpenTrailPaperApp
 import com.raemond.opentrailpaper.ble.BleManager
 import com.raemond.opentrailpaper.data.Prefs
+import com.raemond.opentrailpaper.data.RouteImport
+import kotlinx.coroutines.launch
 
 /**
  * The single activity.
@@ -59,6 +63,30 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+        handleImport(intent)
+    }
+
+    /**
+     * singleTask, so an ACTION_VIEW from Files arrives here rather than in a
+     * second copy of the activity. setIntent keeps getIntent() honest for
+     * anything that reads it later.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleImport(intent)
+    }
+
+    /** A .gpx opened from another app. Parsed off the main thread. */
+    private fun handleImport(intent: Intent?) {
+        val uri = when (intent?.action) {
+            Intent.ACTION_VIEW -> intent.data
+            Intent.ACTION_SEND -> IntentCompat.getParcelableExtra(
+                intent, Intent.EXTRA_STREAM, Uri::class.java,
+            )
+            else -> null
+        } ?: return
+        lifecycleScope.launch { RouteImport.read(this@MainActivity, uri) }
     }
 
     override fun onResume() {

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MapsSheet.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MapsSheet.kt
@@ -79,9 +79,26 @@ import kotlin.math.min
  * by its H3 id and renders them straight off the SD card, so map coverage is
  * limited by the card, not memory — and re-selecting an overlapping area only
  * ever sends the genuinely new tiles.
+ *
+ * [seed] pre-fills the selection instead of asking for a box, which is how the
+ * Route screen hands over the hexes a planned route crosses. Everything after
+ * the selection — what counts as new, the OSM fetch, the streaming, progress,
+ * cancel — is the same code either way; only the way the rider names an area
+ * differs.
+ *
+ * It must be a value that does not change while this sheet is open. Opening the
+ * sheet refreshes the tile store and the device's tile list, so a caller that
+ * passes a list derived from those recomputes it as a NEW list the moment this
+ * sheet appears — and a changing unstable parameter recomposes this whole
+ * screen, map and all, in a loop that pins the main thread. Snapshot it at the
+ * tap instead.
  */
 @Composable
-fun MapsSheet(ble: BleManager, onDismiss: () -> Unit) {
+fun MapsSheet(
+    ble: BleManager,
+    seed: List<MapTile> = emptyList(),
+    onDismiss: () -> Unit,
+) {
     val scope = rememberCoroutineScope()
     val projector = remember { MapProjector() }
     val haptics = LocalHapticFeedback.current
@@ -106,8 +123,11 @@ fun MapsSheet(ble: BleManager, onDismiss: () -> Unit) {
     var drawMode by remember { mutableStateOf(false) }
     var dragStart by remember { mutableStateOf<Offset?>(null) }
     var dragEnd by remember { mutableStateOf<Offset?>(null) }
-    var box by remember { mutableStateOf<BoundingBox?>(null) }
-    var tiles by remember { mutableStateOf<List<MapTile>>(emptyList()) }
+    // Seeded too, not just [tiles]: the card is gated on having a box, so
+    // without one a seeded selection draws its hexes on the map and then offers
+    // the rider nothing to tap.
+    var box by remember { mutableStateOf(BoundingBox.around(seed.flatMap { it.hexagon })) }
+    var tiles by remember { mutableStateOf(seed) }
     var excluded by remember { mutableStateOf<Set<String>>(emptySet()) }
     var converted by remember { mutableStateOf<Set<String>>(emptySet()) }
     var failedHexes by remember { mutableStateOf<Set<String>>(emptySet()) }
@@ -122,6 +142,22 @@ fun MapsSheet(ble: BleManager, onDismiss: () -> Unit) {
         ble.refreshDeviceTiles()
         EInkTileStore.refresh()
         onDispose { }
+    }
+
+    // A seeded selection frames itself, and claims the framing flag so the
+    // frame-all-coverage shot below doesn't pull the camera off it a moment
+    // later. Declared before that effect so it wins the flag.
+    //
+    // Waits for the map to report a region, which is the first moment it has a
+    // size. Framing before that runs zoomToBoundingBox against a zero-sized
+    // MapView, which spins the main thread until the system reports the app as
+    // not responding. The frame-all-coverage effect below is safe for exactly
+    // the same reason — it sits behind the same region guard.
+    LaunchedEffect(region != null) {
+        if (region == null || didFrameCoverage) return@LaunchedEffect
+        val bounds = BoundingBox.around(seed.flatMap { it.hexagon }) ?: return@LaunchedEffect
+        didFrameCoverage = true
+        camera = MapCamera.box(bounds, paddingPx = 32)
     }
 
     // Hexes in the drawn box that aren't on the device yet, in whichever state the

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/OsmMap.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/OsmMap.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -13,6 +13,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -279,18 +280,25 @@ fun OsmMap(
         },
     )
 
-    // Required by OpenStreetMap and by CARTO, and quiet enough to live under the
-    // screen's own title without competing with it. Bottom-left is where a map
-    // would normally put this and where every screen here has its controls.
+    // Required by OpenStreetMap and by CARTO. Bottom-right, which is where a map
+    // conventionally puts this and the one corner no screen here floats a
+    // control over — top-left put it adrift in the middle of the view, under
+    // the screen's title rather than beside it.
+    //
+    // Lifted by the same inset the camera uses, so it sits just above whatever
+    // card is floating over the map instead of behind it.
     Text(
         MapStyle.attribution,
         style = barlow(9.sp),
         color = Palette.muted,
         maxLines = 1,
         modifier = Modifier
-            .align(Alignment.TopStart)
-            .windowInsetsPadding(WindowInsets.statusBars)
-            .padding(start = 18.dp, top = 66.dp)
+            .align(Alignment.BottomEnd)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .padding(
+                end = 10.dp,
+                bottom = 8.dp + with(LocalDensity.current) { bottomInsetPx.toDp() },
+            )
             .background(Palette.paper.copy(alpha = 0.72f), RoundedCornerShape(4.dp))
             .padding(horizontal = 5.dp, vertical = 2.dp),
     )

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RootScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RootScreen.kt
@@ -71,8 +71,15 @@ fun RootScreen(
     val overlay = rememberOverlayHostState()
     // An import can arrive from another app while any tab is up; the route it
     // produced is only meaningful on the one that draws routes.
-    LaunchedEffect(RouteImport.pending, RouteImport.error) {
-        if (RouteImport.pending != null || RouteImport.error != null) tab = 1
+    //
+    // Keyed on `fresh` rather than on the route itself, because the route now
+    // outlives the screen that draws it: keying on `pending` would re-claim the
+    // tab on every activity recreation, for a route that arrived minutes ago.
+    // Not rotation — this activity is locked to portrait — but a font or
+    // display size change, a locale switch, or "don't keep activities" all
+    // recreate it, and the rider should stay on the tab they chose.
+    LaunchedEffect(RouteImport.fresh, RouteImport.error) {
+        if (RouteImport.fresh || RouteImport.error != null) tab = 1
     }
     CompositionLocalProvider(LocalOverlayHost provides overlay) {
     Box(Modifier.fillMaxSize().background(Palette.paper)) {

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RootScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RootScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.raemond.opentrailpaper.ble.BleManager
 import com.raemond.opentrailpaper.data.Prefs
+import com.raemond.opentrailpaper.data.RouteImport
 
 private class Tab(val label: String, val icon: ImageVector)
 
@@ -67,6 +69,11 @@ fun RootScreen(
     }
 
     val overlay = rememberOverlayHostState()
+    // An import can arrive from another app while any tab is up; the route it
+    // produced is only meaningful on the one that draws routes.
+    LaunchedEffect(RouteImport.pending, RouteImport.error) {
+        if (RouteImport.pending != null || RouteImport.error != null) tab = 1
+    }
     CompositionLocalProvider(LocalOverlayHost provides overlay) {
     Box(Modifier.fillMaxSize().background(Palette.paper)) {
         Scaffold(

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Signpost
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -44,9 +46,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -61,6 +65,7 @@ import com.raemond.opentrailpaper.data.RouteImport
 import com.raemond.opentrailpaper.data.Units
 import com.raemond.opentrailpaper.map.EInkTileStore
 import com.raemond.opentrailpaper.map.H3Tiles
+import com.raemond.opentrailpaper.map.MapTile
 import com.raemond.opentrailpaper.map.OutlineHex
 import com.raemond.opentrailpaper.routing.Routing
 import kotlinx.coroutines.launch
@@ -86,7 +91,26 @@ fun RouteScreen(ble: BleManager) {
     }
     /** Hexes the planned route crosses that NOTHING covers — see below. */
     var gapHexes by remember { mutableStateOf<List<OutlineHex>>(emptyList()) }
+    /** The same gaps as tiles, for seeding a download. Kept even when the
+     *  overlay above is deliberately empty — see [recomputeCoverage]. */
+    var gapTiles by remember { mutableStateOf<List<MapTile>>(emptyList()) }
     var showSaved by remember { mutableStateOf(false) }
+    var showMaps by remember { mutableStateOf(false) }
+    /**
+     * The gaps as they stood when the rider tapped download.
+     *
+     * A snapshot, not [gapTiles] itself: opening the Maps sheet refreshes the
+     * tile store and the device's tile list, both of which rebuild [gapTiles]
+     * as a new list — and handing a sheet a parameter that changes identity
+     * underneath it recomposes the whole sheet, map included, in a loop.
+     */
+    var mapsSeed by remember { mutableStateOf<List<MapTile>>(emptyList()) }
+    /**
+     * Measured height of the floating stack at the bottom. The map runs
+     * full-bleed underneath it, so without this a route frames itself to the
+     * whole screen and lands half-hidden behind the card.
+     */
+    var cardHeightPx by remember { mutableStateOf(0) }
     var didCentre by remember { mutableStateOf(false) }
 
     val here: LatLon? = ble.lastLocation?.let { LatLon(it.latitude, it.longitude) }
@@ -109,7 +133,7 @@ fun RouteScreen(ble: BleManager) {
     // in this composable dies on a tab tap, and a rider who leaves for the Ride
     // tab to connect the head unit has to find their route still here when they
     // come back. RouteImport holds it until they clear it.
-    LaunchedEffect(RouteImport.pending) {
+    LaunchedEffect(RouteImport.pending, cardHeightPx > 0) {
         val imported = RouteImport.pending ?: return@LaunchedEffect
         results = emptyList()
         destination = null
@@ -126,6 +150,12 @@ fun RouteScreen(ble: BleManager) {
         // Framed on every redraw, not only on arrival: the camera is remembered
         // here too, so a tab round-trip would otherwise restore the route with
         // the map sitting somewhere else entirely.
+        //
+        // Also re-runs once the card has been measured, because a route that
+        // arrives before first layout would otherwise be framed against a
+        // zero inset and sit behind the card. Keyed on the boolean, not the
+        // height, so the later shrink when a button disappears doesn't yank
+        // the camera out from under someone reading the map.
         BoundingBox.around(imported.points)?.let {
             camera = MapCamera.box(it.paddedForDisplay())
         }
@@ -148,22 +178,28 @@ fun RouteScreen(ble: BleManager) {
     fun recomputeCoverage() {
         val coords = preview?.points
         if (coords.isNullOrEmpty()) {
+            gapTiles = emptyList()
             gapHexes = emptyList()
             return
         }
         val covered = EInkTileStore.ids + ble.deviceTileIds
-        if (covered.isEmpty()) {
-            // Nothing downloaded at all. Papering the whole route in hexagons
-            // would say only what the empty Maps screen already says.
-            gapHexes = emptyList()
-            return
-        }
         val seen = HashSet<String>()
-        gapHexes = coords.mapNotNull { c ->
+        gapTiles = coords.mapNotNull { c ->
             val id = H3Tiles.idAt(c) ?: return@mapNotNull null
             if (id in covered || !seen.add(id)) return@mapNotNull null
-            val t = H3Tiles.tile(id) ?: return@mapNotNull null
-            OutlineHex(id, t.hexagon, t.center, synced = false, missing = true)
+            H3Tiles.tile(id)
+        }
+        // The OVERLAY stays silent when nothing is downloaded at all: papering
+        // the whole route in hexagons would say only what the empty Maps screen
+        // already says. The download button deliberately does not follow that
+        // rule — a rider carrying no maps is exactly who needs it, and they are
+        // the one person the overlay never speaks to.
+        gapHexes = if (covered.isEmpty()) {
+            emptyList()
+        } else {
+            gapTiles.map {
+                OutlineHex(it.id, it.hexagon, it.center, synced = false, missing = true)
+            }
         }
     }
 
@@ -191,6 +227,7 @@ fun RouteScreen(ble: BleManager) {
             destination = destination?.let { MapDestination(it.name, it.coordinate) },
             camera = camera,
             showUserLocation = ble.locationPermission.isGranted,
+            bottomInsetPx = cardHeightPx,
         )
 
         // "Route" title pill, floated top-left.
@@ -209,6 +246,7 @@ fun RouteScreen(ble: BleManager) {
         Column(
             Modifier
                 .align(Alignment.BottomCenter)
+                .onSizeChanged { cardHeightPx = it.height }
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
@@ -239,18 +277,26 @@ fun RouteScreen(ble: BleManager) {
                 }
             }
 
-            SearchField(
-                value = query,
-                onValueChange = { query = it },
-                searching = searching,
-            ) {
-                if (query.isBlank()) return@SearchField
-                searching = true
-                error = null
-                scope.launch {
-                    results = Routing.search(query, here)
-                    searching = false
-                    if (results.isEmpty()) error = "Nothing found for “$query”"
+            // Hidden while an imported route is up. Searching would build a
+            // different route and throw this one away, and the rider who just
+            // opened a file did not come here to type a destination — the
+            // card's clear button is the way back to searching. A route this
+            // screen built itself keeps the field: the query that produced it
+            // is still the obvious thing to edit.
+            if (preview?.imported != true) {
+                SearchField(
+                    value = query,
+                    onValueChange = { query = it },
+                    searching = searching,
+                ) {
+                    if (query.isBlank()) return@SearchField
+                    searching = true
+                    error = null
+                    scope.launch {
+                        results = Routing.search(query, here)
+                        searching = false
+                        if (results.isEmpty()) error = "Nothing found for “$query”"
+                    }
                 }
             }
 
@@ -309,6 +355,11 @@ fun RouteScreen(ble: BleManager) {
                     cueCount = if (p.imported) p.maneuvers.size else null,
                     cuesTruncated = p.cuesTruncated,
                     derivingCues = derivingCues,
+                    mapGapCount = gapTiles.size,
+                    onDownloadMaps = {
+                        mapsSeed = gapTiles
+                        showMaps = true
+                    },
                     progress = ble.lastUploadProgress,
                     sent = ble.routeSent,
                     received = ble.routeReceived,
@@ -370,6 +421,12 @@ fun RouteScreen(ble: BleManager) {
 
     if (showSaved) {
         SavedRoutesSheet(ble) { showSaved = false }
+    }
+
+    // The Maps tool, opened with this route's uncovered hexes already selected
+    // so the rider lands on the download rather than on an empty drawing board.
+    if (showMaps) {
+        MapsSheet(ble = ble, seed = mapsSeed) { showMaps = false }
     }
 }
 
@@ -521,6 +578,8 @@ private fun RouteSummaryCard(
     cueCount: Int?,
     cuesTruncated: Boolean,
     derivingCues: Boolean,
+    mapGapCount: Int,
+    onDownloadMaps: () -> Unit,
     progress: Double?,
     sent: Boolean,
     received: Boolean,
@@ -580,26 +639,58 @@ private fun RouteSummaryCard(
         }
         // Imported routes arrive with no turn cues. Fetching them sends the
         // shape of this route to a third party, so it is a thing the rider
-        // asks for, named in the button, rather than something that happens.
+        // asks for — and the service is named under the button, in front of
+        // them before they tap, rather than buried in a dialog after.
         if (cueCount == 0) {
             Spacer(Modifier.size(12.dp))
             if (derivingCues) {
                 Row(
+                    Modifier.fillMaxWidth().padding(vertical = 13.dp),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.Center,
                 ) {
                     CircularProgressIndicator(Modifier.size(18.dp), color = Palette.accent)
-                    Text("Fetching turn cues…", style = barlow(12.sp), color = Palette.muted)
+                    Spacer(Modifier.size(12.dp))
+                    Text("Fetching turn cues…", style = barlow(13.sp), color = Palette.muted)
                 }
             } else {
-                TextButton(onClick = onAddCues) {
-                    Text(
-                        "Add turn cues via routing.openstreetmap.de",
-                        style = barlow(13.sp, FontWeight.SemiBold),
-                        color = Palette.accent,
-                    )
-                }
+                SecondaryButton(
+                    title = "Add turn cues",
+                    icon = Icons.Filled.Signpost,
+                    onClick = onAddCues,
+                )
+                Text(
+                    "Fetched from routing.openstreetmap.de",
+                    style = barlow(11.sp),
+                    color = Palette.faint,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 6.dp),
+                    textAlign = TextAlign.Center,
+                )
             }
+        }
+        // The route crosses ground the head unit can't draw. Offering the fix
+        // here rather than only in Settings, because this is the screen where a
+        // rider finds out — the gap hexagons are already on the map behind this
+        // card. The download itself still belongs to the Maps tool; this only
+        // opens it with the route's own gaps already selected.
+        if (mapGapCount > 0) {
+            Spacer(Modifier.size(12.dp))
+            SecondaryButton(
+                title = "Download $mapGapCount map area${if (mapGapCount == 1) "" else "s"}",
+                icon = Icons.Filled.Download,
+                onClick = onDownloadMaps,
+            )
+            Text(
+                "This route crosses ground the device has no map for",
+                style = barlow(11.sp),
+                color = Palette.faint,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 6.dp),
+                textAlign = TextAlign.Center,
+            )
         }
         Spacer(Modifier.size(12.dp))
         when {

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -111,6 +111,7 @@ fun RouteScreen(ble: BleManager) {
             error = null
             ble.routeSent = false
             ble.routeReceived = false
+            derivingCues = false
             preview = imported.asPreview()
             BoundingBox.around(imported.points)?.let {
                 camera = MapCamera.box(it.paddedForDisplay())
@@ -301,6 +302,12 @@ fun RouteScreen(ble: BleManager) {
                         error = null
                         scope.launch {
                             val set = Routing.cues(p.points)
+                            // The rider can clear this route, or import another,
+                            // while OSRM is still thinking. A slow request must
+                            // not resurrect a route they dismissed — nor report
+                            // its failure over whatever replaced it. Whoever
+                            // moved the preview on resets the spinner.
+                            if (preview !== p) return@launch
                             derivingCues = false
                             if (set == null) {
                                 error = "Couldn't fetch turn cues — check your connection"
@@ -324,6 +331,7 @@ fun RouteScreen(ble: BleManager) {
                         preview = null
                         destination = null
                         error = null
+                        derivingCues = false
                     },
                 )
             }

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -1,5 +1,7 @@
 package com.raemond.opentrailpaper.ui
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -19,6 +21,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Search
@@ -42,15 +45,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raemond.opentrailpaper.ble.BleManager
+import com.raemond.opentrailpaper.ble.Maneuver
 import com.raemond.opentrailpaper.data.BoundingBox
 import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.GpxExporter
+import com.raemond.opentrailpaper.data.ImportedRoute
 import com.raemond.opentrailpaper.data.LatLon
+import com.raemond.opentrailpaper.data.RouteImport
 import com.raemond.opentrailpaper.data.Units
 import com.raemond.opentrailpaper.map.EInkTileStore
 import com.raemond.opentrailpaper.map.H3Tiles
@@ -70,7 +77,8 @@ fun RouteScreen(ble: BleManager) {
     var results by remember { mutableStateOf<List<Routing.Place>>(emptyList()) }
     var searching by remember { mutableStateOf(false) }
     var destination by remember { mutableStateOf<Routing.Place?>(null) }
-    var route by remember { mutableStateOf<Routing.Route?>(null) }
+    var preview by remember { mutableStateOf<Preview?>(null) }
+    var derivingCues by remember { mutableStateOf(false) }
     var building by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
     var camera by remember {
@@ -94,6 +102,29 @@ fun RouteScreen(ble: BleManager) {
 
     LaunchedEffect(Unit) { EInkTileStore.refresh() }
 
+    // A route imported from a file, whether picked here or opened from another
+    // app. Framed the same way a searched route is.
+    LaunchedEffect(RouteImport.pending) {
+        RouteImport.consume()?.let { imported ->
+            results = emptyList()
+            destination = null
+            error = null
+            ble.routeSent = false
+            ble.routeReceived = false
+            preview = imported.asPreview()
+            BoundingBox.around(imported.points)?.let {
+                camera = MapCamera.box(it.paddedForDisplay())
+            }
+        }
+    }
+
+    LaunchedEffect(RouteImport.error) {
+        RouteImport.error?.let {
+            error = it
+            RouteImport.clearError()
+        }
+    }
+
     /**
      * The hexes the route crosses that neither the phone nor the device holds.
      *
@@ -102,7 +133,7 @@ fun RouteScreen(ble: BleManager) {
      * part the camera happens to frame, so panning must not change the answer.
      */
     fun recomputeCoverage() {
-        val coords = route?.coordinates
+        val coords = preview?.points
         if (coords.isNullOrEmpty()) {
             gapHexes = emptyList()
             return
@@ -123,7 +154,17 @@ fun RouteScreen(ble: BleManager) {
         }
     }
 
-    LaunchedEffect(route, EInkTileStore.version, ble.deviceTileIds) { recomputeCoverage() }
+    LaunchedEffect(preview, EInkTileStore.version, ble.deviceTileIds) { recomputeCoverage() }
+
+    val context = LocalContext.current
+    // Permissive on the picker where the rider is choosing the file themselves;
+    // the manifest filters, which decide what shows up in *other* apps'
+    // choosers, are the ones that have to stay narrow.
+    val pickGpx = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri != null) scope.launch { RouteImport.read(context, uri) }
+    }
 
     Box(Modifier.fillMaxSize().background(Palette.paper)) {
         // Same map component as the Maps screen, but showing only the GAP hexes —
@@ -133,7 +174,7 @@ fun RouteScreen(ble: BleManager) {
         OsmMap(
             modifier = Modifier.fillMaxSize(),
             outlines = gapHexes,
-            route = route?.coordinates,
+            route = preview?.points,
             destination = destination?.let { MapDestination(it.name, it.coordinate) },
             camera = camera,
             showUserLocation = ble.locationPermission.isGranted,
@@ -159,6 +200,17 @@ fun RouteScreen(ble: BleManager) {
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                RoundMapButton(Icons.Filled.FileOpen, enabled = true) {
+                    pickGpx.launch(
+                        arrayOf(
+                            "application/gpx+xml",
+                            "application/octet-stream",
+                            "application/xml",
+                            "text/xml",
+                        ),
+                    )
+                }
+                Spacer(Modifier.size(10.dp))
                 RoundMapButton(Icons.Filled.MyLocation, enabled = true) {
                     camera = here?.let { MapCamera.region(it, 0.05) } ?: MapCamera.followUser()
                 }
@@ -189,7 +241,7 @@ fun RouteScreen(ble: BleManager) {
                 }
             }
 
-            if (results.isNotEmpty() && route == null) {
+            if (results.isNotEmpty() && preview == null) {
                 ResultsList(results) { place ->
                     destination = place
                     results = emptyList()
@@ -207,7 +259,7 @@ fun RouteScreen(ble: BleManager) {
                         if (built == null) {
                             error = "Couldn't build a route there"
                         } else {
-                            route = built
+                            preview = built.asPreview(place.name)
                             built.bounds?.let { camera = MapCamera.box(it.paddedForDisplay()) }
                         }
                     }
@@ -230,27 +282,46 @@ fun RouteScreen(ble: BleManager) {
                 Card { Text(it, style = barlow(13.sp), color = Palette.accent) }
             }
 
-            route?.let { r ->
+            preview?.let { p ->
                 RouteSummaryCard(
-                    name = destination?.name ?: "Route",
-                    mode = r.mode,
-                    distanceKm = r.distanceMeters / 1000,
-                    minutes = (r.durationSeconds / 60).toInt(),
+                    name = p.name,
+                    mode = p.mode,
+                    distanceKm = p.distanceMeters / 1000,
+                    minutes = p.minutes,
+                    cueCount = if (p.imported) p.maneuvers.size else null,
+                    cuesTruncated = p.cuesTruncated,
+                    derivingCues = derivingCues,
                     progress = ble.lastUploadProgress,
                     sent = ble.routeSent,
                     received = ble.routeReceived,
                     canSend = ble.state == BleManager.ConnState.CONNECTED,
                     useMiles = ble.useMiles,
+                    onAddCues = {
+                        derivingCues = true
+                        error = null
+                        scope.launch {
+                            val set = Routing.cues(p.points)
+                            derivingCues = false
+                            if (set == null) {
+                                error = "Couldn't fetch turn cues — check your connection"
+                            } else {
+                                preview = p.copy(
+                                    maneuvers = set.maneuvers,
+                                    cuesTruncated = set.truncated,
+                                )
+                            }
+                        }
+                    },
                     onSend = {
-                        val name = DeviceText.routeFileName(destination?.name)
+                        val name = DeviceText.routeFileName(p.name)
                         ble.uploadRoute(
                             name = name,
-                            gpx = GpxExporter.make(name, r.coordinates),
-                            maneuvers = r.maneuvers,
+                            gpx = GpxExporter.make(name, p.points),
+                            maneuvers = p.maneuvers,
                         )
                     },
                     onClear = {
-                        route = null
+                        preview = null
                         destination = null
                         error = null
                     },
@@ -263,6 +334,45 @@ fun RouteScreen(ble: BleManager) {
         SavedRoutesSheet(ble) { showSaved = false }
     }
 }
+
+/**
+ * What the screen is previewing, however it arrived.
+ *
+ * A searched route and an imported one differ in exactly two ways — an import
+ * has no time estimate and starts with no turn cues — so they share everything
+ * below this point rather than growing a parallel set of states.
+ */
+private data class Preview(
+    val name: String,
+    val points: List<LatLon>,
+    val distanceMeters: Double,
+    /** Null for an import: there is no honest time estimate for someone else's route. */
+    val minutes: Int?,
+    val mode: String,
+    val maneuvers: List<Maneuver>,
+    val imported: Boolean,
+    val cuesTruncated: Boolean = false,
+)
+
+private fun Routing.Route.asPreview(name: String) = Preview(
+    name = name,
+    points = coordinates,
+    distanceMeters = distanceMeters,
+    minutes = (durationSeconds / 60).toInt(),
+    mode = mode,
+    maneuvers = maneuvers,
+    imported = false,
+)
+
+private fun ImportedRoute.asPreview() = Preview(
+    name = name,
+    points = points,
+    distanceMeters = distanceMeters,
+    minutes = null,
+    mode = mode,
+    maneuvers = emptyList(),
+    imported = true,
+)
 
 /**
  * Grow the box by a fraction of its own size on each axis, so a route framed by
@@ -368,12 +478,16 @@ private fun RouteSummaryCard(
     name: String,
     mode: String,
     distanceKm: Double,
-    minutes: Int,
+    minutes: Int?,
+    cueCount: Int?,
+    cuesTruncated: Boolean,
+    derivingCues: Boolean,
     progress: Double?,
     sent: Boolean,
     received: Boolean,
     canSend: Boolean,
     useMiles: Boolean,
+    onAddCues: () -> Unit,
     onSend: () -> Unit,
     onClear: () -> Unit,
 ) {
@@ -399,13 +513,23 @@ private fun RouteSummaryCard(
                         )
                     }
                     Text(
-                        String.format(
-                            Locale.US,
-                            "%.1f %s · %d min",
-                            Units.distance(distanceKm, useMiles),
-                            Units.distLabel(useMiles),
-                            minutes,
-                        ),
+                        buildString {
+                            append(
+                                String.format(
+                                    Locale.US,
+                                    "%.1f %s",
+                                    Units.distance(distanceKm, useMiles),
+                                    Units.distLabel(useMiles),
+                                ),
+                            )
+                            // Only for a route we built: there is no honest
+                            // duration for a file somebody else planned.
+                            if (minutes != null) append(" · $minutes min")
+                            if (cueCount != null && cueCount > 0) {
+                                append(" · $cueCount turns")
+                                if (cuesTruncated) append(" (capped)")
+                            }
+                        },
                         style = TypeScale.body,
                         color = Palette.muted,
                     )
@@ -413,6 +537,29 @@ private fun RouteSummaryCard(
             }
             IconButton(onClick = onClear) {
                 Icon(Icons.Filled.Cancel, contentDescription = "Clear route", tint = Palette.muted)
+            }
+        }
+        // Imported routes arrive with no turn cues. Fetching them sends the
+        // shape of this route to a third party, so it is a thing the rider
+        // asks for, named in the button, rather than something that happens.
+        if (cueCount == 0) {
+            Spacer(Modifier.size(12.dp))
+            if (derivingCues) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CircularProgressIndicator(Modifier.size(18.dp), color = Palette.accent)
+                    Text("Fetching turn cues…", style = barlow(12.sp), color = Palette.muted)
+                }
+            } else {
+                TextButton(onClick = onAddCues) {
+                    Text(
+                        "Add turn cues via routing.openstreetmap.de",
+                        style = barlow(13.sp, FontWeight.SemiBold),
+                        color = Palette.accent,
+                    )
+                }
             }
         }
         Spacer(Modifier.size(12.dp))

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -138,7 +138,7 @@ fun RouteScreen(ble: BleManager) {
     // in this composable dies on a tab tap, and a rider who leaves for the Ride
     // tab to connect the head unit has to find their route still here when they
     // come back. RouteImport holds it until they clear it.
-    LaunchedEffect(RouteImport.pending, cardHeightPx > 0) {
+    LaunchedEffect(RouteImport.arrival, cardHeightPx > 0) {
         val imported = RouteImport.pending ?: return@LaunchedEffect
         results = emptyList()
         destination = null

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -104,18 +104,30 @@ fun RouteScreen(ble: BleManager) {
 
     // A route imported from a file, whether picked here or opened from another
     // app. Framed the same way a searched route is.
+    //
+    // Rebuilt from RouteImport rather than taken from it: everything remembered
+    // in this composable dies on a tab tap, and a rider who leaves for the Ride
+    // tab to connect the head unit has to find their route still here when they
+    // come back. RouteImport holds it until they clear it.
     LaunchedEffect(RouteImport.pending) {
-        RouteImport.consume()?.let { imported ->
-            results = emptyList()
-            destination = null
-            error = null
+        val imported = RouteImport.pending ?: return@LaunchedEffect
+        results = emptyList()
+        destination = null
+        error = null
+        derivingCues = false
+        preview = imported.asPreview(RouteImport.cues)
+        if (RouteImport.fresh) {
+            RouteImport.markDrawn()
+            // Only an arrival invalidates the last upload. A redraw is the same
+            // route the rider already sent, and still says so.
             ble.routeSent = false
             ble.routeReceived = false
-            derivingCues = false
-            preview = imported.asPreview()
-            BoundingBox.around(imported.points)?.let {
-                camera = MapCamera.box(it.paddedForDisplay())
-            }
+        }
+        // Framed on every redraw, not only on arrival: the camera is remembered
+        // here too, so a tab round-trip would otherwise restore the route with
+        // the map sitting somewhere else entirely.
+        BoundingBox.around(imported.points)?.let {
+            camera = MapCamera.box(it.paddedForDisplay())
         }
     }
 
@@ -307,20 +319,30 @@ fun RouteScreen(ble: BleManager) {
                         error = null
                         scope.launch {
                             val set = Routing.cues(p.points)
+                            derivingCues = false
                             // The rider can clear this route, or import another,
                             // while OSRM is still thinking. A slow request must
                             // not resurrect a route they dismissed — nor report
-                            // its failure over whatever replaced it. Whoever
-                            // moved the preview on resets the spinner.
+                            // its failure over whatever replaced it.
                             if (preview !== p) return@launch
-                            derivingCues = false
-                            if (set == null) {
-                                error = "Couldn't fetch turn cues — check your connection"
-                            } else {
-                                preview = p.copy(
-                                    maneuvers = set.maneuvers,
-                                    cuesTruncated = set.truncated,
-                                )
+                            when {
+                                set == null ->
+                                    error = "Couldn't fetch turn cues — check your connection"
+                                // Not a failure: a path with no junctions in it
+                                // has nothing to call out, and saying the network
+                                // broke would send the rider chasing a fault
+                                // that isn't there.
+                                set.maneuvers.isEmpty() ->
+                                    error = "This route has no turns to call out"
+                                else -> {
+                                    // Parked so a tab round-trip doesn't quietly
+                                    // cost a second request for the same cues.
+                                    RouteImport.noteCues(set)
+                                    preview = p.copy(
+                                        maneuvers = set.maneuvers,
+                                        cuesTruncated = set.truncated,
+                                    )
+                                }
                             }
                         }
                     },
@@ -333,6 +355,9 @@ fun RouteScreen(ble: BleManager) {
                         )
                     },
                     onClear = {
+                        // The import outlives this screen, so clearing it here
+                        // is not enough — it would come back on the next tab.
+                        RouteImport.clear()
                         preview = null
                         destination = null
                         error = null
@@ -377,14 +402,15 @@ private fun Routing.Route.asPreview(name: String) = Preview(
     imported = false,
 )
 
-private fun ImportedRoute.asPreview() = Preview(
+private fun ImportedRoute.asPreview(cues: Routing.CueSet?) = Preview(
     name = name,
     points = points,
     distanceMeters = distanceMeters,
     minutes = null,
     mode = mode,
-    maneuvers = emptyList(),
+    maneuvers = cues?.maneuvers.orEmpty(),
     imported = true,
+    cuesTruncated = cues?.truncated == true,
 )
 
 /**

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -117,8 +117,13 @@ fun RouteScreen(ble: BleManager) {
 
     // Frame the rider as soon as there is a fix, instead of sitting on the
     // fallback region until the first tap of "recenter".
-    LaunchedEffect(here) {
-        if (!didCentre && here != null) {
+    //
+    // Never over a route, though. The first fix can land a second or two after
+    // an import — long enough for the rider to see their route framed and then
+    // watch the map slide away to wherever they are standing, which on an
+    // imported route is usually a different part of the country.
+    LaunchedEffect(here, preview == null) {
+        if (!didCentre && here != null && preview == null) {
             didCentre = true
             camera = MapCamera.region(here, 0.08)
         }

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -257,6 +257,11 @@ fun RouteScreen(ble: BleManager) {
                     scope.launch {
                         val built = Routing.route(from, place.coordinate)
                         building = false
+                        // The file button is live while this is in flight, so an
+                        // import can land first. A search tap only starts from an
+                        // empty preview: if one exists by now the rider moved on,
+                        // and their route must not be overwritten by this one.
+                        if (preview != null) return@launch
                         if (built == null) {
                             error = "Couldn't build a route there"
                         } else {

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/RouteScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raemond.opentrailpaper.ble.BleManager
 import com.raemond.opentrailpaper.data.BoundingBox
+import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.GpxExporter
 import com.raemond.opentrailpaper.data.LatLon
 import com.raemond.opentrailpaper.data.Units
@@ -241,7 +242,7 @@ fun RouteScreen(ble: BleManager) {
                     canSend = ble.state == BleManager.ConnState.CONNECTED,
                     useMiles = ble.useMiles,
                     onSend = {
-                        val name = fileName(destination?.name)
+                        val name = DeviceText.routeFileName(destination?.name)
                         ble.uploadRoute(
                             name = name,
                             gpx = GpxExporter.make(name, r.coordinates),
@@ -277,14 +278,6 @@ private fun BoundingBox.paddedForDisplay(
     val padLat = maxOf((north - south) * fraction, (minimumSpanDeg - (north - south)) / 2, 0.0)
     val padLon = maxOf((east - west) * fraction, (minimumSpanDeg - (east - west)) / 2, 0.0)
     return BoundingBox(south - padLat, west - padLon, north + padLat, east + padLon)
-}
-
-private fun fileName(destination: String?): String {
-    val base = destination?.takeIf { it.isNotBlank() } ?: "route"
-    val safe = base.lowercase(Locale.US)
-        .replace(' ', '_')
-        .filter { it.isLetterOrDigit() || it == '_' }
-    return safe.take(24) + ".gpx"
 }
 
 @Composable

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/Theme.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/Theme.kt
@@ -146,6 +146,53 @@ fun PrimaryButton(
     }
 }
 
+/**
+ * Full-width secondary action — [PrimaryButton]'s pill, outlined rather than
+ * filled.
+ *
+ * Same geometry on purpose: an optional action stacked above a primary one has
+ * to read as a button of the same family, or it reads as a link. Colour carries
+ * the hierarchy instead — vermilion on paper rather than paper on vermilion —
+ * so the eye still lands on the primary action first. Slightly shorter than
+ * [PrimaryButton] for the same reason.
+ */
+@Composable
+fun SecondaryButton(
+    title: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .fillMaxWidth()
+            .border(
+                1.5.dp,
+                if (enabled) Palette.accent else Palette.hairline,
+                RoundedCornerShape(26.dp),
+            ),
+        shape = RoundedCornerShape(26.dp),
+        contentPadding = PaddingValues(vertical = 13.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Palette.surface,
+            contentColor = Palette.accent,
+            disabledContainerColor = Palette.surface,
+            disabledContentColor = Palette.faint,
+        ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (icon != null) Icon(icon, contentDescription = null)
+            Text(title, style = condensed(18.sp, FontWeight.SemiBold))
+        }
+    }
+}
+
 private val LightScheme = lightColorScheme(
     primary = Palette.accent,
     onPrimary = Palette.accentInk,

--- a/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
+++ b/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
@@ -1,5 +1,6 @@
 package com.raemond.opentrailpaper
 
+import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.GpxImporter
 import com.raemond.opentrailpaper.data.ImportResult
 import org.junit.Assert.assertEquals
@@ -208,5 +209,73 @@ class GpxImportTest {
         """.trimIndent()
         assertEquals("", ok(noType).mode)
         assertNull(ok(noType).activityType)
+    }
+
+    // MARK: device text budgets
+
+    @Test
+    fun `route filename folds accents away and stays inside the name budget`() {
+        val n = DeviceText.routeFileName("From Poronin to Kościelisko")
+        assertEquals("from_poronin_to_koscielisko.gpx", n)
+        assertTrue(n, n.toByteArray(Charsets.UTF_8).size <= 31)
+        assertTrue(n, n.all { it.code < 128 })
+    }
+
+    @Test
+    fun `route filename truncates by bytes and never ends in an underscore`() {
+        val n = DeviceText.routeFileName("Petla z Leszna na polnoc i jeszcze dalej na wschod")
+        assertTrue(n, n.toByteArray(Charsets.UTF_8).size <= 31)
+        assertTrue(n, n.endsWith(".gpx"))
+        assertTrue(n, !n.removeSuffix(".gpx").endsWith("_"))
+    }
+
+    @Test
+    fun `route filename falls back when the title has nothing usable in it`() {
+        assertEquals("route.gpx", DeviceText.routeFileName(null))
+        assertEquals("route.gpx", DeviceText.routeFileName("   "))
+        assertEquals("route.gpx", DeviceText.routeFileName("!!! ???"))
+    }
+
+    /**
+     * The firmware copies cue text into a char[48] with snprintf, which cuts at
+     * 47 bytes with no regard for UTF-8. "Ł" is two bytes; splitting it puts an
+     * invalid sequence on the panel. Already reachable from search-built routes
+     * down any long Polish street — imports only make it common.
+     */
+    @Test
+    fun `maneuver text truncates on a codepoint boundary`() {
+        val long = "Turn slightly right onto Jakuba Ignacego Łaszczyńskiego"
+        assertTrue(long.toByteArray(Charsets.UTF_8).size > DeviceText.MANEUVER_BUDGET)
+
+        val fitted = DeviceText.maneuverText(long)
+        val bytes = fitted.toByteArray(Charsets.UTF_8)
+        assertTrue("${bytes.size} bytes", bytes.size <= DeviceText.MANEUVER_BUDGET)
+        // Round-trips cleanly: no half-character at the end.
+        assertEquals(fitted, String(bytes, Charsets.UTF_8))
+        assertTrue(fitted, fitted.startsWith("Turn slightly right"))
+    }
+
+    @Test
+    fun `maneuver text leaves a cue that already fits completely alone`() {
+        val short = "Turn left onto Ustup"
+        assertEquals(short, DeviceText.maneuverText(short))
+    }
+
+    @Test
+    fun `maneuver text prefers to cut at a word boundary`() {
+        val fitted = DeviceText.maneuverText("Turn right onto Aleja Krakowska Wschodnia Poludniowa")
+        assertTrue(fitted, !fitted.endsWith(" "))
+        assertTrue(fitted, fitted.toByteArray(Charsets.UTF_8).size <= DeviceText.MANEUVER_BUDGET)
+    }
+
+    @Test
+    fun `fitUtf8 never splits a multi-byte character`() {
+        // 20 two-byte characters against a 15-byte budget.
+        val accented = "ą".repeat(20)
+        val fitted = DeviceText.fitUtf8(accented, 15)
+        val bytes = fitted.toByteArray(Charsets.UTF_8)
+        assertTrue("${bytes.size}", bytes.size <= 15)
+        assertEquals(fitted, String(bytes, Charsets.UTF_8))
+        assertEquals(7, fitted.length)
     }
 }

--- a/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
+++ b/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
@@ -2,6 +2,7 @@ package com.raemond.opentrailpaper
 
 import com.raemond.opentrailpaper.ble.Maneuver
 import com.raemond.opentrailpaper.data.DeviceText
+import com.raemond.opentrailpaper.data.GpxExporter
 import com.raemond.opentrailpaper.data.GpxImporter
 import com.raemond.opentrailpaper.data.ImportResult
 import com.raemond.opentrailpaper.data.LatLon
@@ -10,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Locale
 
 /**
  * Reading someone else's GPX.
@@ -212,6 +214,44 @@ class GpxImportTest {
         """.trimIndent()
         assertEquals("", ok(noType).mode)
         assertNull(ok(noType).activityType)
+    }
+
+    @Test
+    fun `an external entity gets nothing, whatever it names`() {
+        val xxe = """
+            <?xml version="1.0"?>
+            <!DOCTYPE gpx [<!ENTITY leak SYSTEM "file:///etc/passwd">]>
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <trk><trkseg>
+                <trkpt lat="52.1" lon="21.1"></trkpt>
+                <trkpt lat="52.2" lon="21.2"></trkpt>
+              </trkseg><name>&leak;</name></trk>
+            </gpx>
+        """.trimIndent()
+        // A .gpx arrives from any app on the phone, so a file that names a path
+        // must come back with the entity empty rather than the file in it.
+        // On the JVM the factory feature alone already refuses it — the parser
+        // here is Xerces, which is exactly why this cannot stand in for the
+        // device. It guards the property, not the mechanism.
+        assertEquals("fallback", ok(xxe).name)
+    }
+
+    @Test
+    fun `a german phone still round-trips a route through a dot`() {
+        val original = Locale.getDefault()
+        try {
+            // Both halves have to hold under a comma-decimal locale: the parse
+            // reads a dotted attribute as a number, and the export writes it
+            // back dotted for the device's scanner.
+            Locale.setDefault(Locale.GERMANY)
+            val r = ok(komoot)
+            val gpx = GpxExporter.make("ride", r.points)
+            assertTrue(gpx, gpx.contains("lat=\"49.337633\""))
+            assertTrue(gpx, gpx.contains("lon=\"20.005195\""))
+            assertTrue(gpx, !gpx.contains(","))
+        } finally {
+            Locale.setDefault(original)
+        }
     }
 
     // MARK: device text budgets

--- a/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
+++ b/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
@@ -1,8 +1,11 @@
 package com.raemond.opentrailpaper
 
+import com.raemond.opentrailpaper.ble.Maneuver
 import com.raemond.opentrailpaper.data.DeviceText
 import com.raemond.opentrailpaper.data.GpxImporter
 import com.raemond.opentrailpaper.data.ImportResult
+import com.raemond.opentrailpaper.data.LatLon
+import com.raemond.opentrailpaper.routing.Routing
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -277,5 +280,79 @@ class GpxImportTest {
         assertTrue("${bytes.size}", bytes.size <= 15)
         assertEquals(fitted, String(bytes, Charsets.UTF_8))
         assertEquals(7, fitted.length)
+    }
+
+    // MARK: cue derivation (the pure parts — the OSRM call itself is network)
+
+    private fun line(n: Int) = (0 until n).map { LatLon(52.0 + it * 0.001, 21.0) }
+
+    @Test
+    fun `via sampling keeps the ends and returns the count asked for`() {
+        val s = Routing.sampleByDistance(line(1000), 50)
+        assertEquals(50, s.size)
+        assertEquals(52.0, s.first().lat, 1e-9)
+        assertEquals(line(1000).last().lat, s.last().lat, 1e-9)
+    }
+
+    @Test
+    fun `via sampling spaces points by distance, not by index`() {
+        // Dense at the start, sparse after: sampling by index would put almost
+        // every via in the first kilometre.
+        val dense = (0 until 500).map { LatLon(52.0 + it * 0.00001, 21.0) }
+        val sparse = (1..100).map { LatLon(52.005 + it * 0.001, 21.0) }
+        val s = Routing.sampleByDistance(dense + sparse, 10)
+        assertEquals(10, s.size)
+        val firstHalf = s.count { it.lat < 52.005 }
+        assertTrue("$firstHalf of 10 vias landed in the dense head", firstHalf <= 3)
+    }
+
+    @Test
+    fun `via sampling copes with a track shorter than the sample count`() {
+        val s = Routing.sampleByDistance(line(3), 50)
+        assertTrue(s.size in 2..3)
+        assertEquals(line(3).last().lat, s.last().lat, 1e-9)
+    }
+
+    private fun cue(i: Int, filler: Boolean = false, slight: Boolean = false) =
+        Routing.Cue(Maneuver(52.0 + i * 0.001, 21.0, "Turn left"), filler, slight)
+
+    @Test
+    fun `triage keeps everything when the cues fit`() {
+        val r = Routing.triage((0 until 90).map { cue(it) }, cap = 128)
+        assertEquals(90, r.maneuvers.size)
+        assertTrue(!r.truncated)
+    }
+
+    @Test
+    fun `triage drops filler before real turns`() {
+        val cues = (0 until 100).map { cue(it) } + (100 until 140).map { cue(it, filler = true) }
+        val r = Routing.triage(cues, cap = 128)
+        assertEquals(100, r.maneuvers.size)
+        assertTrue(!r.truncated)
+    }
+
+    @Test
+    fun `triage drops slight turns only after filler is gone`() {
+        val cues = (0 until 120).map { cue(it) } +
+            (120 until 140).map { cue(it, slight = true) } +
+            (140 until 150).map { cue(it, filler = true) }
+        val r = Routing.triage(cues, cap = 128)
+        assertEquals(120, r.maneuvers.size)
+        assertTrue(!r.truncated)
+    }
+
+    @Test
+    fun `triage truncates and says so when even the real turns overflow`() {
+        val r = Routing.triage((0 until 200).map { cue(it) }, cap = 128)
+        assertEquals(128, r.maneuvers.size)
+        assertTrue(r.truncated)
+    }
+
+    @Test
+    fun `triage fits every cue's text to the device budget`() {
+        val long = "Turn slightly right onto Jakuba Ignacego Łaszczyńskiego"
+        val r = Routing.triage(listOf(Routing.Cue(Maneuver(52.0, 21.0, long), false, false)), 128)
+        val bytes = r.maneuvers[0].text.toByteArray(Charsets.UTF_8)
+        assertTrue("${bytes.size}", bytes.size <= DeviceText.MANEUVER_BUDGET)
     }
 }

--- a/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
+++ b/companion-android/app/src/test/java/com/raemond/opentrailpaper/GpxImportTest.kt
@@ -1,0 +1,212 @@
+package com.raemond.opentrailpaper
+
+import com.raemond.opentrailpaper.data.GpxImporter
+import com.raemond.opentrailpaper.data.ImportResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reading someone else's GPX.
+ *
+ * The shapes here are copied from real Komoot and Strava exports, because the
+ * two mistakes that matter are both shape mistakes: picking up the author's
+ * name instead of the route's, and treating a waypoint as a route point.
+ */
+class GpxImportTest {
+
+    private fun parse(xml: String, fallback: String = "fallback") =
+        GpxImporter.parse(xml.byteInputStream(), fallback)
+
+    private fun ok(xml: String, fallback: String = "fallback") =
+        (parse(xml, fallback) as ImportResult.Ok).route
+
+    /** A Komoot export: metadata name, author link, trk name, trk type. */
+    private val komoot = """
+        <?xml version='1.0' encoding='UTF-8'?>
+        <gpx version="1.1" creator="https://www.komoot.de"
+             xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata>
+            <name>Metadata Name</name>
+            <author><link href="https://www.komoot.de">
+              <text>komoot</text><type>text/html</type>
+            </link></author>
+          </metadata>
+          <trk>
+            <name>Track Name</name>
+            <type>racebike</type>
+            <trkseg>
+              <trkpt lat="49.337633" lon="20.005195"><ele>734.6</ele></trkpt>
+              <trkpt lat="49.337637" lon="20.005103"><ele>734.6</ele></trkpt>
+            </trkseg>
+            <trkseg>
+              <trkpt lat="49.337728" lon="20.004207"><ele>734.6</ele></trkpt>
+            </trkseg>
+          </trk>
+        </gpx>
+    """.trimIndent()
+
+    @Test
+    fun `reads track points across every segment`() {
+        val r = ok(komoot)
+        assertEquals(3, r.points.size)
+        assertEquals(49.337633, r.points[0].lat, 1e-9)
+        assertEquals(20.005195, r.points[0].lon, 1e-9)
+        assertEquals(20.004207, r.points[2].lon, 1e-9)
+    }
+
+    /**
+     * Komoot nests <type>text/html</type> inside <author><link>. A parser that
+     * takes the first <type> it sees reports the author's link type as the
+     * activity — this actually happened while measuring the sample files.
+     */
+    @Test
+    fun `takes name and type from the track, not the author block`() {
+        val r = ok(komoot)
+        assertEquals("Track Name", r.name)
+        assertEquals("racebike", r.activityType)
+        assertEquals("Cycling", r.mode)
+    }
+
+    /** Strava puts the athlete's name in <metadata><author><name>. */
+    @Test
+    fun `ignores the author name in a strava export`() {
+        val strava = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <gpx creator="StravaGPX" version="1.1"
+                 xmlns="http://www.topografix.com/GPX/1/1">
+             <metadata>
+              <author><name>Some Athlete</name></author>
+             </metadata>
+             <trk>
+              <name>WR objazd 2026</name>
+              <type>cycling</type>
+              <trkseg>
+               <trkpt lat="52.240190" lon="20.889220"><ele>107.07</ele></trkpt>
+               <trkpt lat="52.240280" lon="20.887850"><ele>106.98</ele></trkpt>
+              </trkseg>
+             </trk>
+            </gpx>
+        """.trimIndent()
+        assertEquals("WR objazd 2026", ok(strava).name)
+    }
+
+    /**
+     * The firmware's scanner is tag-agnostic: it strstr's for lat=" then lon="
+     * and pairs them whatever tag they sit in (routes.cpp:319). A file with
+     * leading waypoints would have them dragged into the polyline in file
+     * order. This is the reason we parse and re-emit rather than pass through.
+     */
+    @Test
+    fun `ignores waypoints entirely`() {
+        val withWpt = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <wpt lat="0.0" lon="0.0"><name>Parking</name></wpt>
+              <wpt lat="1.0" lon="1.0"><name>Cafe</name></wpt>
+              <trk><name>Real Route</name><trkseg>
+                <trkpt lat="52.1" lon="21.1"></trkpt>
+                <trkpt lat="52.2" lon="21.2"></trkpt>
+              </trkseg></trk>
+            </gpx>
+        """.trimIndent()
+        val r = ok(withWpt)
+        assertEquals(2, r.points.size)
+        assertEquals(52.1, r.points[0].lat, 1e-9)
+    }
+
+    @Test
+    fun `falls back to route points when there is no track`() {
+        val rte = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <rte><name>Garmin Style</name>
+                <rtept lat="52.1" lon="21.1"></rtept>
+                <rtept lat="52.2" lon="21.2"></rtept>
+              </rte>
+            </gpx>
+        """.trimIndent()
+        val r = ok(rte)
+        assertEquals(2, r.points.size)
+        assertEquals("Garmin Style", r.name)
+    }
+
+    @Test
+    fun `falls back to metadata name then to the filename`() {
+        val metaOnly = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <metadata><name>From Metadata</name></metadata>
+              <trk><trkseg>
+                <trkpt lat="52.1" lon="21.1"></trkpt>
+                <trkpt lat="52.2" lon="21.2"></trkpt>
+              </trkseg></trk>
+            </gpx>
+        """.trimIndent()
+        assertEquals("From Metadata", ok(metaOnly).name)
+
+        val noNames = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <trk><trkseg>
+                <trkpt lat="52.1" lon="21.1"></trkpt>
+                <trkpt lat="52.2" lon="21.2"></trkpt>
+              </trkseg></trk>
+            </gpx>
+        """.trimIndent()
+        assertEquals("my ride", ok(noNames, "my ride").name)
+    }
+
+    @Test
+    fun `rejects something that is not gpx`() {
+        assertTrue(parse("<html><body>nope</body></html>") is ImportResult.NotGpx)
+        assertTrue(parse("this is not xml at all {}") is ImportResult.NotGpx)
+    }
+
+    @Test
+    fun `rejects a gpx with fewer than two points`() {
+        val one = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <trk><trkseg><trkpt lat="52.1" lon="21.1"></trkpt></trkseg></trk>
+            </gpx>
+        """.trimIndent()
+        assertTrue(parse(one) is ImportResult.NoPoints)
+
+        val none = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <metadata><name>Empty</name></metadata>
+            </gpx>
+        """.trimIndent()
+        assertTrue(parse(none) is ImportResult.NoPoints)
+    }
+
+    @Test
+    fun `decimates a file past the firmware point cap`() {
+        val sb = StringBuilder("<gpx version=\"1.1\" xmlns=\"http://www.topografix.com/GPX/1/1\"><trk><trkseg>")
+        for (i in 0 until 10_000) {
+            sb.append("<trkpt lat=\"52.").append(1000000 + i).append("\" lon=\"21.0\"></trkpt>")
+        }
+        sb.append("</trkseg></trk></gpx>")
+        val r = ok(sb.toString())
+        assertTrue("got ${r.points.size}", r.points.size <= GpxImporter.MAX_POINTS)
+        assertTrue(r.points.size > GpxImporter.MAX_POINTS / 2)
+    }
+
+    @Test
+    fun `distance comes out of the geometry`() {
+        val r = ok(komoot)
+        // Three points a few tens of metres apart in the Tatra foothills.
+        assertTrue("got ${r.distanceMeters}", r.distanceMeters in 50.0..250.0)
+    }
+
+    @Test
+    fun `mode is blank when the file does not say what it is for`() {
+        val noType = """
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+              <trk><trkseg>
+                <trkpt lat="52.1" lon="21.1"></trkpt>
+                <trkpt lat="52.2" lon="21.2"></trkpt>
+              </trkseg></trk>
+            </gpx>
+        """.trimIndent()
+        assertEquals("", ok(noType).mode)
+        assertNull(ok(noType).activityType)
+    }
+}


### PR DESCRIPTION
Import a `.gpx` into the Android companion — from a file picker on the Route screen, or by opening one in another app and choosing OpenTrailPaper. The route previews on the map and is sent to the head unit **exactly as it came**.

Turn cues are optional and opt-in. "Add turn cues" samples the track to 50 via points, asks OSRM for directions through them, then discards OSRM's polyline and keeps only the maneuver coordinates — `mapManeuversToRoute()` projects those onto whatever geometry is loaded, so the ridden route stays the rider's own file. Measured against four real Komoot/Strava exports, cues land a median 0–1 m from the original track, 36 m worst case.

<p>
<img src="https://raw.githubusercontent.com/tajchert/OpenTrailPaper/pr-assets/import.png" width="250">
<img src="https://raw.githubusercontent.com/tajchert/OpenTrailPaper/pr-assets/cues.png" width="250">
</p>

The file is parsed and re-emitted through `GpxExporter` rather than passed through, because `routes.cpp`'s scanner pairs any `lat=`/`lon=` it finds regardless of enclosing tag — a Komoot file with leading `<wpt>` entries would otherwise drag them into the polyline. It also drops `<ele>`/`<time>`, which cuts a 137 KB export to ~52 KB on the air.

Two fixes here stand alone and are easy to split out if you'd rather take them separately:

- `uploadRoute` truncated cue text on a byte boundary against the firmware's `char[48]`, so a long non-ASCII street name could put half a character on the panel. Reachable today from ordinary search-built routes, not just imports.
- CI built the Android app but never ran its unit tests, so `FormatTest` and `MeshChannelUrlTest` were ungated.

28 new JVM unit tests (no device, no network, no new dependencies). Verified on hardware: both import paths, cue derivation, tab-round-trip persistence, and the seeded map-area download.

iOS is not included.
