### PR TITLE
CI: build and publish a sideloadable Android APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Needed so the firmware job can publish a Release on push to main.
+# Needed so the firmware and Android jobs can publish Releases on push to main.
 permissions:
   contents: write
 
@@ -190,17 +190,88 @@ jobs:
         run: ./gradlew --no-daemon testDebugUnitTest
 
       # The runner image ships the Android SDK at $ANDROID_HOME, so there is
-      # no local.properties step. Debug only: it proves the app compiles (the
-      # same bar as the iOS job) and needs no signing — keystore.properties
-      # is gitignored, and the release path falls back to env vars this job
-      # deliberately doesn't set.
+      # no local.properties step.
+      #
+      # Release, not debug, so the APK is the minified build riders actually
+      # get — R8 stripping a class the app reflects on would otherwise only
+      # surface after a merge. It is signed with a dedicated *sideload* key
+      # held in repo secrets: not the Play upload key, which (under Play App
+      # Signing) is not the key Play-installed copies carry anyway, and whose
+      # leak would be far worse than this one's. A fork PR has no secrets, so
+      # there the build comes out unsigned (app/build.gradle.kts tolerates
+      # that) and simply proves it compiles.
+      - name: Install sideload signing key
+        if: ${{ secrets.OTP_KEYSTORE_B64 != '' }}
+        env:
+          OTP_KEYSTORE_B64: ${{ secrets.OTP_KEYSTORE_B64 }}
+        run: |
+          echo "$OTP_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/sideload.jks"
+          echo "OTP_KEYSTORE_FILE=$RUNNER_TEMP/sideload.jks" >> "$GITHUB_ENV"
+
       - name: Build
-        run: ./gradlew --no-daemon assembleDebug
+        env:
+          OTP_KEYSTORE_PASSWORD: ${{ secrets.OTP_KEYSTORE_PASSWORD }}
+          OTP_KEY_ALIAS: ${{ secrets.OTP_KEY_ALIAS }}
+          OTP_KEY_PASSWORD: ${{ secrets.OTP_KEY_PASSWORD }}
+        run: ./gradlew --no-daemon assembleRelease
+
+      # Read versionName out of the built APK rather than re-parsing the
+      # gradle file, so the tag below can never disagree with what installs.
+      - name: Read app version
+        id: app
+        run: |
+          aapt=$(ls "$ANDROID_HOME"/build-tools/*/aapt | sort -V | tail -1)
+          v=$("$aapt" dump badging app/build/outputs/apk/release/app-release.apk \
+                | sed -n "s/.*versionName='\([^']*\)'.*/\1/p")
+          echo "version=$v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          cp app/build/outputs/apk/release/app-release.apk "OpenTrailPaper-$v.apk"
 
       # Installable straight from the workflow run, the way the firmware
-      # artifact is flashable — debug-signed, so it installs on any device
-      # with unknown-sources enabled.
+      # artifact is flashable. Only useful when signed (see above).
       - uses: actions/upload-artifact@v4
         with:
-          name: companion-android-debug
-          path: companion-android/app/build/outputs/apk/debug/app-debug.apk
+          name: companion-android-apk
+          path: companion-android/OpenTrailPaper-*.apk
+          if-no-files-found: error
+
+      # An unsigned APK will not install on any phone, so publishing one would
+      # be a broken download with a green check next to it. Fail loudly on
+      # main instead: the secrets have gone missing, which is a config problem
+      # to fix, not a build to ship.
+      - name: Verify the APK is signed
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          apksigner=$(ls "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
+          if ! "$apksigner" verify --print-certs "OpenTrailPaper-${{ steps.app.outputs.version }}.apk"; then
+            echo "::error::release APK is unsigned — OTP_KEYSTORE_* secrets missing or wrong"
+            exit 1
+          fi
+
+      # Publish the APK as a GitHub Release so anyone can sideload it without a
+      # GitHub login (Actions artifacts need auth and expire). One release per
+      # versionName, refreshed on every push to main, same as the firmware.
+      #
+      # prerelease is load-bearing: both companion apps fetch
+      # /releases/latest to find firmware.bin, and GitHub excludes prereleases
+      # from "latest". Without it the newest APK release would shadow the
+      # firmware and every in-app update check would find nothing.
+      - name: Write release notes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cat > relnotes.md <<EOF
+          Android companion app ${{ steps.app.outputs.version }}, built from ${GITHUB_SHA}.
+
+          Download the APK below and open it on your phone; Android will ask you to allow installs from your browser or file manager the first time. Updates install over the top of an earlier sideloaded copy. This build is signed with a different key from the Play Store version, so it cannot update a Play-installed copy (uninstall that one first).
+          EOF
+
+      - name: Publish APK release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: app-v${{ steps.app.outputs.version }}
+          name: Android app ${{ steps.app.outputs.version }}
+          body_path: companion-android/relnotes.md
+          prerelease: true
+          files: companion-android/OpenTrailPaper-${{ steps.app.outputs.version }}.apk
+          fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,11 +200,16 @@ jobs:
       # leak would be far worse than this one's. A fork PR has no secrets, so
       # there the build comes out unsigned (app/build.gradle.kts tolerates
       # that) and simply proves it compiles.
+      # (Guarded in the shell: the secrets context is not allowed in a
+      # step-level `if`.)
       - name: Install sideload signing key
-        if: ${{ secrets.OTP_KEYSTORE_B64 != '' }}
         env:
           OTP_KEYSTORE_B64: ${{ secrets.OTP_KEYSTORE_B64 }}
         run: |
+          if [ -z "$OTP_KEYSTORE_B64" ]; then
+            echo "::warning::OTP_KEYSTORE_B64 not available — release APK will be unsigned"
+            exit 0
+          fi
           echo "$OTP_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/sideload.jks"
           echo "OTP_KEYSTORE_FILE=$RUNNER_TEMP/sideload.jks" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   push:
     branches: [main]
+    # Android app releases are cut by tag (android-v<versionName>); see the
+    # android job. Only that job does real work on a tag push.
+    tags: ["android-v*"]
   pull_request:
   workflow_dispatch:
 
@@ -17,6 +20,7 @@ permissions:
 jobs:
   firmware:
     name: Firmware (ESP32-S3)
+    if: ${{ !startsWith(github.ref, 'refs/tags/android-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -126,6 +130,7 @@ jobs:
   # C++ with no Arduino dependency, which is why it was written that way.
   mesh-tests:
     name: Meshtastic wire format
+    if: ${{ !startsWith(github.ref, 'refs/tags/android-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -134,6 +139,7 @@ jobs:
 
   ios:
     name: Companion app (iOS)
+    if: ${{ !startsWith(github.ref, 'refs/tags/android-v') }}
     # RouteView uses MKDirectionsTransportType.cycling, which Apple only
     # exposes in the iOS 26 SDK (backdated to iOS 14 availability). macos-15
     # defaults to Xcode 16.4 / iOS 18.5, where that symbol does not exist.
@@ -240,12 +246,29 @@ jobs:
           path: companion-android/OpenTrailPaper-*.apk
           if-no-files-found: error
 
+      # Everything below runs only for an android-v* tag push: that is the one
+      # deliberate act that publishes an APK. Pushes to main and PRs stop at
+      # the artifact above.
+      #
+      # The tag must name the version the APK actually carries, or a rider
+      # would download "0.4" and get 0.3. Bump versionName/versionCode in
+      # app/build.gradle.kts, merge, then tag that commit.
+      - name: Check the tag matches versionName
+        if: startsWith(github.ref, 'refs/tags/android-v')
+        run: |
+          want="${GITHUB_REF_NAME#android-v}"
+          have="${{ steps.app.outputs.version }}"
+          if [ "$want" != "$have" ]; then
+            echo "::error::tag $GITHUB_REF_NAME but app/build.gradle.kts versionName is $have"
+            exit 1
+          fi
+
       # An unsigned APK will not install on any phone, so publishing one would
-      # be a broken download with a green check next to it. Fail loudly on
-      # main instead: the secrets have gone missing, which is a config problem
-      # to fix, not a build to ship.
+      # be a broken download with a green check next to it. Fail loudly
+      # instead: the secrets have gone missing, which is a config problem to
+      # fix, not a build to ship.
       - name: Verify the APK is signed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/android-v')
         run: |
           apksigner=$(ls "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
           if ! "$apksigner" verify --print-certs "OpenTrailPaper-${{ steps.app.outputs.version }}.apk"; then
@@ -254,15 +277,16 @@ jobs:
           fi
 
       # Publish the APK as a GitHub Release so anyone can sideload it without a
-      # GitHub login (Actions artifacts need auth and expire). One release per
-      # versionName, refreshed on every push to main, same as the firmware.
+      # GitHub login (Actions artifacts need auth and expire). Unlike the
+      # firmware, which republishes on every push to main, an app release is
+      # cut only by tagging — so what riders download only changes on purpose.
       #
       # prerelease is load-bearing: both companion apps fetch
       # /releases/latest to find firmware.bin, and GitHub excludes prereleases
       # from "latest". Without it the newest APK release would shadow the
       # firmware and every in-app update check would find nothing.
       - name: Write release notes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/android-v')
         run: |
           cat > relnotes.md <<EOF
           Android companion app ${{ steps.app.outputs.version }}, built from ${GITHUB_SHA}.
@@ -271,10 +295,10 @@ jobs:
           EOF
 
       - name: Publish APK release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/android-v')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: app-v${{ steps.app.outputs.version }}
+          tag_name: ${{ github.ref_name }}
           name: Android app ${{ steps.app.outputs.version }}
           body_path: companion-android/relnotes.md
           prerelease: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -96,6 +96,28 @@ jobs:
           echo "]" >> _site/firmware/index.json
           echo "--- index.json ---"; cat _site/firmware/index.json
 
+      # Serve the newest sideload APK from a fixed path too, so the site's
+      # Android button never has to know a version number. Release tags are
+      # app-v<versionName> (see build.yml); the newest such release wins.
+      # No release yet is not an error — the button just 404s until the first
+      # push to main publishes one, and the workflow_run trigger above redeploys
+      # as soon as that happens.
+      - name: Bundle the Android APK
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p _site/app
+          tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 50 \
+                  --json tagName --jq '[.[].tagName | select(startswith("app-v"))][0] // empty')
+          if [ -n "$tag" ] && gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+               --pattern 'OpenTrailPaper-*.apk' --dir _site/app; then
+            mv _site/app/OpenTrailPaper-*.apk _site/app/OpenTrailPaper.apk
+            printf '{"tag": "%s", "url": "app/OpenTrailPaper.apk"}\n' "$tag" > _site/app/index.json
+            echo "bundled $tag"
+          else
+            echo "no Android app release yet"
+          fi
+
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,11 +12,14 @@ on:
       - "docs/**"
       - ".github/workflows/pages.yml"
   # Redeploy after a firmware build publishes a Release, so the flasher's
-  # bundled firmware/ directory picks up the new version (see "Bundle firmware").
+  # bundled firmware/ directory picks up the new version (see "Bundle firmware"),
+  # and after an android-v* tag publishes an APK (see "Bundle the Android APK").
+  # For a tag-triggered run, head_branch is the tag name, which is what the
+  # branches filter matches against.
   workflow_run:
     workflows: ["Build"]
     types: [completed]
-    branches: [main]
+    branches: ["main", "android-v*"]
   workflow_dispatch:
 
 permissions:
@@ -98,9 +101,9 @@ jobs:
 
       # Serve the newest sideload APK from a fixed path too, so the site's
       # Android button never has to know a version number. Release tags are
-      # app-v<versionName> (see build.yml); the newest such release wins.
+      # android-v<versionName> (see build.yml); the newest such release wins.
       # No release yet is not an error — the button just 404s until the first
-      # push to main publishes one, and the workflow_run trigger above redeploys
+      # android-v* tag publishes one, and the workflow_run trigger above redeploys
       # as soon as that happens.
       - name: Bundle the Android APK
         env:
@@ -108,7 +111,7 @@ jobs:
         run: |
           mkdir -p _site/app
           tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 50 \
-                  --json tagName --jq '[.[].tagName | select(startswith("app-v"))][0] // empty')
+                  --json tagName --jq '[.[].tagName | select(startswith("android-v"))][0] // empty')
           if [ -n "$tag" ] && gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
                --pattern 'OpenTrailPaper-*.apk' --dir _site/app; then
             mv _site/app/OpenTrailPaper-*.apk _site/app/OpenTrailPaper.apk

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ and an in-browser Web Serial firmware flasher (Chrome/Edge, no toolchain needed)
 Source in [`docs/`](docs/).
 
 The iOS app is on the [App Store](https://apps.apple.com/us/app/opentrailpaper/id6793646642).
-The Android app is a sideloadable APK, built by CI from every push to `main`:
+The Android app is a sideloadable APK that CI builds and signs for each `android-v*` tag:
 grab it from the [project site](https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk)
-or from the `app-v*` entries on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases).
+or from the `android-v*` entries on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases).
 
 The board has everything onboard: ESP32-S3 (16 MB flash / 8 MB PSRAM, BLE 5),
 960×540 e-paper (driven in 540×960 portrait) with GT911 touch, GPS (u-blox

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ and [Jetpack Compose on Android](companion-android/).
 and an in-browser Web Serial firmware flasher (Chrome/Edge, no toolchain needed).
 Source in [`docs/`](docs/).
 
+The iOS app is on the [App Store](https://apps.apple.com/us/app/opentrailpaper/id6793646642).
+The Android app is a sideloadable APK, built by CI from every push to `main`:
+grab it from the [project site](https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk)
+or from the `app-v*` entries on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases).
+
 The board has everything onboard: ESP32-S3 (16 MB flash / 8 MB PSRAM, BLE 5),
 960×540 e-paper (driven in 540×960 portrait) with GT911 touch, GPS (u-blox
 MIA-M10Q or L76K/CASIC — autodetected), SD card slot, PCF8563 RTC, BQ25896

--- a/companion-android/README.md
+++ b/companion-android/README.md
@@ -43,8 +43,8 @@ format.
 
 ## Install without building
 
-CI builds a signed release APK from every push to `main` and publishes it as an
-`app-v<version>` prerelease on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases);
+Each `android-v<version>` tag makes CI build a signed release APK and publish it
+as a prerelease on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases);
 the project site serves the newest one at a fixed URL:
 <https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk>. Open it on
 the phone and allow the install when Android asks. It is signed with a

--- a/companion-android/README.md
+++ b/companion-android/README.md
@@ -41,6 +41,16 @@ format.
 - **Dashboard editor** — reorder and resize the fields the panel shows, with a
   preview that runs the firmware's own layout algorithm in device pixels.
 
+## Install without building
+
+CI builds a signed release APK from every push to `main` and publishes it as an
+`app-v<version>` prerelease on the [Releases page](https://github.com/RaemondBW/OpenTrailPaper/releases);
+the project site serves the newest one at a fixed URL:
+<https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk>. Open it on
+the phone and allow the install when Android asks. It is signed with a
+dedicated sideload key (see [RELEASING.md](RELEASING.md)), so it updates over an
+earlier sideloaded copy but not over one installed from Play.
+
 ## Build & run
 
 Requires JDK 17, the Android SDK (platform 35, build-tools 35), CMake 3.22.1 and

--- a/companion-android/RELEASING.md
+++ b/companion-android/RELEASING.md
@@ -71,11 +71,24 @@ bump it — and by this repo's convention the iOS side moves with it.
 ## Sideload builds (CI)
 
 Separate from Play: `.github/workflows/build.yml` builds `assembleRelease` on
-every push and PR, and on a push to `main` publishes the APK as the
-`app-v<versionName>` GitHub **prerelease** (prerelease so it never becomes
-`/releases/latest`, which both companion apps read to find `firmware.bin`).
-`pages.yml` then copies the newest one to
+every push and PR as a compile check, and publishes an APK **only when an
+`android-v<versionName>` tag is pushed**. The release it creates is a GitHub
+**prerelease** (so it never becomes `/releases/latest`, which both companion
+apps read to find `firmware.bin`). `pages.yml` then copies the newest one to
 `https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk`.
+
+To cut one:
+
+```sh
+# 1. bump versionCode and versionName in app/build.gradle.kts, merge to main
+# 2. tag that commit — the tag must match versionName or CI refuses it
+git tag android-v0.4
+git push origin android-v0.4
+```
+
+Pushing the tag runs only the Android job; the firmware, iOS and mesh jobs
+skip on `android-v*` refs. Nothing published on `main` ever changes the
+download — a rider gets a new build only when you tag one.
 
 It is signed with a **dedicated sideload key**, not the upload key above, for
 two reasons: under Play App Signing the upload key is not the signature a
@@ -102,10 +115,10 @@ printf sideload | gh secret set OTP_KEY_ALIAS
 Losing this key means sideload users must uninstall before their next update;
 that is annoying, not fatal, which is the point of keeping it separate.
 
-Every push to `main` with the same `versionName` refreshes the same release, so
-the APK's `versionCode` only moves when you bump it here. Android lets a
-same-`versionCode` build install over itself, so riders can still pick up a
-fresh CI build; bump the version whenever a change is worth telling them about.
+Re-tagging the same version (delete and recreate the tag) refreshes that
+release in place, but every tag should normally come with a `versionCode`
+bump: Android decides whether an install is an update by `versionCode`, and the
+iOS build number moves with it by this repo's convention.
 
 ## 4. Play Console, one-time setup
 

--- a/companion-android/RELEASING.md
+++ b/companion-android/RELEASING.md
@@ -68,6 +68,45 @@ Nothing printed means unsigned — step 2 did not take.
 strictly higher than the last one Play has seen**, so the second release must
 bump it — and by this repo's convention the iOS side moves with it.
 
+## Sideload builds (CI)
+
+Separate from Play: `.github/workflows/build.yml` builds `assembleRelease` on
+every push and PR, and on a push to `main` publishes the APK as the
+`app-v<versionName>` GitHub **prerelease** (prerelease so it never becomes
+`/releases/latest`, which both companion apps read to find `firmware.bin`).
+`pages.yml` then copies the newest one to
+`https://raemondbw.github.io/OpenTrailPaper/app/OpenTrailPaper.apk`.
+
+It is signed with a **dedicated sideload key**, not the upload key above, for
+two reasons: under Play App Signing the upload key is not the signature a
+Play-installed copy carries, so an upload-key APK could not update one anyway;
+and a leaked repo secret should cost a sideload key, not the Play one. The key
+lives with the other secrets:
+
+```
+private_keys/opentrailpaper-sideload.jks     # PKCS12, alias "sideload"
+private_keys/opentrailpaper-sideload.pass    # store and key password
+```
+
+CI reads it from four repo secrets — `OTP_KEYSTORE_B64` (the `.jks`,
+base64), `OTP_KEYSTORE_PASSWORD`, `OTP_KEY_ALIAS`, `OTP_KEY_PASSWORD` — which
+`gradle.kts` consumes through the same `OTP_*` env vars as step 2. To rotate:
+
+```sh
+base64 -i private_keys/opentrailpaper-sideload.jks | gh secret set OTP_KEYSTORE_B64
+gh secret set OTP_KEYSTORE_PASSWORD < private_keys/opentrailpaper-sideload.pass
+gh secret set OTP_KEY_PASSWORD      < private_keys/opentrailpaper-sideload.pass
+printf sideload | gh secret set OTP_KEY_ALIAS
+```
+
+Losing this key means sideload users must uninstall before their next update;
+that is annoying, not fatal, which is the point of keeping it separate.
+
+Every push to `main` with the same `versionName` refreshes the same release, so
+the APK's `versionCode` only moves when you bump it here. Android lets a
+same-`versionCode` build install over itself, so riders can still pick up a
+fresh CI build; bump the version whenever a change is worth telling them about.
+
 ## 4. Play Console, one-time setup
 
 A closed test still needs most of the store paperwork done.

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@
         <a class="btn secondary" href="app/OpenTrailPaper.apk">Download the Android APK →</a>
         <span class="app-cta-note">Beta · Android 8 or later · sideload</span>
       </div>
-      <span class="app-cta-note android-note">The APK is built by CI from every change on <code>main</code>; open it on your phone and allow the install when Android asks. Questions or bugs: <a href="https://discord.gg/N6rp9v8xtJ">the Discord</a>.</span>
+      <span class="app-cta-note android-note">Open it on your phone and allow the install when Android asks; updates install over the top of an earlier download. Questions or bugs: <a href="https://discord.gg/N6rp9v8xtJ">the Discord</a>.</span>
     </div>
     <div class="app-gallery">
       <figure class="app-shot">

--- a/docs/index.html
+++ b/docs/index.html
@@ -105,10 +105,14 @@
     <h2>Use the app for setup and file transfer.</h2>
     <p class="sub">The iOS and Android companions can plan and transfer routes, build offline maps, copy recorded rides, change settings and install firmware updates over Bluetooth. The head unit does not need the phone during a ride.</p>
     <div class="cta-row app-cta">
-      <a class="btn accent" href="https://apps.apple.com/us/app/opentrailpaper/id6793646642">View in the App Store →</a>
-      <span class="app-cta-note">Free · iPhone · iOS 17 or later</span>
-      <a class="btn secondary" href="app/OpenTrailPaper.apk">Download the Android APK →</a>
-      <span class="app-cta-note">Beta · Android 8 or later · sideload</span>
+      <div class="app-store">
+        <a class="btn accent" href="https://apps.apple.com/us/app/opentrailpaper/id6793646642">View in the App Store →</a>
+        <span class="app-cta-note">Free · iPhone · iOS 17 or later</span>
+      </div>
+      <div class="app-store">
+        <a class="btn secondary" href="app/OpenTrailPaper.apk">Download the Android APK →</a>
+        <span class="app-cta-note">Beta · Android 8 or later · sideload</span>
+      </div>
       <span class="app-cta-note android-note">The APK is built by CI from every change on <code>main</code>; open it on your phone and allow the install when Android asks. Questions or bugs: <a href="https://discord.gg/N6rp9v8xtJ">the Discord</a>.</span>
     </div>
     <div class="app-gallery">

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,13 +101,15 @@
 
 <section id="app" class="dim">
   <div class="wrap">
-    <p class="kicker">02 — Optional iPhone app</p>
+    <p class="kicker">02 — Optional phone app</p>
     <h2>Use the app for setup and file transfer.</h2>
-    <p class="sub">The iOS companion can plan and transfer routes, build offline maps, copy recorded rides, change settings and install firmware updates over Bluetooth. The head unit does not need the phone during a ride.</p>
+    <p class="sub">The iOS and Android companions can plan and transfer routes, build offline maps, copy recorded rides, change settings and install firmware updates over Bluetooth. The head unit does not need the phone during a ride.</p>
     <div class="cta-row app-cta">
       <a class="btn accent" href="https://apps.apple.com/us/app/opentrailpaper/id6793646642">View in the App Store →</a>
       <span class="app-cta-note">Free · iPhone · iOS 17 or later</span>
-      <span class="app-cta-note android-note">Android is in closed beta — <a href="https://discord.gg/N6rp9v8xtJ">ask in the Discord</a> to join.</span>
+      <a class="btn secondary" href="app/OpenTrailPaper.apk">Download the Android APK →</a>
+      <span class="app-cta-note">Beta · Android 8 or later · sideload</span>
+      <span class="app-cta-note android-note">The APK is built by CI from every change on <code>main</code>; open it on your phone and allow the install when Android asks. Questions or bugs: <a href="https://discord.gg/N6rp9v8xtJ">the Discord</a>.</span>
     </div>
     <div class="app-gallery">
       <figure class="app-shot">

--- a/docs/style.css
+++ b/docs/style.css
@@ -409,6 +409,9 @@ section .sub { color: var(--ink-soft); font-size: 1.06rem; margin: 0 0 40px; max
 .app-cta-note { color: var(--ink-soft); font-size: 0.9rem; }
 /* Full flex row so the Android line breaks below the App Store button + note. */
 .app-cta-note.android-note { flex-basis: 100%; }
+/* Button + its one-line note wrap as a unit, so a narrow viewport never
+   strands a note under the other platform's button. */
+.app-store { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
 /* Below 860px .cta-row stacks and centres its button, so the note follows it. */
 @media (max-width: 860px) {
   .app-cta { margin-bottom: 24px; }


### PR DESCRIPTION
## What

- The Android CI job now builds `assembleRelease` (minified, R8) instead of debug, signs it with a dedicated **sideload key** from repo secrets, and uploads `OpenTrailPaper-<version>.apk` as the run artifact on every push and PR.
- **Publishing is tag-driven.** Pushing `android-v<versionName>` builds, signs and publishes that APK as an `android-v*` GitHub **prerelease**. CI refuses the tag if it does not match `versionName` in `app/build.gradle.kts`. Pushes to main never publish. On a tag push only the Android job runs.
- Prerelease is load-bearing: both companion apps hit `/releases/latest` for `firmware.bin`, and GitHub keeps prereleases out of "latest".
- `pages.yml` copies the newest `android-v*` APK to a fixed URL on the site, `app/OpenTrailPaper.apk`, and redeploys after a tag run.
- The site's app section offers "Download the Android APK" next to the App Store button, replacing the closed-beta Discord note. README, `companion-android/README.md` and `RELEASING.md` document the flow.

## Cutting a release

```sh
# bump versionCode + versionName in app/build.gradle.kts, merge to main, then
git tag android-v0.4 && git push origin android-v0.4
```

## Why a separate key

Not the Play upload key: under Play App Signing that key isn't the signature Play-installed copies carry anyway, so an upload-key APK couldn't update a Play install; and if a repo secret leaks it should cost the sideload key, not the Play one. Key + password live in `private_keys/` (gitignored) alongside the upload key; the four `OTP_*` secrets are already set on the repo.

## Verified

- Local `assembleRelease` through the same `OTP_*` env-var path CI uses; `apksigner verify` shows a V2 signature.
- A CI-built artifact from this PR, downloaded and checked with `apksigner`, carries the sideload certificate.
- Both workflow files parse; the `aapt` version extraction and the `gh release list` tag filter were run against the real APK / real repo.

## Notes

- On a fork PR (no secrets) the build comes out unsigned and just proves it compiles.
- `versionName`/`versionCode` are still 0.3 / 10 while iOS is at 0.5 / 13, despite the "kept in step" comment. Not changed here; the first tag should probably bump them.
- The tag-push path itself has not been exercised until the first `android-v*` tag is pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zwb8iv775NfvZD6zXtH2h
