### PR TITLE
Mesh: choose region, TX power and frequency slot from the apps

### DIFF
--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/BleManager.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/BleManager.kt
@@ -174,6 +174,7 @@ class BleManager(private val app: Application) {
     var meshNodes by mutableStateOf<List<MeshNode>>(emptyList()); private set
     var meshChannels by mutableStateOf<List<MeshChannel>>(emptyList()); private set
     var meshPresets by mutableStateOf<List<MeshPreset>>(emptyList()); private set
+    var meshRegions by mutableStateOf<List<MeshRegion>>(emptyList()); private set
     var meshStats by mutableStateOf(MeshStats()); private set
 
     /** The device refused the last send — radio off, or its outbox is full. */
@@ -224,6 +225,7 @@ class BleManager(private val app: Application) {
     private val meshNodesBuilding = ArrayList<MeshNode>()
     private val meshChannelsBuilding = ArrayList<MeshChannel>()
     private val meshPresetsBuilding = ArrayList<MeshPreset>()
+    private val meshRegionsBuilding = ArrayList<MeshRegion>()
 
     /** Negotiated ATT payload; one byte of every packet is the opcode. */
     private var mtu = 23
@@ -1628,8 +1630,10 @@ class BleManager(private val app: Application) {
         writeChar(meshChar, byteArrayOf(0x03))     // history
         writeChar(meshChar, byteArrayOf(0x04))     // nodes
         writeChar(meshChar, byteArrayOf(0x0c))     // channels
-        // Fixed for the life of the firmware, so once is enough.
+        // Fixed for the life of the firmware, so once is enough. An older
+        // firmware ignores 0x10 and simply never answers it.
         if (meshPresets.isEmpty()) writeChar(meshChar, byteArrayOf(0x0a))
+        if (meshRegions.isEmpty()) writeChar(meshChar, byteArrayOf(0x10))
     }
 
     /** Sends to one node, or to the whole channel when [to] is null. */
@@ -1705,6 +1709,22 @@ class BleManager(private val app: Application) {
     fun setMeshPreset(index: Int) = writeChar(meshChar, byteArrayOf(0x0b, index.toByte()))
 
     /**
+     * Sets the regulatory region. A legal setting, not a preference: it must match
+     * both the country and the band the LoRa module was built for. The device
+     * retunes and forgets everything it heard on the old band.
+     */
+    fun setMeshRegion(index: Int) = writeChar(meshChar, byteArrayOf(0x11, index.toByte()))
+
+    /** TX power in dBm; 0 asks for the most the region and the radio allow. */
+    fun setMeshTxPower(dbm: Int) = writeChar(meshChar, byteArrayOf(0x12, dbm.toByte()))
+
+    /**
+     * Pins the frequency slot (1-based, like Meshtastic's channel number), or 0
+     * to go back to deriving it from the channel name.
+     */
+    fun setMeshFreqSlot(slot: Int) = writeChar(meshChar, byteArrayOf(0x13, slot.toByte()))
+
+    /**
      * Adds or replaces a private channel. Slot 0 is the primary and is refused by
      * the firmware — it decides the frequency.
      */
@@ -1762,6 +1782,13 @@ class BleManager(private val app: Application) {
                     shortName = short,
                     longName = long,
                     presetIndex = if (i < d.size) d[i].toInt() and 0xFF else 0,
+                    // Five more trailing bytes from a firmware that lets the phone
+                    // set the radio up; absent from one that fixes the region.
+                    regionIndex = if (i + 5 < d.size) d[i + 1].toInt() and 0xFF else null,
+                    txPowerDbm = if (i + 5 < d.size) d[i + 2].toInt() else null,
+                    slotOverride = if (i + 5 < d.size) d[i + 3].toInt() and 0xFF else null,
+                    slotCount = if (i + 5 < d.size) d[i + 4].toInt() and 0xFF else null,
+                    activeSlot = if (i + 5 < d.size) d[i + 5].toInt() and 0xFF else null,
                 )
             }
 
@@ -1870,6 +1897,25 @@ class BleManager(private val app: Application) {
             0x9a -> {                                             // end of presets
                 meshPresets = meshPresetsBuilding.toList()
                 meshPresetsBuilding.clear()
+            }
+
+            0x9d -> {                                             // one region
+                if (d.size < 15) return
+                meshRegionsBuilding.add(
+                    MeshRegion(
+                        index = d[1].toInt() and 0xFF,
+                        startHz = le32(d, 2).toLong() and 0xFFFF_FFFFL,
+                        endHz = le32(d, 6).toLong() and 0xFFFF_FFFFL,
+                        spacingHz = le32(d, 10).toLong() and 0xFFFF_FFFFL,
+                        powerLimitDbm = d[14].toInt(),
+                        name = lenStringAt(d, 15).first,
+                    ),
+                )
+            }
+
+            0x9e -> {                                             // end of regions
+                meshRegions = meshRegionsBuilding.toList()
+                meshRegionsBuilding.clear()
             }
 
             0x9b -> {                                             // one channel, with its key

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/MeshModels.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ble/MeshModels.kt
@@ -128,9 +128,26 @@ data class MeshState(
     val unread: Int = 0,
     /** Index into `BleManager.meshPresets`. */
     val presetIndex: Int = 0,
+    // The radio configuration a newer firmware appends to the state packet. Null
+    // means it did not — an older firmware whose region is fixed at build time —
+    // and the controls for these stay hidden rather than showing a guess.
+    /** Index into `BleManager.meshRegions`. */
+    val regionIndex: Int? = null,
+    /** The power actually in use, in dBm — never the "maximum" request value 0. */
+    val txPowerDbm: Int? = null,
+    /** 0 = the slot is the hash of the channel name; otherwise a pinned slot, 1-based. */
+    val slotOverride: Int? = null,
+    /** How many bandwidth-wide slots the region has at the current modem. */
+    val slotCount: Int? = null,
+    /** The slot the radio is on, 1-based, whichever way it was chosen. */
+    val activeSlot: Int? = null,
 ) {
     val nodeId: String get() = meshNodeId(nodeNum)
     val frequencyMHz: Double get() = frequencyHz / 1_000_000.0
+
+    /** The firmware lets the phone set region, power and slot. */
+    val hasRadioConfig: Boolean get() = regionIndex != null
+    val slotIsAutomatic: Boolean get() = (slotOverride ?: 0) == 0
 
     /** Nothing has been heard from the device yet. */
     val isUnknown: Boolean get() = nodeNum == 0
@@ -154,6 +171,45 @@ data class MeshPreset(
     val codingRate: Int,
 ) {
     val detail: String get() = String.format(Locale.US, "SF%d · %.0f kHz", sf, bandwidthKhz)
+}
+
+/**
+ * A regulatory region the device can be set to: the band its frequency slots are
+ * cut from and the power it may use there. Streamed from the device for the same
+ * reason the presets are — the firmware owns the table (`mesh::kRegions`), and a
+ * copy of Meshtastic's region list on the phone is a copy that drifts.
+ */
+data class MeshRegion(
+    val index: Int,
+    val name: String,
+    val startHz: Long,
+    val endHz: Long,
+    val spacingHz: Long,
+    /** The region's legal limit, which is above what the radio can do in most of them. */
+    val powerLimitDbm: Int,
+) {
+    val startMHz: Double get() = startHz / 1_000_000.0
+    val endMHz: Double get() = endHz / 1_000_000.0
+
+    /** "902–928 MHz", with decimals only where the edges have them. */
+    val band: String
+        get() = "${mhz(startMHz)}–${mhz(endMHz)} MHz"
+
+    /** What TX power can actually be set: the region's ceiling or the SX1262's 22 dBm. */
+    val maxTxDbm: Int get() = minOf(powerLimitDbm, RADIO_MAX_DBM)
+
+    val detail: String get() = "$band · max $maxTxDbm dBm"
+
+    private fun mhz(v: Double): String =
+        if (v == Math.floor(v)) String.format(Locale.US, "%.0f", v)
+        else String.format(Locale.US, "%.3f", v).trimEnd('0')
+
+    companion object {
+        /** The SX1262's hardware ceiling; the region limit only binds below it. */
+        const val RADIO_MAX_DBM = 22
+        /** Below this the PA is barely on; Meshtastic's own floor is the same. */
+        const val MIN_TX_DBM = 2
+    }
 }
 
 /**

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MeshSettingsSheet.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MeshSettingsSheet.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -31,18 +33,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raemond.opentrailpaper.ble.BleManager
 import com.raemond.opentrailpaper.ble.MeshPreset
+import com.raemond.opentrailpaper.ble.MeshRegion
 import java.util.Locale
 
 /**
  * Radio and identity.
  *
- * Region is absent on purpose: which band the radio may use is set at build time
- * in the firmware, because it is a certification question rather than a
- * preference.
+ * Region, power and frequency slot only appear when the firmware reports them
+ * (`MeshState.hasRadioConfig`); an older firmware fixes the region at build time
+ * and there is nothing to show for it beyond the frequency.
  */
 @Composable
 fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
@@ -58,8 +63,18 @@ fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
      * frequency too — not something to do on a mis-tap.
      */
     var pendingPreset by remember { mutableStateOf<MeshPreset?>(null) }
+    /** Same for "switch region?": a wrong band is a legal problem, not just a deaf radio. */
+    var pendingRegion by remember { mutableStateOf<MeshRegion?>(null) }
+    /**
+     * Slider position while the thumb is down. Sent on release, not per pixel:
+     * each write re-tunes the PA, and the device pushes a fresh state back that
+     * would otherwise fight the thumb.
+     */
+    var draggingPower by remember { mutableStateOf<Float?>(null) }
+    var slotText by remember { mutableStateOf("") }
 
     val activePreset = ble.meshPresets.firstOrNull { it.index == state.presetIndex }
+    val activeRegion = ble.meshRegions.firstOrNull { it.index == state.regionIndex }
 
     LaunchedEffect(Unit) {
         longName = state.longName
@@ -103,11 +118,165 @@ fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
                     )
                 }
                 InfoRow("Modem", activePreset?.let { "${it.name} · SF${it.sf}" } ?: "—")
+                if (state.hasRadioConfig) {
+                    InfoRow("Region", activeRegion?.let { "${it.name} · ${it.band}" } ?: "—")
+                }
                 InfoRow(
                     "Frequency",
                     String.format(Locale.US, "%.3f MHz", state.frequencyMHz),
                 )
+                if (state.hasRadioConfig) {
+                    InfoRow(
+                        "Slot",
+                        "${state.activeSlot} of ${state.slotCount}" +
+                            if (state.slotIsAutomatic) " · from name" else " · pinned",
+                    )
+                    InfoRow("Power", "${state.txPowerDbm} dBm")
+                }
                 InfoRow("Status", if (state.radioOk) "up" else "not found")
+            }
+
+            if (state.hasRadioConfig) {
+                Card {
+                    TrackedLabel("Region · which band")
+                    Spacer(Modifier.size(6.dp))
+                    // Listed from the device, like the modems: the firmware owns
+                    // the table, and it is the firmware that has to be right.
+                    if (ble.meshRegions.isEmpty()) {
+                        Text(
+                            "Ask the device for its region list by reconnecting.",
+                            style = barlow(15.sp),
+                            color = Palette.muted,
+                        )
+                    }
+                    for (r in ble.meshRegions) {
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { pendingRegion = r }
+                                .padding(vertical = 3.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(
+                                    r.name,
+                                    style = condensed(19.sp, FontWeight.SemiBold),
+                                    color = Palette.ink,
+                                )
+                                Text(r.detail, style = barlow(14.sp), color = Palette.muted)
+                            }
+                            if (r.index == state.regionIndex) {
+                                Icon(Icons.Filled.Check, contentDescription = null, tint = Palette.accent)
+                            }
+                        }
+                    }
+                    Text(
+                        "A legal setting, not a preference: it has to match the " +
+                            "country you ride in AND the band the LoRa module was " +
+                            "built for. An 868 MHz module cannot be talked onto 915 " +
+                            "by software — it will just be deaf and out of spec.",
+                        style = barlow(14.sp),
+                        color = Palette.muted,
+                    )
+                }
+
+                Card {
+                    TrackedLabel("Transmit power")
+                    Spacer(Modifier.size(6.dp))
+                    val maxDbm = activeRegion?.maxTxDbm ?: MeshRegion.RADIO_MAX_DBM
+                    val minDbm = MeshRegion.MIN_TX_DBM
+                    val shown = draggingPower?.toInt() ?: (state.txPowerDbm ?: maxDbm)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            "$shown dBm",
+                            style = condensed(19.sp, FontWeight.SemiBold),
+                            color = Palette.ink,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text("max $maxDbm", style = barlow(14.sp), color = Palette.muted)
+                    }
+                    Slider(
+                        value = draggingPower ?: (state.txPowerDbm ?: maxDbm).toFloat(),
+                        onValueChange = { draggingPower = it },
+                        onValueChangeFinished = {
+                            draggingPower?.let { ble.setMeshTxPower(it.toInt()) }
+                            draggingPower = null
+                        },
+                        valueRange = minDbm.toFloat()..maxDbm.toFloat(),
+                        steps = (maxDbm - minDbm - 1).coerceAtLeast(0),
+                        colors = SliderDefaults.colors(
+                            thumbColor = Palette.accent,
+                            activeTrackColor = Palette.accent,
+                        ),
+                    )
+                    Text(
+                        "Capped at what the region allows and the radio can do. " +
+                            "Full power reaches furthest; lower it to spare the " +
+                            "battery when the group rides close together.",
+                        style = barlow(13.sp),
+                        color = Palette.muted,
+                    )
+                }
+
+                Card {
+                    TrackedLabel("Frequency slot")
+                    Spacer(Modifier.size(6.dp))
+                    val count = state.slotCount ?: 1
+                    Text(
+                        if (state.slotIsAutomatic) {
+                            "Automatic: slot ${state.activeSlot} of $count, from the channel name."
+                        } else {
+                            "Pinned to slot ${state.activeSlot} of $count."
+                        },
+                        style = barlow(15.sp),
+                        color = Palette.ink,
+                    )
+                    Spacer(Modifier.size(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        MeshTextField(
+                            slotText,
+                            { slotText = it.filter { c -> c.isDigit() }.take(3) },
+                            "Slot 1–$count",
+                            modifier = Modifier.weight(1f),
+                            keyboardType = KeyboardType.Number,
+                        )
+                        val wanted = slotText.toIntOrNull()
+                        TextButton(
+                            onClick = {
+                                wanted?.let { ble.setMeshFreqSlot(it) }
+                                slotText = ""
+                            },
+                            enabled = wanted != null && wanted in 1..count,
+                        ) {
+                            Text(
+                                "Pin",
+                                style = condensed(18.sp, FontWeight.SemiBold),
+                                color = if (wanted != null && wanted in 1..count) Palette.accent
+                                else Palette.faint,
+                            )
+                        }
+                        if (!state.slotIsAutomatic) {
+                            TextButton(onClick = { ble.setMeshFreqSlot(0); slotText = "" }) {
+                                Text(
+                                    "Automatic",
+                                    style = condensed(18.sp, FontWeight.SemiBold),
+                                    color = Palette.accent,
+                                )
+                            }
+                        }
+                    }
+                    Text(
+                        "Meshtastic's frequency slot (its \"channel number\"). Normally " +
+                            "the channel name picks it, and everyone using the same " +
+                            "name lands on the same slot — pin one only to match a " +
+                            "group that has pinned theirs. Slots are numbered from 1.",
+                        style = barlow(13.sp),
+                        color = Palette.muted,
+                    )
+                }
             }
 
             Card {
@@ -279,6 +448,33 @@ fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
         )
     }
 
+    pendingRegion?.let { r ->
+        AlertDialog(
+            onDismissRequest = { pendingRegion = null },
+            title = { Text("Switch region?") },
+            text = {
+                Text(
+                    "Switch to ${r.name} (${r.band})? The region is a legal " +
+                        "setting: it must match the country you are in and the " +
+                        "band the LoRa module was built for — an 868 MHz module " +
+                        "cannot be tuned to 915 MHz by software. The device retunes " +
+                        "and clears the messages and neighbours it learned on the " +
+                        "old band.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    ble.setMeshRegion(r.index)
+                    pendingRegion = null
+                }) { Text("Switch") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRegion = null }) { Text("Cancel") }
+            },
+            containerColor = Palette.surface,
+        )
+    }
+
     pendingPreset?.let { p ->
         AlertDialog(
             onDismissRequest = { pendingPreset = null },
@@ -319,6 +515,7 @@ internal fun MeshTextField(
     onValueChange: (String) -> Unit,
     placeholder: String,
     modifier: Modifier = Modifier,
+    keyboardType: KeyboardType = KeyboardType.Text,
 ) {
     TextField(
         value = value,
@@ -327,6 +524,7 @@ internal fun MeshTextField(
         placeholder = { Text(placeholder, style = barlow(16.sp), color = Palette.faint) },
         textStyle = barlow(16.sp),
         singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         colors = TextFieldDefaults.colors(
             focusedContainerColor = Palette.paper,
             unfocusedContainerColor = Palette.paper,

--- a/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MeshSettingsSheet.kt
+++ b/companion-android/app/src/main/java/com/raemond/opentrailpaper/ui/MeshSettingsSheet.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Slider
@@ -65,6 +67,12 @@ fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
     var pendingPreset by remember { mutableStateOf<MeshPreset?>(null) }
     /** Same for "switch region?": a wrong band is a legal problem, not just a deaf radio. */
     var pendingRegion by remember { mutableStateOf<MeshRegion?>(null) }
+    /**
+     * The region list is folded away by default. Twenty-five bands is a wall of
+     * text for a setting almost nobody changes twice, and what a rider actually
+     * wants to see is where the radio is right now.
+     */
+    var regionsExpanded by remember { mutableStateOf(false) }
     /**
      * Slider position while the thumb is down. Sent on release, not per pixel:
      * each write re-tunes the PA, and the device pushes a fresh state back that
@@ -140,44 +148,68 @@ fun MeshSettingsSheet(ble: BleManager, onDismiss: () -> Unit) {
                 Card {
                     TrackedLabel("Region · which band")
                     Spacer(Modifier.size(6.dp))
-                    // Listed from the device, like the modems: the firmware owns
-                    // the table, and it is the firmware that has to be right.
-                    if (ble.meshRegions.isEmpty()) {
+                    // Folded: one row, the band we are on and the frequency
+                    // inside it, with a chevron to open the full list.
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { regionsExpanded = !regionsExpanded }
+                            .padding(vertical = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                activeRegion?.name ?: "—",
+                                style = condensed(19.sp, FontWeight.SemiBold),
+                                color = Palette.ink,
+                            )
+                            Text(
+                                activeRegion?.let {
+                                    String.format(Locale.US, "%s · %.3f MHz", it.band, state.frequencyMHz)
+                                } ?: "Ask the device for its region list by reconnecting.",
+                                style = barlow(14.sp),
+                                color = Palette.muted,
+                            )
+                        }
+                        Icon(
+                            if (regionsExpanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+                            contentDescription = if (regionsExpanded) "Hide regions" else "Choose a region",
+                            tint = Palette.muted,
+                        )
+                    }
+                    if (regionsExpanded) {
+                        // Listed from the device, like the modems: the firmware owns
+                        // the table, and it is the firmware that has to be right.
+                        for (r in ble.meshRegions) {
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { pendingRegion = r }
+                                    .padding(vertical = 3.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    Text(
+                                        r.name,
+                                        style = condensed(19.sp, FontWeight.SemiBold),
+                                        color = Palette.ink,
+                                    )
+                                    Text(r.detail, style = barlow(14.sp), color = Palette.muted)
+                                }
+                                if (r.index == state.regionIndex) {
+                                    Icon(Icons.Filled.Check, contentDescription = null, tint = Palette.accent)
+                                }
+                            }
+                        }
                         Text(
-                            "Ask the device for its region list by reconnecting.",
-                            style = barlow(15.sp),
+                            "A legal setting, not a preference: it has to match the " +
+                                "country you ride in AND the band the LoRa module was " +
+                                "built for. An 868 MHz module cannot be talked onto 915 " +
+                                "by software — it will just be deaf and out of spec.",
+                            style = barlow(14.sp),
                             color = Palette.muted,
                         )
                     }
-                    for (r in ble.meshRegions) {
-                        Row(
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable { pendingRegion = r }
-                                .padding(vertical = 3.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Column(Modifier.weight(1f)) {
-                                Text(
-                                    r.name,
-                                    style = condensed(19.sp, FontWeight.SemiBold),
-                                    color = Palette.ink,
-                                )
-                                Text(r.detail, style = barlow(14.sp), color = Palette.muted)
-                            }
-                            if (r.index == state.regionIndex) {
-                                Icon(Icons.Filled.Check, contentDescription = null, tint = Palette.accent)
-                            }
-                        }
-                    }
-                    Text(
-                        "A legal setting, not a preference: it has to match the " +
-                            "country you ride in AND the band the LoRa module was " +
-                            "built for. An 868 MHz module cannot be talked onto 915 " +
-                            "by software — it will just be deaf and out of spec.",
-                        style = barlow(14.sp),
-                        color = Palette.muted,
-                    )
                 }
 
                 Card {

--- a/companion-ios/Sources/BLEManager.swift
+++ b/companion-ios/Sources/BLEManager.swift
@@ -148,11 +148,48 @@ struct MeshState: Equatable {
     var unread = 0
     /// Index into `BLEManager.meshPresets`.
     var presetIndex: UInt8 = 0
+    /// Radio configuration, sent by firmware that lets the phone choose it. All
+    /// nil on older firmware, which compiled the region in — the sheet hides the
+    /// controls rather than offering a change the device would ignore.
+    var regionIndex: UInt8? = nil
+    /// The power actually in use — never the "maximum" sentinel the setter takes.
+    var txPowerDbm: Int8? = nil
+    /// 0 = the slot comes from the channel name, as on a stock node.
+    var slotOverride: UInt8? = nil
+    var slotCount: UInt8? = nil
+    /// 1-based, like Meshtastic's channel_num.
+    var activeSlot: UInt8? = nil
 
     var nodeId: String { "!" + String(format: "%08x", nodeNum) }
     var frequencyMHz: Double { Double(frequencyHz) / 1_000_000 }
     /// Nothing has been heard from the device yet.
     var isUnknown: Bool { nodeNum == 0 }
+    var hasRadioConfig: Bool { regionIndex != nil }
+}
+
+/// A regulatory region the device can run in: the band, and the power the law
+/// there allows. Streamed from the device like the presets, for the same reason —
+/// the firmware owns the table, and a copy here would drift. The numbers are
+/// Meshtastic's, so a region here means the same frequencies as on a stock node.
+struct MeshRegion: Identifiable, Equatable {
+    let index: UInt8
+    let name: String
+    let startHz: UInt32
+    let endHz: UInt32
+    let spacingHz: UInt32
+    let powerLimitDbm: Int8
+
+    var id: UInt8 { index }
+    /// "902–928 MHz". Sub-MHz edges (EU_868 is 869.4–869.65) keep their decimals.
+    var band: String {
+        func mhz(_ hz: UInt32) -> String {
+            let v = Double(hz) / 1_000_000
+            return v == v.rounded() ? String(format: "%.0f", v) : String(format: "%g", v)
+        }
+        return "\(mhz(startHz))–\(mhz(endHz)) MHz"
+    }
+    /// The SX1262 tops out at 22 dBm, so that is what binds in most regions.
+    var maxTxDbm: Int8 { min(powerLimitDbm, 22) }
 }
 
 /// A position a node broadcast over the mesh.
@@ -360,6 +397,8 @@ final class BLEManager: NSObject, ObservableObject {
     @Published var meshStats = MeshStats()
     @Published var meshPresets: [MeshPreset] = []
     private var meshPresetsBuilding: [MeshPreset] = []
+    @Published var meshRegions: [MeshRegion] = []
+    private var meshRegionsBuilding: [MeshRegion] = []
     @Published var meshChannels: [MeshChannel] = []
     private var meshChannelsBuilding: [MeshChannel] = []
     /// Set when the device refuses a message (radio off, or its outbox is full),
@@ -1135,6 +1174,11 @@ final class BLEManager: NSObject, ObservableObject {
             // Fixed for the life of the firmware, so once is enough.
             p.writeValue(Data([0x0a]), for: c, type: .withResponse)
         }
+        if meshRegions.isEmpty {
+            // Likewise. Older firmware never answers, and the sheet then shows no
+            // region control — which is right, since it has none to change.
+            p.writeValue(Data([0x10]), for: c, type: .withResponse)
+        }
     }
 
     /// Adds or replaces a private channel on the device. Slot 0 is the primary and
@@ -1179,6 +1223,25 @@ final class BLEManager: NSObject, ObservableObject {
     func requestMeshStats() {
         guard let c = meshChar, let p = peripheral else { return }
         p.writeValue(Data([0x09]), for: c, type: .withResponse)
+    }
+
+    /// Moves the radio to another regulatory band. The device retunes, drops the
+    /// messages and neighbours it learned on the old band, and pushes fresh state.
+    func setMeshRegion(_ index: UInt8) {
+        guard let c = meshChar, let p = peripheral else { return }
+        p.writeValue(Data([0x11, index]), for: c, type: .withResponse)
+    }
+
+    /// Transmit power in dBm; 0 asks for the most the region and radio allow.
+    func setMeshTxPower(_ dbm: Int8) {
+        guard let c = meshChar, let p = peripheral else { return }
+        p.writeValue(Data([0x12, UInt8(bitPattern: dbm)]), for: c, type: .withResponse)
+    }
+
+    /// Pins the frequency slot (1-based); 0 lets the channel name choose again.
+    func setMeshFreqSlot(_ slot: UInt8) {
+        guard let c = meshChar, let p = peripheral else { return }
+        p.writeValue(Data([0x13, slot]), for: c, type: .withResponse)
     }
 
     /// Sends a message to one node, or to the whole channel when `to` is nil.
@@ -1341,6 +1404,14 @@ final class BLEManager: NSObject, ObservableObject {
             s.shortName = d.lenString(at: &i)
             s.longName = d.lenString(at: &i)
             if i < d.count { s.presetIndex = d[i] }
+            // Radio config trails the preset; five bytes, all or nothing.
+            if i + 5 < d.count {
+                s.regionIndex = d[i + 1]
+                s.txPowerDbm = Int8(bitPattern: d[i + 2])
+                s.slotOverride = d[i + 3]
+                s.slotCount = d[i + 4]
+                s.activeSlot = d[i + 5]
+            }
             meshState = s
 
         case 0x91:  // one message
@@ -1430,6 +1501,19 @@ final class BLEManager: NSObject, ObservableObject {
         case 0x9a:  // end of the preset list
             meshPresets = meshPresetsBuilding
             meshPresetsBuilding = []
+
+        case 0x9d:  // one region
+            guard d.count >= 15 else { return }
+            var i = 15
+            let name = d.lenString(at: &i)
+            meshRegionsBuilding.append(MeshRegion(
+                index: d[1], name: name,
+                startHz: d.le32(at: 2), endHz: d.le32(at: 6), spacingHz: d.le32(at: 10),
+                powerLimitDbm: Int8(bitPattern: d[14])))
+
+        case 0x9e:  // end of the region list
+            meshRegions = meshRegionsBuilding
+            meshRegionsBuilding = []
 
         case 0x9b:  // one channel, with its key
             guard d.count >= 3 else { return }

--- a/companion-ios/Sources/MeshView.swift
+++ b/companion-ios/Sources/MeshView.swift
@@ -710,9 +710,28 @@ private struct MeshSettingsSheet: View {
     /// on tap because it retunes the radio, and on a bandwidth change it moves
     /// the frequency too — not something to do on a mis-tap.
     @State private var pendingPreset: MeshPreset? = nil
+    /// Same again for the region, which moves the radio further than any modem
+    /// does — and is a legal setting, so it gets the sternest of the alerts.
+    @State private var pendingRegion: MeshRegion? = nil
+    /// Local copies of the radio knobs, so a stepper tap does not wait on the
+    /// device's round trip before the number moves.
+    @State private var txPower: Int = 22
+    @State private var slotText = ""
+    /// Sends the power a moment after the last tap rather than on every one.
+    @State private var txPowerSend: Task<Void, Never>? = nil
 
     private var activePreset: MeshPreset? {
         ble.meshPresets.first { $0.index == ble.meshState.presetIndex }
+    }
+    private var activeRegion: MeshRegion? {
+        guard let i = ble.meshState.regionIndex else { return nil }
+        return ble.meshRegions.first { $0.index == i }
+    }
+    private var maxTxDbm: Int { Int(activeRegion?.maxTxDbm ?? 22) }
+    /// "Slot 19 of 104 · 906.875 MHz" — the one line that says where the radio is.
+    private var slotLine: String? {
+        guard let n = ble.meshState.activeSlot, let of = ble.meshState.slotCount else { return nil }
+        return String(format: "Slot %d of %d · %.3f MHz", Int(n), Int(of), ble.meshState.frequencyMHz)
     }
 
     var body: some View {
@@ -737,9 +756,103 @@ private struct MeshSettingsSheet: View {
                             }
                             row("Modem", activePreset.map { "\($0.name) · SF\($0.sf)" }
                                          ?? "—")
+                            if ble.meshState.hasRadioConfig {
+                                row("Region", activeRegion.map { "\($0.name) · \($0.band)" } ?? "—")
+                            }
                             row("Frequency",
                                 String(format: "%.3f MHz", ble.meshState.frequencyMHz))
+                            if let line = slotLine {
+                                row("Slot", line)
+                            }
                             row("Status", ble.meshState.radioOk ? "up" : "not found")
+                        }
+                    }
+
+                    // Region, power and slot exist only on firmware that lets the
+                    // phone set them; older builds compiled the region in and
+                    // would ignore every write, so the card is not shown at all.
+                    if ble.meshState.hasRadioConfig {
+                        Card {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Region · which band").trackedLabel()
+                                if ble.meshRegions.isEmpty {
+                                    Text("Ask the device for its region list by reconnecting.")
+                                        .font(BarlowFont.text(15))
+                                        .foregroundStyle(Palette.muted)
+                                }
+                                ForEach(ble.meshRegions) { r in
+                                    Button { pendingRegion = r } label: {
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 1) {
+                                                Text(r.name)
+                                                    .font(BarlowFont.condensed(19, .semibold))
+                                                    .foregroundStyle(Palette.ink)
+                                                Text("\(r.band) · max \(r.maxTxDbm) dBm")
+                                                    .font(BarlowFont.text(14))
+                                                    .foregroundStyle(Palette.muted)
+                                            }
+                                            Spacer()
+                                            if r.index == ble.meshState.regionIndex {
+                                                Image(systemName: "checkmark")
+                                                    .foregroundStyle(Palette.accent)
+                                            }
+                                        }
+                                        .padding(.vertical, 3)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                                Text("Which band the radio may use is a legal question, decided by the country you ride in — and by the hardware: the LoRa module is built for one band, and an 868 MHz module cannot be talked onto 915 MHz by software. The numbers are Meshtastic's, so a stock node set to the same region is on the same frequencies.")
+                                    .font(BarlowFont.text(14)).foregroundStyle(Palette.muted)
+                            }
+                        }
+
+                        Card {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Transmit power").trackedLabel()
+                                Stepper("\(txPower) dBm", value: $txPower, in: 2...max(2, maxTxDbm))
+                                    .font(BarlowFont.text(16))
+                                    .onChange(of: txPower) { _, v in
+                                        guard v != Int(ble.meshState.txPowerDbm ?? 0) else { return }
+                                        txPowerSend?.cancel()
+                                        txPowerSend = Task { @MainActor in
+                                            try? await Task.sleep(nanoseconds: 400_000_000)
+                                            if !Task.isCancelled { ble.setMeshTxPower(Int8(v)) }
+                                        }
+                                    }
+                                Text("Up to \(maxTxDbm) dBm here — the region's limit, or the radio's 22 dBm, whichever is lower. Less power is quieter on the battery and on the band; more reaches further.")
+                                    .font(BarlowFont.text(13)).foregroundStyle(Palette.muted)
+                            }
+                        }
+
+                        Card {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Frequency slot").trackedLabel()
+                                if let line = slotLine {
+                                    row(ble.meshState.slotOverride == 0 ? "From the channel name" : "Pinned", line)
+                                }
+                                HStack(spacing: 12) {
+                                    TextField("1–\(Int(ble.meshState.slotCount ?? 1))", text: $slotText)
+                                        .font(BarlowFont.text(16))
+                                        .keyboardType(.numberPad)
+                                    Button("Pin") {
+                                        if let n = Int(slotText), n >= 1,
+                                           n <= Int(ble.meshState.slotCount ?? 1) {
+                                            ble.setMeshFreqSlot(UInt8(n))
+                                        }
+                                    }
+                                    .disabled(Int(slotText).map { $0 < 1 || $0 > Int(ble.meshState.slotCount ?? 1) } ?? true)
+                                    if (ble.meshState.slotOverride ?? 0) != 0 {
+                                        Button("Automatic") {
+                                            slotText = ""
+                                            ble.setMeshFreqSlot(0)
+                                        }
+                                    }
+                                }
+                                .font(BarlowFont.condensed(18, .semibold))
+                                .foregroundStyle(Palette.accent)
+                                Text("Normally the channel name picks the slot, exactly as on a stock node — leave it automatic to reach other people. Pin a slot only to match a node that has done the same; it is Meshtastic's \"frequency slot\" number, counted from 1.")
+                                    .font(BarlowFont.text(13)).foregroundStyle(Palette.muted)
+                            }
                         }
                     }
 
@@ -860,6 +973,19 @@ private struct MeshSettingsSheet: View {
                      ? "The channel name will follow the modem preset again. The device retunes its radio and clears the messages and neighbours it learned on the old channel."
                      : "The device retunes its radio and clears the messages and neighbours it learned on the old channel.")
             }
+            .alert("Change region?", isPresented: Binding(
+                get: { pendingRegion != nil },
+                set: { if !$0 { pendingRegion = nil } })) {
+                Button("Change", role: .destructive) {
+                    if let r = pendingRegion { ble.setMeshRegion(r.index) }
+                    pendingRegion = nil
+                }
+                Button("Cancel", role: .cancel) { pendingRegion = nil }
+            } message: {
+                Text(pendingRegion.map { r in
+                    "Switch to \(r.name) (\(r.band))? The region is a legal setting: it has to match the country you are in, and the band your LoRa module was built for — an 868 MHz module cannot be tuned to 915 MHz by software. The device retunes and clears the messages and neighbours it learned on the old band."
+                } ?? "")
+            }
             .alert("Switch modem?", isPresented: Binding(
                 get: { pendingPreset != nil },
                 set: { if !$0 { pendingPreset = nil } })) {
@@ -880,7 +1006,13 @@ private struct MeshSettingsSheet: View {
                 // state rather than looking like a pinned custom channel.
                 channel = ble.meshState.channelFollowsPreset ? "" : ble.meshState.channel
                 channelKey = ble.meshState.channelKey
+                if let p = ble.meshState.txPowerDbm { txPower = Int(p) }
                 ble.requestMeshStats()
+            }
+            // The device answers a change with fresh state; keep the stepper on
+            // what it actually chose (it may have clamped to the region's limit).
+            .onChange(of: ble.meshState.txPowerDbm) { _, v in
+                if let v { txPower = Int(v) }
             }
         }
     }

--- a/companion-ios/Sources/MeshView.swift
+++ b/companion-ios/Sources/MeshView.swift
@@ -713,6 +713,10 @@ private struct MeshSettingsSheet: View {
     /// Same again for the region, which moves the radio further than any modem
     /// does — and is a legal setting, so it gets the sternest of the alerts.
     @State private var pendingRegion: MeshRegion? = nil
+    /// The region list is folded away by default: twenty-five bands is a wall
+    /// for a setting almost nobody changes twice, and what a rider wants to see
+    /// is where the radio is right now.
+    @State private var regionsExpanded = false
     /// Local copies of the radio knobs, so a stepper tap does not wait on the
     /// device's round trip before the number moves.
     @State private var txPower: Int = 22
@@ -775,34 +779,56 @@ private struct MeshSettingsSheet: View {
                         Card {
                             VStack(alignment: .leading, spacing: 10) {
                                 Text("Region · which band").trackedLabel()
-                                if ble.meshRegions.isEmpty {
-                                    Text("Ask the device for its region list by reconnecting.")
-                                        .font(BarlowFont.text(15))
-                                        .foregroundStyle(Palette.muted)
-                                }
-                                ForEach(ble.meshRegions) { r in
-                                    Button { pendingRegion = r } label: {
-                                        HStack {
-                                            VStack(alignment: .leading, spacing: 1) {
-                                                Text(r.name)
-                                                    .font(BarlowFont.condensed(19, .semibold))
-                                                    .foregroundStyle(Palette.ink)
-                                                Text("\(r.band) · max \(r.maxTxDbm) dBm")
-                                                    .font(BarlowFont.text(14))
-                                                    .foregroundStyle(Palette.muted)
-                                            }
-                                            Spacer()
-                                            if r.index == ble.meshState.regionIndex {
-                                                Image(systemName: "checkmark")
-                                                    .foregroundStyle(Palette.accent)
-                                            }
+                                // Folded: one row, the band we are on and the
+                                // frequency inside it, with a chevron to open
+                                // the full list.
+                                Button {
+                                    withAnimation(.easeInOut(duration: 0.2)) { regionsExpanded.toggle() }
+                                } label: {
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(activeRegion?.name ?? "—")
+                                                .font(BarlowFont.condensed(19, .semibold))
+                                                .foregroundStyle(Palette.ink)
+                                            Text(activeRegion.map {
+                                                String(format: "%@ · %.3f MHz", $0.band, ble.meshState.frequencyMHz)
+                                            } ?? "Ask the device for its region list by reconnecting.")
+                                                .font(BarlowFont.text(14))
+                                                .foregroundStyle(Palette.muted)
                                         }
-                                        .padding(.vertical, 3)
+                                        Spacer()
+                                        Image(systemName: regionsExpanded ? "chevron.up" : "chevron.down")
+                                            .foregroundStyle(Palette.muted)
                                     }
-                                    .buttonStyle(.plain)
+                                    .padding(.vertical, 3)
+                                    .contentShape(Rectangle())
                                 }
-                                Text("Which band the radio may use is a legal question, decided by the country you ride in — and by the hardware: the LoRa module is built for one band, and an 868 MHz module cannot be talked onto 915 MHz by software. The numbers are Meshtastic's, so a stock node set to the same region is on the same frequencies.")
-                                    .font(BarlowFont.text(14)).foregroundStyle(Palette.muted)
+                                .buttonStyle(.plain)
+                                if regionsExpanded {
+                                    ForEach(ble.meshRegions) { r in
+                                        Button { pendingRegion = r } label: {
+                                            HStack {
+                                                VStack(alignment: .leading, spacing: 1) {
+                                                    Text(r.name)
+                                                        .font(BarlowFont.condensed(19, .semibold))
+                                                        .foregroundStyle(Palette.ink)
+                                                    Text("\(r.band) · max \(r.maxTxDbm) dBm")
+                                                        .font(BarlowFont.text(14))
+                                                        .foregroundStyle(Palette.muted)
+                                                }
+                                                Spacer()
+                                                if r.index == ble.meshState.regionIndex {
+                                                    Image(systemName: "checkmark")
+                                                        .foregroundStyle(Palette.accent)
+                                                }
+                                            }
+                                            .padding(.vertical, 3)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                    Text("Which band the radio may use is a legal question, decided by the country you ride in — and by the hardware: the LoRa module is built for one band, and an 868 MHz module cannot be talked onto 915 MHz by software. The numbers are Meshtastic's, so a stock node set to the same region is on the same frequencies.")
+                                        .font(BarlowFont.text(14)).foregroundStyle(Palette.muted)
+                                }
                             }
                         }
 

--- a/docs/meshtastic.md
+++ b/docs/meshtastic.md
@@ -57,26 +57,39 @@ device waits to be asked.
 Everything else survives being switched off: channels, keys, names and the modem
 choice are all persisted, so turning it back on resumes where you were.
 
-## Region
+## Region, power and slot
 
-`MESH_REGION_NAME` and the frequency bounds in `src/config.h` are **compile-time
-constants**, deliberately: which band the radio may use is a legal question, not
-a preference, and a phone-selectable region would let a US-certified unit be
-switched onto EU frequencies. The default is US (902–928 MHz).
+The band the radio uses is a **setting**, chosen in either app (Mesh → settings
+→ Region) or on the console (`mesh region <name>`), from Meshtastic's own region
+table (`mesh::kRegions` in `src/mesh_proto.cpp`). A new or factory-reset device
+starts on `MESH_REGION_DEFAULT` from `src/config.h` (US, 902–928 MHz). The
+setting is stored by name, so a firmware that adds regions never moves anyone's
+band.
 
-To build for another region, change these in `config.h` and rebuild:
+Two things have to be true of the region you pick, and the firmware can check
+neither:
 
-```c
-#define MESH_REGION_NAME    "US"
-#define MESH_FREQ_START_MHZ 902.0f
-#define MESH_FREQ_END_MHZ   928.0f
-#define MESH_SPACING_MHZ    0.0f
-#define MESH_TX_DBM         22
-```
+- **It must be lawful where you ride.** The table carries each region's power
+  limit and the radio is driven at the lower of that and its own 22 dBm ceiling.
+  Duty-cycle limits (EU_868 is 10 %) are not enforced; this firmware only
+  transmits what you type plus a six-hourly announcement.
+- **It must match the hardware.** The LoRa module's matching network is built
+  for one band — a 915 MHz module cannot be talked onto 868 MHz by software (it
+  will mostly work, several dB down and out of spec) and a 433 MHz module is a
+  different chip altogether. The app says so before it applies a change.
 
-Meshtastic's own region table is the reference for the numbers. Note the radio
-must also be the right hardware variant — a 915 MHz module cannot be talked onto
-868 MHz by software.
+Changing region retunes the radio and clears messages and neighbours: a new band
+is a new mesh.
+
+Alongside it, two knobs a stock node also has:
+
+- **TX power** (`mesh power <dBm|max>`) — default is the maximum allowed.
+- **Frequency slot** (`mesh slot <n|auto>`) — Meshtastic's `channel_num`. By
+  default the slot is derived from the channel name (below), which is what keeps
+  two nodes that only agreed on a name on the same frequency. Pinning a number
+  does what it says; a pinned slot past the end of a narrower band is clamped.
+
+The 2.4 GHz `LORA_24` region is not offered: the SX1262 cannot reach it.
 
 ## How a channel becomes a frequency
 
@@ -152,7 +165,7 @@ recommended settings, and this firmware's defaults now match them:
 
 | Their setting | Value | Here |
 |---|---|---|
-| Region | US | `MESH_REGION_NAME`, compile-time |
+| Region | US | Mesh settings in the app, or `mesh region`; stored by name |
 | Preset | Medium Range Fast | pick **MediumFast** in the app |
 | Primary channel name | blank (default) | leave the channel field empty |
 | Encryption key | `AQ==` | key 1, the default |

--- a/src/ble_server.cpp
+++ b/src/ble_server.cpp
@@ -1353,9 +1353,18 @@ class AgnssCb : public NimBLECharacteristicCallbacks {
 //     [0x0d][u8 idx][u8 nameLen][name][psk]    add / replace a private channel
 //     [0x0e][u8 idx]                           forget a private channel
 //     [0x0f][u8 idx][u8 on]                    share our position on a channel
+//     [0x10]                                   send me the region list
+//     [0x11][u8 index]                         set the region
+//     [0x12][i8 dBm]                           set TX power (0 = the maximum
+//                                              the region and radio allow)
+//     [0x13][u8 slot]                          pin the frequency slot, 1-based
+//                                              (0 = derive it from the name)
 //
 //   Device -> phone (notify):
-//     [0x90] state    flags, node number, frequency, channel, our names
+//     [0x90] state    flags, node number, frequency, channel, our names, then
+//                     preset index and (appended later, optional for an older
+//                     app) region index, TX dBm, slot override, slot count,
+//                     active slot
 //     [0x91] message  one per message, oldest first
 //     [0x92]          end of history
 //     [0x93] node     one per known neighbour, with its position if it has sent one
@@ -1369,6 +1378,8 @@ class AgnssCb : public NimBLECharacteristicCallbacks {
 //     [0x9b] channel  one channel, WITH its key — the phone needs it to build a
 //                     share QR, and this link is already the trusted one
 //     [0x9c]          end of the channel list
+//     [0x9d] region   one region the device offers: index, band, power limit, name
+//     [0x9e]          end of the region list
 NimBLECharacteristic* meshChr = nullptr;
 
 // Requests staged by the write callback, serviced in the task. A bitmask rather
@@ -1380,6 +1391,7 @@ constexpr uint8_t MREQ_NODES   = 0x04;
 constexpr uint8_t MREQ_STATS   = 0x08;
 constexpr uint8_t MREQ_PRESETS = 0x10;
 constexpr uint8_t MREQ_CHANNELS = 0x20;
+constexpr uint8_t MREQ_REGIONS = 0x40;
 volatile uint8_t meshReq = 0;
 
 // Outgoing text, staged the same way. queueText() is cheap enough to call from a
@@ -1402,6 +1414,9 @@ volatile uint8_t meshSetKey = 1;
 volatile bool meshChanPending = false;
 volatile int8_t meshEnablePending = -1;   // -1 nothing, 0 off, 1 on
 volatile int8_t meshPresetPending = -1;   // -1 nothing, else a preset index
+volatile int8_t meshRegionPending = -1;   // -1 nothing, else a region index
+volatile int16_t meshTxPending = -1;      // -1 nothing, else dBm (0 = max)
+volatile int16_t meshSlotPending = -1;    // -1 nothing, else 0 (auto) or a slot
 
 // Staged private-channel edits. pskLen 0xFF is the delete marker.
 volatile int8_t meshChanIdxPending = -1;
@@ -1451,7 +1466,38 @@ void sendMeshState() {
     // Appended last so the layout above stays stable: the modem is a second,
     // independent axis from the channel and the app shows both.
     pkt[p++] = mesh_service::presetIndex();
+    // And after it, the radio configuration an app that predates it simply
+    // does not read. Slot numbers are 1-based here as in Meshtastic's UI.
+    pkt[p++] = mesh_service::regionIndex();
+    pkt[p++] = (uint8_t)mesh_service::txPowerDbm();
+    pkt[p++] = mesh_service::freqSlot();
+    const uint32_t nslots = mesh_service::slotCount();
+    pkt[p++] = (uint8_t)(nslots > 255 ? 255 : nslots);
+    const uint32_t aslot = mesh_service::activeSlot();
+    pkt[p++] = (uint8_t)(aslot > 255 ? 255 : aslot);
     meshNotify(pkt, p);
+}
+
+void sendMeshRegions() {
+    for (int i = 0; i < mesh::REGION_COUNT; ++i) {
+        const mesh::Region& r = mesh::kRegions[i];
+        uint8_t pkt[40];
+        int p = 0;
+        pkt[p++] = 0x9d;
+        pkt[p++] = (uint8_t)i;
+        // Hz, like the state packet's frequency: integers, nothing to parse.
+        const uint32_t s = (uint32_t)(r.startMHz * 1e6f + 0.5f);
+        const uint32_t e = (uint32_t)(r.endMHz * 1e6f + 0.5f);
+        const uint32_t g = (uint32_t)(r.spacingMHz * 1e6f + 0.5f);
+        memcpy(pkt + p, &s, 4); p += 4;
+        memcpy(pkt + p, &e, 4); p += 4;
+        memcpy(pkt + p, &g, 4); p += 4;
+        pkt[p++] = (uint8_t)r.powerLimitDbm;
+        p += (int)putStr(pkt + p, r.name, 15);
+        sendChunk(meshChr, pkt, p);
+    }
+    uint8_t end = 0x9e;
+    sendChunk(meshChr, &end, 1);
 }
 
 void sendMeshHistory() {
@@ -1624,6 +1670,16 @@ class MeshCb : public NimBLECharacteristicCallbacks {
         case 0x0b:                                     // set the modem preset
             if (n >= 2) meshPresetPending = (int8_t)p[1];
             break;
+        case 0x10: meshReq |= MREQ_REGIONS; break;
+        case 0x11:                                     // set the region
+            if (n >= 2 && p[1] < mesh::REGION_COUNT) meshRegionPending = (int8_t)p[1];
+            break;
+        case 0x12:                                     // set TX power
+            if (n >= 2 && (int8_t)p[1] >= 0) meshTxPending = (int8_t)p[1];
+            break;
+        case 0x13:                                     // pin the frequency slot
+            if (n >= 2) meshSlotPending = p[1];
+            break;
         case 0x02: {                                   // send a text message
             // [op][u32 dest][u8 channel][utf8]
             if (n < 6) return;
@@ -1728,6 +1784,23 @@ void serviceMeshRequests() {
         // The frequency moves with the bandwidth, so the app needs the new state.
         meshReq |= MREQ_STATE;
     }
+    if (meshRegionPending >= 0) {
+        mesh_service::setRegion((uint8_t)meshRegionPending);
+        meshRegionPending = -1;
+        // A new band is a new mesh: the device forgets its neighbours and
+        // messages, so the app must too.
+        meshReq |= MREQ_STATE | MREQ_HISTORY | MREQ_NODES;
+    }
+    if (meshTxPending >= 0) {
+        mesh_service::setTxPower((int8_t)meshTxPending);
+        meshTxPending = -1;
+        meshReq |= MREQ_STATE;
+    }
+    if (meshSlotPending >= 0) {
+        mesh_service::setFreqSlot((uint8_t)meshSlotPending);
+        meshSlotPending = -1;
+        meshReq |= MREQ_STATE | MREQ_HISTORY | MREQ_NODES;
+    }
     // Taken and cleared in one pass, before any of the streaming below: each
     // send yields for tens of milliseconds, and clearing a bit after that window
     // would drop a request the phone made during it.
@@ -1739,6 +1812,7 @@ void serviceMeshRequests() {
     if (req & MREQ_NODES)   sendMeshNodes();
     if (req & MREQ_STATS)   sendMeshStats();
     if (req & MREQ_PRESETS) sendMeshPresets();
+    if (req & MREQ_REGIONS) sendMeshRegions();
     if (req & MREQ_CHANNELS) sendMeshChannels();
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -81,17 +81,16 @@
 
 // Meshtastic mesh messaging (see docs/meshtastic.md).
 //
-// The region is a COMPILE-TIME choice because it is a legal one, not a
-// preference: US_915 is 902-928 MHz and shipping a device that can be switched
-// onto EU_868 from the phone would put it outside its certification. Change it
-// here (and rebuild) for another region.
-#define MESH_REGION_NAME    "US"
-#define MESH_FREQ_START_MHZ 902.0f
-#define MESH_FREQ_END_MHZ   928.0f
-#define MESH_SPACING_MHZ    0.0f
-// Region power limit is 30 dBm; the SX1262 tops out at 22, which is the cap that
-// actually binds. Meshtastic's own US default is the same.
-#define MESH_TX_DBM         22
+// The region (which band the radio may use) is a persisted setting chosen from
+// the app or the console, from Meshtastic's own table in mesh_proto.cpp — the
+// same choice a stock Meshtastic node asks its owner to make. This is only the
+// value a fresh or factory-reset device starts on. It is a NAME, not an index,
+// so the table can grow without moving anyone's band.
+#define MESH_REGION_DEFAULT "US"
+// The SX1262's own output ceiling. A region's legal limit is often higher (US:
+// 30 dBm); the lower of the two is what the radio is driven at unless the rider
+// turns it down.
+#define MESH_TX_DBM_MAX     22
 // --- Channel name, and the modem it is spoken with -------------------------
 //
 // These are TWO INDEPENDENT settings and conflating them is a trap worth

--- a/src/mesh_proto.cpp
+++ b/src/mesh_proto.cpp
@@ -1,6 +1,7 @@
 #include "mesh_proto.h"
 
 #include <cmath>
+#include <cctype>
 #include <cstring>
 
 namespace {
@@ -609,12 +610,74 @@ uint32_t channelCount(float bwKhz, float freqStartMHz, float freqEndMHz,
     return n < 1.0f ? 1u : (uint32_t)n;
 }
 
+uint32_t slotForName(const char* channelName, uint32_t slotCount) {
+    if (slotCount == 0) return 0;
+    return nameHash(channelName) % slotCount;
+}
+
+float slotFrequencyMHz(uint32_t slot, float bwKhz, float freqStartMHz,
+                       float spacingMHz) {
+    // Meshtastic: freqStart + bw/2000 + channel_num * (spacing + bw/1000).
+    // Every region it ships has spacing 0, so the term is carried for fidelity
+    // rather than because any current band needs it.
+    return freqStartMHz + bwKhz / 2000.0f +
+           (float)slot * (spacingMHz + bwKhz / 1000.0f);
+}
+
 float channelFrequencyMHz(const char* channelName, float bwKhz,
                           float freqStartMHz, float freqEndMHz,
                           float spacingMHz) {
     const uint32_t n = channelCount(bwKhz, freqStartMHz, freqEndMHz, spacingMHz);
-    const uint32_t slot = nameHash(channelName) % n;
-    return freqStartMHz + bwKhz / 2000.0f + (float)slot * (bwKhz / 1000.0f);
+    return slotFrequencyMHz(slotForName(channelName, n), bwKhz, freqStartMHz,
+                            spacingMHz);
+}
+
+// Values verbatim from Meshtastic firmware src/mesh/RadioInterface.cpp
+// (regions[]), September 2026. Duty-cycle limits (EU_868 10 %, UA_868 1 %) are
+// not enforced here: this firmware only transmits what the rider types plus a
+// six-hourly node announcement, which is far inside any of them.
+const Region kRegions[REGION_COUNT] = {
+    {"US",      902.0f,   928.0f,   0.0f, 30},
+    {"EU_868",  869.4f,   869.65f,  0.0f, 27},
+    {"EU_433",  433.0f,   434.0f,   0.0f, 10},
+    {"ANZ",     915.0f,   928.0f,   0.0f, 30},
+    {"ANZ_433", 433.05f,  434.79f,  0.0f, 14},
+    {"CN",      470.0f,   510.0f,   0.0f, 19},
+    {"JP",      920.5f,   923.5f,   0.0f, 13},
+    {"KR",      920.0f,   923.0f,   0.0f, 23},
+    {"TW",      920.0f,   925.0f,   0.0f, 27},
+    {"RU",      868.7f,   869.2f,   0.0f, 20},
+    {"IN",      865.0f,   867.0f,   0.0f, 30},
+    {"NZ_865",  864.0f,   868.0f,   0.0f, 36},
+    {"TH",      920.0f,   925.0f,   0.0f, 27},
+    {"UA_433",  433.0f,   434.7f,   0.0f, 10},
+    {"UA_868",  868.0f,   868.6f,   0.0f, 14},
+    {"MY_433",  433.0f,   435.0f,   0.0f, 20},
+    {"MY_919",  919.0f,   924.0f,   0.0f, 27},
+    {"SG_923",  917.0f,   925.0f,   0.0f, 20},
+    {"PH_433",  433.0f,   434.7f,   0.0f, 10},
+    {"PH_868",  868.0f,   869.4f,   0.0f, 14},
+    {"PH_915",  915.0f,   918.0f,   0.0f, 24},
+    {"KZ_433",  433.075f, 434.775f, 0.0f, 10},
+    {"KZ_863",  863.0f,   868.0f,   0.0f, 30},
+    {"NP_865",  865.0f,   868.0f,   0.0f, 30},
+    {"BR_902",  902.0f,   907.5f,   0.0f, 30},
+};
+
+int regionIndexByName(const char* name) {
+    if (!name) return -1;
+    for (int i = 0; i < REGION_COUNT; ++i) {
+        const char* a = kRegions[i].name;
+        const char* b = name;
+        while (*a && *b && std::tolower((unsigned char)*a) == std::tolower((unsigned char)*b)) { ++a; ++b; }
+        if (!*a && !*b) return i;
+    }
+    return -1;
+}
+
+const Region& region(int index) {
+    if (index < 0 || index >= REGION_COUNT) return kRegions[0];
+    return kRegions[index];
 }
 
 void defaultPsk(uint8_t index, uint8_t out[16]) {

--- a/src/mesh_proto.h
+++ b/src/mesh_proto.h
@@ -217,6 +217,48 @@ uint32_t channelCount(float bwKhz, float freqStartMHz, float freqEndMHz,
 float channelFrequencyMHz(const char* channelName, float bwKhz,
                           float freqStartMHz, float freqEndMHz,
                           float spacingMHz);
+// The two halves of the above, for a node that pins its slot by hand the way
+// Meshtastic's channel_num does: the hash picks a 0-based slot, and a slot has a
+// centre frequency whether or not a hash chose it.
+uint32_t slotForName(const char* channelName, uint32_t slotCount);
+float slotFrequencyMHz(uint32_t slot, float bwKhz, float freqStartMHz,
+                       float spacingMHz);
+
+// ---------------------------------------------------------------------------
+// Regions
+// ---------------------------------------------------------------------------
+//
+// Meshtastic's regulatory table, minus LORA_24 (a 2.4 GHz band the SX1262
+// cannot reach) and UNSET (a node that refuses to transmit; this firmware
+// defaults to MESH_REGION_DEFAULT instead). The band decides how many slots a
+// bandwidth divides into, so the SAME channel name lands on a different
+// frequency in every region — and a US node and an EU node on "LongFast" are not
+// on the same frequency at all.
+//
+// Which region is lawful is a fact about where the rider is AND about which
+// hardware variant they bought: an 868 MHz module's matching network cannot be
+// retuned to 915 by software. The firmware cannot detect the variant, so the
+// choice is the rider's and the app says so before applying it.
+struct Region {
+    const char* name;        // spelled exactly as Meshtastic spells it
+    float  startMHz;
+    float  endMHz;
+    float  spacingMHz;
+    int8_t powerLimitDbm;    // the regulatory ceiling; the radio's own cap
+                             // (22 dBm on the SX1262) binds where it is lower
+};
+
+// ORDER IS A CONTRACT for the BLE index; the persisted setting is the NAME, so
+// the table may grow without moving an existing rider's band.
+constexpr int REGION_COUNT = 25;
+extern const Region kRegions[REGION_COUNT];
+
+// Index of a region by name (case-insensitive), or -1.
+int regionIndexByName(const char* name);
+
+// Always returns a usable region, falling back to US (index 0) for an index
+// this build does not know.
+const Region& region(int index);
 
 // Meshtastic encodes the well-known channel keys as a single byte 1..10 (the
 // default channel's "AQ==" is byte 1). Byte N means the 16-byte default key

--- a/src/mesh_service.cpp
+++ b/src/mesh_service.cpp
@@ -83,6 +83,9 @@ uint8_t chanHash = 0;
 // note in config.h. Bandwidth comes from here too, so the preset also moves the
 // frequency whenever it changes the bandwidth.
 uint8_t presetIdx = MESH_PRESET_DEFAULT;
+uint8_t regionIdx = 0;                 // into mesh::kRegions; settings resolve the name
+int8_t  txDbmSetting = 0;              // 0 = as much as region and radio allow
+uint8_t slotOverride = 0;              // 0 = derive the slot from the channel name
 
 // Recently seen (sender, id) pairs. The mesh floods, so the same packet arrives
 // more than once whenever anyone rebroadcasts it; without this the phone shows
@@ -125,6 +128,9 @@ SemaphoreHandle_t wake = nullptr;
 // transmission, which spans startSend / irq / finishSend and cannot survive it.
 // So they are staged here and picked up at the top of the task loop.
 volatile int8_t reqPreset = -1;        // -1 = nothing, else a preset index
+volatile int8_t reqRegion = -1;        // -1 = nothing, else a region index
+volatile int16_t reqTxDbm = -1;        // -1 = nothing, else 0..MESH_TX_DBM_MAX
+volatile int16_t reqSlot = -1;         // -1 = nothing, else 0 (auto) or a 1-based slot
 volatile int8_t reqEnable = -1;        // -1 = nothing, 0 = off, 1 = on
 char reqChanName[16] = {};
 volatile uint8_t reqChanKey = 0;
@@ -271,10 +277,37 @@ int chanForHash(uint8_t h) {
     return -1;
 }
 
+uint32_t slotCountNow() {
+    const mesh::Region& r = mesh::region(regionIdx);
+    return mesh::channelCount(mesh::preset(presetIdx).bwKhz, r.startMHz, r.endMHz,
+                              r.spacingMHz);
+}
+
+// 0-based. An override past the end of a narrower band (set under a wider one,
+// or a wider bandwidth) is clamped to the last slot rather than wrapped: the
+// rider asked for "as high as it goes", and a wrap would land them somewhere
+// they never chose.
+uint32_t slotNow() {
+    const uint32_t n = slotCountNow();
+    if (slotOverride == 0) return mesh::slotForName(effectiveChan(), n);
+    return slotOverride > n ? n - 1 : (uint32_t)slotOverride - 1;
+}
+
 float channelFreq() {
-    return mesh::channelFrequencyMHz(effectiveChan(), mesh::preset(presetIdx).bwKhz,
-                                     MESH_FREQ_START_MHZ, MESH_FREQ_END_MHZ,
-                                     MESH_SPACING_MHZ);
+    const mesh::Region& r = mesh::region(regionIdx);
+    return mesh::slotFrequencyMHz(slotNow(), mesh::preset(presetIdx).bwKhz,
+                                  r.startMHz, r.spacingMHz);
+}
+
+int8_t txLimitNow() {
+    const int8_t lim = mesh::region(regionIdx).powerLimitDbm;
+    return lim < MESH_TX_DBM_MAX ? lim : (int8_t)MESH_TX_DBM_MAX;
+}
+
+int8_t txDbmNow() {
+    const int8_t lim = txLimitNow();
+    if (txDbmSetting <= 0 || txDbmSetting > lim) return lim;
+    return txDbmSetting;
 }
 
 bool startRadio() {
@@ -286,7 +319,7 @@ bool startRadio() {
     c.cr = p.cr;
     c.syncWord = MESH_SYNC_WORD;
     c.preambleLen = MESH_PREAMBLE_LEN;
-    c.powerDbm = MESH_TX_DBM;
+    c.powerDbm = txDbmNow();
     return lora_radio::begin(c);
 }
 
@@ -710,6 +743,9 @@ bool begin() {
     meshEnabled = settings::meshEnabled();
     chanPskIndex = settings::meshChannelKey();
     presetIdx = settings::meshPreset();
+    regionIdx = settings::meshRegion();
+    txDbmSetting = settings::meshTxPower();
+    slotOverride = settings::meshFreqSlot();
     posMask = settings::meshPositionChannels();
     snprintf(chanExplicit, sizeof(chanExplicit), "%s", settings::meshChannel());
     snprintf(myLongName, sizeof(myLongName), "%s", settings::meshLongName());
@@ -739,12 +775,18 @@ bool begin() {
     }
     radioUp = startRadio();
     if (radioUp)
-        diag::log("mesh: %s region, %.4f MHz", MESH_REGION_NAME, channelFreq());
+        diag::log("mesh: %s region, slot %u/%u%s, %.4f MHz, %d dBm",
+                  mesh::region(regionIdx).name, (unsigned)slotNow() + 1,
+                  (unsigned)slotCountNow(), slotOverride ? " (pinned)" : "",
+                  channelFreq(), txDbmNow());
     return true;
 }
 
 void applyEnabled(bool on);
 void applyPreset(uint8_t index);
+void applyRegion(uint8_t index);
+void applyTxPower(int8_t dbm);
+void applyFreqSlot(uint8_t slot);
 void applyPrivateChannel(uint8_t index, const char* name, const uint8_t* psk,
                          size_t pskLen, bool remove);
 void applyChannelChange(const char* name, uint8_t pskIndex);
@@ -771,6 +813,21 @@ void applyPendingConfig() {
         const uint8_t idx = (uint8_t)reqPreset;
         reqPreset = -1;
         applyPreset(idx);
+    }
+    if (reqRegion >= 0) {
+        const uint8_t idx = (uint8_t)reqRegion;
+        reqRegion = -1;
+        applyRegion(idx);
+    }
+    if (reqTxDbm >= 0) {
+        const int8_t dbm = (int8_t)reqTxDbm;
+        reqTxDbm = -1;
+        applyTxPower(dbm);
+    }
+    if (reqSlot >= 0) {
+        const uint8_t slot = (uint8_t)reqSlot;
+        reqSlot = -1;
+        applyFreqSlot(slot);
     }
     if (reqPrivIdx >= 0) {
         char name[sizeof(reqPrivName)];
@@ -991,6 +1048,30 @@ void setPreset(uint8_t index) {
     if (wake) xSemaphoreGive(wake);
 }
 
+uint8_t regionIndex() { return regionIdx; }
+void setRegion(uint8_t index) {
+    if (index >= mesh::REGION_COUNT) return;
+    reqRegion = (int8_t)index;
+    if (wake) xSemaphoreGive(wake);
+}
+
+int8_t txPowerDbm() { return txDbmNow(); }
+int8_t txPowerLimitDbm() { return txLimitNow(); }
+void setTxPower(int8_t dbm) {
+    if (dbm < 0) return;
+    reqTxDbm = dbm > MESH_TX_DBM_MAX ? MESH_TX_DBM_MAX : dbm;
+    if (wake) xSemaphoreGive(wake);
+}
+
+uint8_t freqSlot() { return slotOverride; }
+void setFreqSlot(uint8_t slot) {
+    reqSlot = slot;
+    if (wake) xSemaphoreGive(wake);
+}
+
+uint32_t slotCount() { return slotCountNow(); }
+uint32_t activeSlot() { return slotNow() + 1; }
+
 void setChannel(const char* name, uint8_t pskIndex) {
     // Only a null pointer is refused. An EMPTY name is the meaningful request to
     // stop pinning a channel and follow the modem preset again — rejecting it here
@@ -1035,6 +1116,63 @@ void applyPreset(uint8_t index) {
     if (meshEnabled) {
         // Restarted rather than tweaked: bandwidth is part of a preset, and a
         // bandwidth change moves the frequency slot as well as the modem.
+        radioUp = startRadio();
+        nextNodeInfoMs = millis() + 5000;
+    }
+}
+
+// The frequency moved, so the mesh we were part of is gone: neighbours and
+// messages belong to the old one, and anything queued was framed for it.
+void forgetMesh() {
+    take();
+    outboxCount = 0;
+    msgCount = msgHead = unread = 0;
+    nodeUsed = 0;
+    memset(seen, 0, sizeof(seen));
+    changed = true;
+    give();
+}
+
+// Applies a staged region change. Mesh task only.
+void applyRegion(uint8_t index) {
+    if (index >= mesh::REGION_COUNT || index == regionIdx) return;
+    regionIdx = index;
+    settings::setMeshRegion(index);
+    forgetMesh();
+    diag::log("mesh: region %s (%.3f-%.3f MHz, limit %d dBm) -> slot %u/%u, "
+              "%.4f MHz, %d dBm", mesh::region(regionIdx).name,
+              mesh::region(regionIdx).startMHz, mesh::region(regionIdx).endMHz,
+              mesh::region(regionIdx).powerLimitDbm, (unsigned)slotNow() + 1,
+              (unsigned)slotCountNow(), channelFreq(), txDbmNow());
+    if (meshEnabled) {
+        radioUp = startRadio();
+        nextNodeInfoMs = millis() + 5000;
+    }
+}
+
+// Applies a staged power change. Mesh task only. Restarted rather than
+// re-programmed in place: lora_radio::begin() is the one path that is known to
+// leave the SX1262 in a consistent state, and a power change is rare.
+void applyTxPower(int8_t dbm) {
+    if (dbm == txDbmSetting) return;
+    txDbmSetting = dbm;
+    settings::setMeshTxPower(dbm);
+    diag::log("mesh: tx power %d dBm (asked %d, limit %d)", txDbmNow(), dbm,
+              txLimitNow());
+    if (meshEnabled && radioUp) radioUp = startRadio();
+}
+
+// Applies a staged slot override. Mesh task only. 0 goes back to the name.
+void applyFreqSlot(uint8_t slot) {
+    if (slot == slotOverride) return;
+    const uint32_t before = slotNow();
+    slotOverride = slot;
+    settings::setMeshFreqSlot(slot);
+    if (slotNow() != before) forgetMesh();
+    diag::log("mesh: slot %s%u -> %u/%u, %.4f MHz", slot ? "pinned to " : "auto, ",
+              (unsigned)slot, (unsigned)slotNow() + 1, (unsigned)slotCountNow(),
+              channelFreq());
+    if (meshEnabled && slotNow() != before) {
         radioUp = startRadio();
         nextNodeInfoMs = millis() + 5000;
     }

--- a/src/mesh_service.h
+++ b/src/mesh_service.h
@@ -129,6 +129,20 @@ uint8_t presetIndex();
 const char* presetName();
 void setPreset(uint8_t index);
 
+// Radio configuration beyond the modem: which band (mesh::kRegions), how loud,
+// and — optionally — which slot in the band, pinned by number the way
+// Meshtastic's channel_num does instead of derived from the channel name. All
+// persisted; all applied by the mesh task, like the preset.
+uint8_t regionIndex();
+void setRegion(uint8_t index);
+int8_t txPowerDbm();                 // the value the radio is actually driven at
+int8_t txPowerLimitDbm();            // the most this region and radio allow
+void setTxPower(int8_t dbm);         // 0 = the maximum allowed
+uint8_t freqSlot();                  // the override, 0 = follow the channel name
+void setFreqSlot(uint8_t slot);      // 1-based; 0 clears the override
+uint32_t slotCount();                // how many slots this region/bandwidth has
+uint32_t activeSlot();               // the one in use, 1-based
+
 // Queues a text message and returns its packet id (0 if the outbox is full, the
 // text is empty, the channel is not one we hold, or the radio is down). Safe to
 // call from another task. `channel` 0 is the primary; 1.. are private channels.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -50,6 +50,11 @@ uint8_t meshPresetIdx = MESH_PRESET_DEFAULT;
 // Bitmask of channels we share our position on. 0 = none, which is the default:
 // telling a public mesh where you are should be a decision, not an accident.
 uint8_t meshPosMask = 0;
+// Region index (resolved from the stored NAME at load), TX power (0 = max the
+// region and radio allow) and frequency-slot override (0 = from the name).
+uint8_t meshRegionIdx = 0;
+int8_t  meshTxDbm = 0;
+uint8_t meshSlot = 0;
 char meshLong[40] = "";
 char meshShort[8] = "";
 const char* KEYS[3] = {"sens_hr", "sens_pwr", "sens_cad"};
@@ -89,6 +94,18 @@ void begin() {
     // A preset written by a newer firmware that knew more of them must not leave
     // this build driving the radio with garbage.
     if (meshPresetIdx >= mesh::PRESET_COUNT) meshPresetIdx = MESH_PRESET_DEFAULT;
+    {
+        // Stored by name: a region this build does not know (written by a newer
+        // one) must not leave the radio on an index that means something else
+        // here, so it falls back to the build default rather than to slot 0.
+        char rn[16] = "";
+        prefs.getString("meshregion", rn, sizeof(rn));
+        int ri = mesh::regionIndexByName(rn);
+        if (ri < 0) ri = mesh::regionIndexByName(MESH_REGION_DEFAULT);
+        meshRegionIdx = ri < 0 ? 0 : (uint8_t)ri;
+    }
+    meshTxDbm = (int8_t)constrain(prefs.getChar("meshtxdbm", 0), 0, MESH_TX_DBM_MAX);
+    meshSlot = prefs.getUChar("meshslot", 0);
     prefs.getString("meshlong", meshLong, sizeof(meshLong));
     prefs.getString("meshshort", meshShort, sizeof(meshShort));
     Serial.printf("[cfg] ftp=%dW tz=%dmin sensors=[%s|%s|%s]\n", ftp, tz,
@@ -318,6 +335,25 @@ void setMeshPreset(uint8_t index) {
     if (index >= mesh::PRESET_COUNT) return;
     meshPresetIdx = index;
     prefs.putUChar("meshpreset", index);
+}
+
+uint8_t meshRegion() { return meshRegionIdx; }
+void setMeshRegion(uint8_t index) {
+    if (index >= mesh::REGION_COUNT) return;
+    meshRegionIdx = index;
+    prefs.putString("meshregion", mesh::kRegions[index].name);
+}
+
+int8_t meshTxPower() { return meshTxDbm; }
+void setMeshTxPower(int8_t dbm) {
+    meshTxDbm = (int8_t)constrain(dbm, 0, MESH_TX_DBM_MAX);
+    prefs.putChar("meshtxdbm", meshTxDbm);
+}
+
+uint8_t meshFreqSlot() { return meshSlot; }
+void setMeshFreqSlot(uint8_t slot) {
+    meshSlot = slot;
+    prefs.putUChar("meshslot", slot);
 }
 
 const char* meshLongName() { return meshLong; }

--- a/src/settings.h
+++ b/src/settings.h
@@ -73,8 +73,6 @@ bool rtcTrusted();
 void setRtcTrusted(bool ok);
 
 // --- Meshtastic mesh messaging (see mesh_service.h) ------------------------
-// The region is NOT here: it is a compile-time constant in config.h, because
-// which band the radio may use is a legal question, not a preference.
 
 bool meshEnabled();               // false = the LoRa radio is never powered up
 void setMeshEnabled(bool on);
@@ -102,6 +100,23 @@ void setMeshPositionChannels(uint8_t mask);
 // Separate from the channel, which decides where. MESH_PRESET_DEFAULT until set.
 uint8_t meshPreset();
 void setMeshPreset(uint8_t index);
+
+// LoRa region: an index into mesh::kRegions. Persisted by NAME so the table can
+// grow without moving an existing rider's band; an unknown stored name falls
+// back to MESH_REGION_DEFAULT.
+uint8_t meshRegion();
+void setMeshRegion(uint8_t index);
+
+// Transmit power in dBm. 0 (the default) means the most the region and the
+// radio allow; mesh_service resolves that against the region's limit.
+int8_t meshTxPower();
+void setMeshTxPower(int8_t dbm);
+
+// Frequency slot override, 1-based like Meshtastic's channel_num. 0 (the
+// default) means the slot is derived from the channel name, which is what keeps
+// two nodes that only agreed on a name on the same frequency.
+uint8_t meshFreqSlot();
+void setMeshFreqSlot(uint8_t slot);
 
 // How this node introduces itself on the mesh. Empty until first set, at which
 // point mesh_service derives a default from the node number.

--- a/src/ui_dashboard.cpp
+++ b/src/ui_dashboard.cpp
@@ -1599,6 +1599,15 @@ static void printMeshReport() {
     const mesh::ModemPreset& mp = mesh::preset(mesh_service::presetIndex());
     Serial.printf("[mesh] modem %s: SF%u BW%.0f CR4/%u\n", mp.name, mp.sf, mp.bwKhz,
                   mp.cr);
+    // The band, and where in it. Slot numbers are 1-based as Meshtastic shows
+    // them; "pinned" means the rider chose the number, otherwise the name did.
+    const mesh::Region& rg = mesh::region(mesh_service::regionIndex());
+    Serial.printf("[mesh] region %s %.3f-%.3f MHz, slot %u/%u%s, %d dBm (limit %d)\n",
+                  rg.name, rg.startMHz, rg.endMHz,
+                  (unsigned)mesh_service::activeSlot(),
+                  (unsigned)mesh_service::slotCount(),
+                  mesh_service::freqSlot() ? " pinned" : "",
+                  mesh_service::txPowerDbm(), mesh_service::txPowerLimitDbm());
 
     // Every channel we can decrypt. All share the frequency above — only the
     // primary's name decides that; the rest are told apart by their hash.
@@ -1889,6 +1898,40 @@ static void runConsoleLine(char* line) {
             const int idx = mesh::presetIndexByName(want);
             if (idx < 0) { Serial.printf("[cmd] unknown preset '%s'\n", want); return; }
             mesh_service::setPreset((uint8_t)idx);
+        } else if (arg && !strcasecmp(arg, "region")) {
+            char* want = strtok(nullptr, " \t");
+            if (!want) {
+                Serial.println("[cmd] mesh region <name>. Must match BOTH the country");
+                Serial.println("      and the LoRa module's hardware band. Available:");
+                for (int i = 0; i < mesh::REGION_COUNT; ++i) {
+                    const mesh::Region& r = mesh::kRegions[i];
+                    Serial.printf("  %-8s %8.3f-%8.3f MHz  limit %2d dBm%s\n", r.name,
+                                  r.startMHz, r.endMHz, r.powerLimitDbm,
+                                  i == mesh_service::regionIndex() ? "  <- current" : "");
+                }
+                return;
+            }
+            const int idx = mesh::regionIndexByName(want);
+            if (idx < 0) { Serial.printf("[cmd] unknown region '%s'\n", want); return; }
+            mesh_service::setRegion((uint8_t)idx);
+        } else if (arg && !strcasecmp(arg, "power")) {
+            char* want = strtok(nullptr, " \t");
+            if (!want) {
+                Serial.printf("[cmd] mesh power <dBm|max>   (now %d, limit %d)\n",
+                              mesh_service::txPowerDbm(), mesh_service::txPowerLimitDbm());
+                return;
+            }
+            mesh_service::setTxPower(!strcasecmp(want, "max") ? 0 : (int8_t)atoi(want));
+        } else if (arg && !strcasecmp(arg, "slot")) {
+            char* want = strtok(nullptr, " \t");
+            if (!want) {
+                Serial.printf("[cmd] mesh slot <1-%u|auto>   (now %u%s)\n",
+                              (unsigned)mesh_service::slotCount(),
+                              (unsigned)mesh_service::activeSlot(),
+                              mesh_service::freqSlot() ? ", pinned" : ", from the name");
+                return;
+            }
+            mesh_service::setFreqSlot(!strcasecmp(want, "auto") ? 0 : (uint8_t)atoi(want));
         } else if (arg && !strcasecmp(arg, "channel")) {
             char* want = strtok(nullptr, " \t");
             if (!want) {

--- a/tools/mesh_test/mesh_test.cpp
+++ b/tools/mesh_test/mesh_test.cpp
@@ -102,6 +102,55 @@ static void testDefaultPsk() {
 
 // The two hashes that decide where a default node listens. Both are checked
 // against the published behaviour of a stock US node on the primary channel:
+// The region table is what decides where a channel name lands, and its numbers
+// are regulatory: a typo here is a node transmitting outside its band while
+// reporting success. Pinned against values Meshtastic publishes.
+static void testRegions() {
+    check(mesh::REGION_COUNT == 25, "25 sub-GHz regions");
+    check(mesh::regionIndexByName("US") == 0, "US is region 0");
+    check(mesh::regionIndexByName("eu_868") >= 0, "region lookup is case-insensitive");
+    check(mesh::regionIndexByName("LORA_24") < 0, "2.4 GHz is not offered on an SX1262");
+    check(&mesh::region(200) == &mesh::kRegions[0], "unknown region index falls back to US");
+
+    // EU_868 is 869.4-869.65 MHz: exactly one 250 kHz slot, so every channel
+    // name lands on 869.525 MHz — the frequency Meshtastic documents for EU_868.
+    const mesh::Region& eu = mesh::region(mesh::regionIndexByName("EU_868"));
+    const uint32_t n = mesh::channelCount(250.0f, eu.startMHz, eu.endMHz, eu.spacingMHz);
+    check(n == 1, "EU_868 has one 250 kHz slot");
+    const float f = mesh::channelFrequencyMHz("LongFast", 250.0f, eu.startMHz,
+                                              eu.endMHz, eu.spacingMHz);
+    printf("      EU_868 LongFast = %.4f MHz\n", f);
+    check(std::fabs(f - 869.525f) < 0.0005f, "EU_868 LongFast is 869.525 MHz");
+
+    // The split helpers must reproduce the one-shot function, and an explicit
+    // slot must count from the band edge the same way the hash does.
+    const uint32_t us = mesh::channelCount(250.0f, 902.0f, 928.0f, 0.0f);
+    check(mesh::slotForName("LongFast", us) == 19, "slotForName matches the hash placement");
+    check(std::fabs(mesh::slotFrequencyMHz(19, 250.0f, 902.0f, 0.0f) - 906.875f) < 0.0005f,
+          "slot 19 of US/250 kHz is 906.875 MHz");
+    check(std::fabs(mesh::slotFrequencyMHz(0, 250.0f, 902.0f, 0.0f) - 902.125f) < 0.0005f,
+          "slot 0 is centred half a bandwidth above the band edge");
+
+    // Every band must hold at least one slot at every bandwidth we offer, or a
+    // rider picking that preset would have a modulo-by-zero waiting.
+    for (int r = 0; r < mesh::REGION_COUNT; ++r)
+        for (int i = 0; i < mesh::PRESET_COUNT; ++i) {
+            const mesh::Region& rg = mesh::kRegions[r];
+            const uint32_t c = mesh::channelCount(mesh::kPresets[i].bwKhz, rg.startMHz,
+                                                  rg.endMHz, rg.spacingMHz);
+            if (c < 1) { check(false, "a region/preset pair has no slots"); return; }
+            const float fc = mesh::channelFrequencyMHz("LongFast", mesh::kPresets[i].bwKhz,
+                                                       rg.startMHz, rg.endMHz, rg.spacingMHz);
+            if (fc < rg.startMHz || fc > rg.endMHz) {
+                printf("      %s @ %.0f kHz -> %.4f MHz is outside %.3f-%.3f\n", rg.name,
+                       mesh::kPresets[i].bwKhz, fc, rg.startMHz, rg.endMHz);
+                check(false, "a channel centre falls outside its band");
+                return;
+            }
+        }
+    check(true, "every region/preset pair yields an in-band centre frequency");
+}
+
 // LongFast lands on slot 19 of 104, which is 906.875 MHz.
 static void testChannelPlacement() {
     const uint32_t n = mesh::channelCount(250.0f, 902.0f, 928.0f, 0.0f);
@@ -670,6 +719,7 @@ int main() {
     testCtrRoundTrip();
     testDefaultPsk();
     testChannelPlacement();
+    testRegions();
     testPresets();
     testBayMeshSettings();
     testChannelSet();


### PR DESCRIPTION
## What

The LoRa **region** (which band the radio uses) was a compile-time constant in `config.h`. It is now a persisted setting, chosen in either companion app (Mesh → settings → Radio) or on the console, from Meshtastic's own region table. Two related knobs a stock Meshtastic node also exposes come with it: **TX power** and a **frequency slot** override (Meshtastic's `channel_num`).

- **Firmware**: `mesh::kRegions` (25 sub-GHz regions, values verbatim from Meshtastic's `RadioInterface.cpp`; `LORA_24` omitted since the SX1262 cannot reach 2.4 GHz). Region is stored by name in NVS so the table can grow without moving a rider's band. Fresh / factory-reset devices start on `MESH_REGION_DEFAULT` (US), so nothing changes for existing devices. Power defaults to the lower of the region limit and the radio's 22 dBm. Changes are staged and applied on the mesh task like preset changes; a region or slot change retunes the radio and clears messages/neighbours (new band = new mesh).
- **BLE**: `0x10` list regions, `0x11` set region, `0x12` set TX dBm (0 = max), `0x13` pin slot (0 = from name). `0x9d`/`0x9e` stream the region list. Five optional bytes appended to the `0x90` state packet after the preset index carry region, dBm, slot override, slot count, active slot. Older apps never read past the preset byte; newer apps hide the Radio section when the bytes are absent.
- **Android + iOS**: Radio section in the Mesh settings sheet with a region list (band + max dBm, confirm dialog stating the region is a legal setting that must match both the country and the module's hardware band), a TX power slider/stepper (2 dBm to the region cap), and a slot control (pin 1..N or back to automatic), plus Region/Slot info rows.
- **Console**: `mesh region <name>`, `mesh power <dBm|max>`, `mesh slot <n|auto>`; the `mesh` report shows region, slot and power.
- **Docs**: `docs/meshtastic.md` region section rewritten.

## Worth knowing

The old doc argued for compile-time region on certification grounds. That argument still applies in spirit: the firmware cannot detect which hardware variant (868/915/433 module) it is running on, so it cannot stop a rider picking a band the module is not matched for. Both apps say this in the confirm dialog, the same way the Meshtastic app leaves the choice to the owner. Duty-cycle limits (EU_868 10 %) are not enforced; this firmware transmits only typed messages and a six-hourly announcement.

## Verified

- `pio run` succeeds (worktree with vendor/ symlink).
- Host mesh tests pass, including new ones: 25 regions, name lookup, EU_868 has one 250 kHz slot and LongFast lands on 869.525 MHz, slot helpers reproduce the hash placement, every region/preset pair yields an in-band centre.
- Android `assembleDebug` and unit tests pass; iOS builds against the simulator SDK the way CI does.
- **Not** exercised on hardware. The region switch restarts the radio via the same `startRadio()` path a preset change uses.

## Not done here

- No firmware version bump / CHANGELOG entry, following the repo's separate "Bump firmware" commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zwb8iv775NfvZD6zXtH2h
